### PR TITLE
Подключить timeout-чекбокс и spinbox'ы в AUTO-подборе кластеров

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -1176,11 +1176,20 @@ def calculate_cluster_auto():
     # Таймауты можно отключить, чтобы не терять потенциально хороший,
     # но долгий кандидат. Если в UI нет явного контролла, по умолчанию
     # таймауты считаются отключенными.
-    timeout_toggle = getattr(ui, "checkBox_cluster_auto_use_timeout", None)
+    timeout_toggle = (
+        getattr(ui, "checkBox_cluster_auto_timeout", None)
+        or getattr(ui, "checkBox_cluster_auto_use_timeout", None)
+    )
     use_timeouts = bool(timeout_toggle.isChecked()) if timeout_toggle is not None else False
 
-    total_timeout_ctrl = getattr(ui, "doubleSpinBox_cluster_auto_timeout_total", None)
-    per_candidate_timeout_ctrl = getattr(ui, "doubleSpinBox_cluster_auto_timeout_candidate", None)
+    total_timeout_ctrl = (
+        getattr(ui, "spinBox_cluster_auto_timeout_all", None)
+        or getattr(ui, "doubleSpinBox_cluster_auto_timeout_total", None)
+    )
+    per_candidate_timeout_ctrl = (
+        getattr(ui, "spinBox_cluster_auto_timeout_candidate", None)
+        or getattr(ui, "doubleSpinBox_cluster_auto_timeout_candidate", None)
+    )
 
     total_timeout_sec = (
         float(total_timeout_ctrl.value())


### PR DESCRIPTION
### Motivation
- Поддержать реальные UI-контролы таймаутов для AUTO-подбора параметров кластерного анализа, т.к. ранее код читал старые имена контролов и новые элементы формы не влияли на поведение.

### Description
- В `calculate_cluster_auto` подключены контролы `checkBox_cluster_auto_timeout`, `spinBox_cluster_auto_timeout_candidate`, `spinBox_cluster_auto_timeout_all` с обратным fallback на старые имена `checkBox_cluster_auto_use_timeout` и `doubleSpinBox_cluster_auto_timeout_*` для совместимости.

### Testing
- Компиляция файла прошла успешно: выполнена команда `python -m py_compile cluster.py` и ошибок не выявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de38bb60f8832fa89aca5793275a69)