### PR TITLE
Synchronize cluster colors between matplotlib map and radarogram

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -972,25 +972,30 @@ def plot_cluster_map(
             continue
 
         mask = labels == label
+        cluster_color = get_cluster_color(label)
 
         plt.scatter(
             x[mask],
             y[mask],
             s=point_size,
             label=f"cluster {int(label)}",
+            c=cluster_color,
+            edgecolors=cluster_color,
             alpha=0.85
         )
 
     # шум
     if -1 in unique_labels:
         mask = labels == -1
+        noise_cluster_color = get_cluster_color(-1)
         plt.scatter(
             x[mask],
             y[mask],
             s=point_size,
-            c=noise_color,
+            c=noise_cluster_color if noise_color == "gray" else noise_color,
             marker=noise_marker,
             label=noise_label,
+            edgecolors=noise_cluster_color if noise_color == "gray" else noise_color,
             alpha=0.8
         )
 


### PR DESCRIPTION
### Motivation
- Обеспечить согласованное отображение цветов кластеров между картой (`matplotlib`) и отрисовкой на радарограмме (использующей `get_cluster_color`).
- Избежать рассинхрона, когда одна и та же метка кластера рисуется разными цветами в разных представлениях.

### Description
- В `plot_cluster_map` использована общая функция `get_cluster_color(label)` для выбора цвета каждого кластера вместо стандартного цветового цикла `matplotlib`.
- Для точек кластеров явно заданы цвет заполнения и обводки через параметры `c` и `edgecolors` с использованием значения из `get_cluster_color`.
- Отрисовка шума (`label = -1`) теперь по умолчанию использует цвет из `get_cluster_color(-1)` (серый), при этом сохранена возможность переопределения через аргумент `noise_color`.
- Небольшие правки в `cluster.py` для согласования поведения карты и радарограммы без изменения интерфейса функции.

### Testing
- Запущена проверка синтаксиса файла: `python -m py_compile /workspace/geovel_1.0/cluster.py`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dddc0639f4832f810526f19b5bd2b7)