### PR TITLE
Apply AUTO cluster candidate from results table with double-click and cache results

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -51,6 +51,9 @@ class CandidateResult(TypedDict):
     error_text: str
 
 
+cluster_auto_results_cache: list[CandidateResult] = []
+
+
 def make_candidate_config(
         *,
         scaler_mode: str,
@@ -976,6 +979,9 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
     """
     Заполняет таблицу результатов AUTO-подбора.
     """
+    global cluster_auto_results_cache
+    cluster_auto_results_cache = list(results or [])
+
     table = ui.tableWidget_cluster_auto_result
     headers = [
         "Rank", "Score", "Method", "Scaler", "PCA",
@@ -1038,6 +1044,27 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
             table.setItem(row_idx, col_idx, item)
 
     table.resizeColumnsToContents()
+
+
+def apply_selected_auto_result_from_table(row_idx: int, _column_idx: int) -> None:
+    """
+    По двойному клику в таблице AUTO применяет выбранный вариант к настройкам UI.
+    """
+    if row_idx < 0 or row_idx >= len(cluster_auto_results_cache):
+        set_info("AUTO: выбранная строка вне диапазона результатов.", "brown")
+        return
+
+    selected_result = cluster_auto_results_cache[row_idx]
+    if selected_result.get("status") != "ok":
+        set_info("AUTO: выбранный вариант невалиден и не может быть применен.", "brown")
+        return
+
+    apply_auto_result_to_ui(selected_result)
+    set_info(
+        f"AUTO: применен вариант #{row_idx + 1} "
+        f"(score={_safe_num(selected_result.get('score'), precision=4)}).",
+        "green"
+    )
 
 
 def apply_auto_result_to_ui(best_result: CandidateResult) -> None:

--- a/geovel.py
+++ b/geovel.py
@@ -555,6 +555,7 @@ ui.checkBox_clust_clean_nan.clicked.connect(update_clust_clear_nan)
 ui.pushButton_clust_prev_prof.clicked.connect(draw_prev_cluster_profile)
 ui.pushButton_clust_next_prof.clicked.connect(draw_next_cluster_profile)
 ui.pushButton_clust_auto.clicked.connect(calculate_cluster_auto)
+ui.tableWidget_cluster_auto_result.cellDoubleClicked.connect(apply_selected_auto_result_from_table)
 
 
 time = datetime.datetime.now()


### PR DESCRIPTION
### Motivation
- Allow users to apply an AUTO-selected clustering candidate directly from the results table by interacting with the UI. 
- Preserve the latest AUTO run results in a short-lived cache to map table rows to candidate payloads for quick application.

### Description
- Added a global cache `cluster_auto_results_cache: list[CandidateResult]` to store the last set of AUTO results. 
- `render_auto_results_table` now writes `results` into `cluster_auto_results_cache` when populating the UI table. 
- Implemented `apply_selected_auto_result_from_table(row_idx, _column_idx)` to validate the clicked row, ensure the candidate `status` is `ok`, call `apply_auto_result_to_ui`, and surface informational messages via `set_info`. 
- Wired the table double-click signal by connecting `ui.tableWidget_cluster_auto_result.cellDoubleClicked` to `apply_selected_auto_result_from_table` in `geovel.py`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2a76a334832f9ca31feea617b218)