### PR TITLE
Добавить циклическую навигацию профилей (prev/next) во вкладке Cluster

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -114,6 +114,42 @@ def redraw_cluster_for_current_profile_from_cache():
         is_cluster_redraw_in_progress = False
 
 
+def switch_cluster_profile(step: int):
+    """
+    Переключает профиль в comboBox_profile по кругу и перерисовывает:
+    - радарограмму (draw_radarogram)
+    - кластерную заливку из runtime-cache
+    """
+    profile_count = ui.comboBox_profile.count()
+    if profile_count <= 0:
+        set_info("Список профилей пуст. Переключение недоступно.", "brown")
+        return
+
+    current_index = ui.comboBox_profile.currentIndex()
+    if current_index < 0:
+        current_index = 0
+
+    next_index = (current_index + step) % profile_count
+    ui.comboBox_profile.setCurrentIndex(next_index)
+
+    draw_radarogram()
+    redraw_cluster_for_current_profile_from_cache()
+
+
+def draw_prev_cluster_profile():
+    """
+    Отрисовывает предыдущий профиль (по кругу) с результатом кластеризации.
+    """
+    switch_cluster_profile(-1)
+
+
+def draw_next_cluster_profile():
+    """
+    Отрисовывает следующий профиль (по кругу) с результатом кластеризации.
+    """
+    switch_cluster_profile(1)
+
+
 def get_cluster_color(label):
     """
     Возвращает цвет кластера:

--- a/geovel.py
+++ b/geovel.py
@@ -552,6 +552,8 @@ ui.comboBox_clust_set.activated.connect(update_list_clust_param)
 ui.comboBox_clust_set.activated.connect(update_list_clust_object)
 ui.comboBox_clust_obj.activated.connect(show_finite_report)
 ui.checkBox_clust_clean_nan.clicked.connect(update_clust_clear_nan)
+ui.pushButton_clust_prev_prof.clicked.connect(draw_prev_cluster_profile)
+ui.pushButton_clust_next_prof.clicked.connect(draw_next_cluster_profile)
 
 
 time = datetime.datetime.now()


### PR DESCRIPTION
### Motivation
- Привязать кнопки "предыдущий/следующий профиль" во вкладке кластерного анализа к отрисовке соответствующего профиля и к ранее рассчитанным результатам кластеризации из runtime-кэша. 
- Сделать переключение профилей циклическим (после последнего — первый, перед первым — последний) и обеспечить последовательность: выбор профиля в `comboBox_profile` → `draw_radarogram()` → отрисовка кластерной заливки из кэша.

### Description
- Добавлены функции `switch_cluster_profile(step)`, `draw_prev_cluster_profile()` и `draw_next_cluster_profile()` в `cluster.py` для циклического переключения индекса `ui.comboBox_profile` и последующего вызова `draw_radarogram()` и `redraw_cluster_for_current_profile_from_cache()`.
- Добавлена простая проверка пустого списка профилей с сообщением через `set_info` для безопасного поведения при отсутствии профилей.
- Подключены сигналы кнопок к новым обработчикам в `geovel.py` через `ui.pushButton_clust_prev_prof.clicked.connect(draw_prev_cluster_profile)` и `ui.pushButton_clust_next_prof.clicked.connect(draw_next_cluster_profile)`.
- Существующая логика отрисовки из кэша оставлена без изменений и вызывается после обновления выбора профиля.

### Testing
- Запущена компиляция проверка синтаксиса командой `python -m py_compile cluster.py geovel.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd63467c0832f8b06f6933f7cab38)