### PR TITLE
Stage 6: finalize AUTO results table formatting

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -766,6 +766,13 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
         score_val = result.get("score")
         noise = _to_finite_float(stats.get("noise_fraction"))
 
+        status_raw = str(result.get("status", "—"))
+        status_view = {
+            "ok": "OK",
+            "invalid": "INVALID",
+            "error": "ERROR"
+        }.get(status_raw, status_raw.upper() if status_raw else "—")
+
         row_values = [
             str(row_idx + 1),
             _safe_num(score_val, precision=4),
@@ -776,19 +783,18 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
             _safe_num(metrics.get("davies_bouldin"), precision=4),
             _safe_num(metrics.get("calinski_harabasz"), precision=2),
             str(stats.get("n_clusters", "—")),
-            (f"{(noise * 100.0):.1f}" if noise is not None else "—"),
-            str(result.get("status", "—"))
+            (f"{(noise * 100.0):.1f}%" if noise is not None else "—"),
+            status_view
         ]
 
         for col_idx, value in enumerate(row_values):
             item = QTableWidgetItem(str(value))
-            if col_idx in (0, 1, 5, 6, 7, 8, 9):
+            if col_idx in (0, 1, 5, 6, 7, 8, 9, 10):
                 item.setTextAlignment(Qt.AlignCenter)
             if col_idx == 10:
-                status = str(result.get("status", ""))
-                if status == "ok":
+                if status_raw == "ok":
                     item.setForeground(QBrush(QColor("darkgreen")))
-                elif status == "invalid":
+                elif status_raw == "invalid":
                     item.setForeground(QBrush(QColor("darkorange")))
                 else:
                     item.setForeground(QBrush(QColor("darkred")))


### PR DESCRIPTION
### Motivation
- Сделать вывод результатов авто-подбора в `tableWidget_cluster_auto_result` более читаемым и соответствующим спецификации этапа 6 (формат таблицы). 

### Description
- Обновлена функция `render_auto_results_table` в `cluster.py` — статус теперь отображается как `OK`/`INVALID`/`ERROR`, в колонке `Noise %` добавлен суффикс `%`, колонка `Status` выровнена по центру, при этом цветовая индикация основывается на исходном (raw) значении статуса и подсказки/tooltip с конфигом/ошибкой сохранены. 

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile cluster.py` успешно завершилась.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de10b9d6c8832fb75eb7946c61ed1e)