### PR TITLE
Enable applying AUTO cluster variant by double-clicking result row

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -12,6 +12,7 @@ from func import *
 # Этап 1 (MVP): ключ анализа = id ObjectSet (clust_object_id).
 cluster_profile_cache = {}
 is_cluster_redraw_in_progress = False
+cluster_auto_results_cache: list[CandidateResult] = []
 
 
 class CandidateConfig(TypedDict):
@@ -976,6 +977,9 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
     """
     Заполняет таблицу результатов AUTO-подбора.
     """
+    global cluster_auto_results_cache
+    cluster_auto_results_cache = list(results or [])
+
     table = ui.tableWidget_cluster_auto_result
     headers = [
         "Rank", "Score", "Method", "Scaler", "PCA",
@@ -1038,6 +1042,27 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
             table.setItem(row_idx, col_idx, item)
 
     table.resizeColumnsToContents()
+
+
+def apply_selected_auto_result_from_table(row_idx: int, _column_idx: int) -> None:
+    """
+    По двойному клику в таблице AUTO применяет выбранный вариант к настройкам UI.
+    """
+    if row_idx < 0 or row_idx >= len(cluster_auto_results_cache):
+        set_info("AUTO: выбранная строка вне диапазона результатов.", "brown")
+        return
+
+    selected_result = cluster_auto_results_cache[row_idx]
+    if selected_result.get("status") != "ok":
+        set_info("AUTO: выбранный вариант невалиден и не может быть применен.", "brown")
+        return
+
+    apply_auto_result_to_ui(selected_result)
+    set_info(
+        f"AUTO: применен вариант #{row_idx + 1} "
+        f"(score={_safe_num(selected_result.get('score'), precision=4)}).",
+        "green"
+    )
 
 
 def apply_auto_result_to_ui(best_result: CandidateResult) -> None:

--- a/geovel.py
+++ b/geovel.py
@@ -555,6 +555,7 @@ ui.checkBox_clust_clean_nan.clicked.connect(update_clust_clear_nan)
 ui.pushButton_clust_prev_prof.clicked.connect(draw_prev_cluster_profile)
 ui.pushButton_clust_next_prof.clicked.connect(draw_next_cluster_profile)
 ui.pushButton_clust_auto.clicked.connect(calculate_cluster_auto)
+ui.tableWidget_cluster_auto_result.cellDoubleClicked.connect(apply_selected_auto_result_from_table)
 
 
 time = datetime.datetime.now()


### PR DESCRIPTION
### Motivation
- Improve UX for cluster AUTO tuning by allowing users to quickly apply a candidate configuration from the results table to the cluster controls. 
- The action should happen on double-click to avoid accidental switching.

### Description
- Add a runtime cache `cluster_auto_results_cache` to `cluster.py` to preserve the last rendered candidate results for row -> candidate mapping. 
- Update `render_auto_results_table` to store the provided `results` into `cluster_auto_results_cache`. 
- Implement `apply_selected_auto_result_from_table(row_idx, _column_idx)` in `cluster.py` which validates the clicked row, checks that the candidate `status` is `ok`, calls `apply_auto_result_to_ui(...)` and shows feedback via `set_info`.
- Wire the UI by connecting `ui.tableWidget_cluster_auto_result.cellDoubleClicked` to `apply_selected_auto_result_from_table` in `geovel.py` so a double-click applies the selected variant.

### Testing
- Ran `python -m py_compile cluster.py geovel.py` and the files compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2a76a334832f9ca31feea617b218)