### PR TITLE
Change ObjectSet data/report to Text and add gzip serialization for large cluster datasets

### DIFF
--- a/alembic/versions/9b1f2a6c4d31_change_object_set_data_report_to_text.py
+++ b/alembic/versions/9b1f2a6c4d31_change_object_set_data_report_to_text.py
@@ -1,0 +1,29 @@
+"""change_object_set_data_report_to_text
+
+Revision ID: 9b1f2a6c4d31
+Revises: df983186961d
+Create Date: 2026-04-16 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '9b1f2a6c4d31'
+down_revision: Union[str, None] = 'df983186961d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('object_set') as batch_op:
+        batch_op.alter_column('data', existing_type=sa.String(), type_=sa.Text(), existing_nullable=True)
+        batch_op.alter_column('report', existing_type=sa.String(), type_=sa.Text(), existing_nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('object_set') as batch_op:
+        batch_op.alter_column('data', existing_type=sa.Text(), type_=sa.String(), existing_nullable=True)
+        batch_op.alter_column('report', existing_type=sa.Text(), type_=sa.String(), existing_nullable=True)

--- a/cluster.py
+++ b/cluster.py
@@ -1,4 +1,6 @@
 import pandas as pd
+import base64
+import gzip
 import hashlib
 import json
 from collections import Counter
@@ -57,6 +59,41 @@ class CandidateResult(TypedDict):
 
 
 cluster_auto_results_cache: list[CandidateResult] = []
+
+
+CLUSTER_DATA_GZIP_PREFIX = "gzjson:"
+
+
+def _serialize_cluster_dataset(data: list[list[Any]]) -> str:
+    """
+    Сериализует набор данных кластера в компактный JSON,
+    а для крупных наборов — в gzip+base64 строку.
+    """
+    json_payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    encoded_size = len(json_payload.encode("utf-8"))
+
+    # Сжимаем только крупные payload, чтобы снизить размер записи в БД.
+    if encoded_size < 10 * 1024 * 1024:
+        return json_payload
+
+    compressed = gzip.compress(json_payload.encode("utf-8"), compresslevel=6)
+    b64_payload = base64.b64encode(compressed).decode("ascii")
+    return f"{CLUSTER_DATA_GZIP_PREFIX}{b64_payload}"
+
+
+def _deserialize_cluster_dataset(raw_data: str) -> list[list[Any]]:
+    """
+    Десериализует набор данных кластера из JSON или gzip+base64 формата.
+    """
+    if not raw_data:
+        return []
+
+    if raw_data.startswith(CLUSTER_DATA_GZIP_PREFIX):
+        compressed_b64 = raw_data[len(CLUSTER_DATA_GZIP_PREFIX):]
+        decompressed = gzip.decompress(base64.b64decode(compressed_b64.encode("ascii")))
+        return json.loads(decompressed.decode("utf-8"))
+
+    return json.loads(raw_data)
 
 
 CLUSTER_MAP_INTERP_RESOLUTION_MIN = 50
@@ -1349,7 +1386,7 @@ def calculate_cluster_auto():
         return
 
     try:
-        base_data = json.loads(clust_object.data)
+        base_data = _deserialize_cluster_dataset(clust_object.data)
     except Exception as exc:
         set_info(f"AUTO: ошибка чтения данных объекта: {exc}", "red")
         return
@@ -2055,7 +2092,8 @@ def collect_clust_object():
     print(high_corr_table)
 
     data = working_data_result.values.tolist()
-    new_cluster_obj = ObjectSet(research_id=get_research_id(), analysis_id=get_curr_clust_analys_id(), data=json.dumps(data), report=report)
+    serialized_data = _serialize_cluster_dataset(data)
+    new_cluster_obj = ObjectSet(research_id=get_research_id(), analysis_id=get_curr_clust_analys_id(), data=serialized_data, report=report)
     session.add(new_cluster_obj)
     session.commit()
     update_list_clust_object()
@@ -3011,7 +3049,7 @@ def calculate_cluster():
     clust_object_id = get_curr_clust_object_id()
     clust_analys_id = get_curr_clust_analys_id()
     clust_object = session.query(ObjectSet).filter_by(id=clust_object_id).first()
-    data = json.loads(clust_object.data)
+    data = _deserialize_cluster_dataset(clust_object.data)
     raw_meta = np.array(data, dtype=object)[:, 0] if data else np.array([])
     selected_button = ui.buttonGroup_3.checkedButton()
 

--- a/models_db/model_cluster.py
+++ b/models_db/model_cluster.py
@@ -16,8 +16,8 @@ class ObjectSet(Base):
     id = Column(Integer, primary_key=True)
     research_id = Column(Integer, ForeignKey('research.id'))
     analysis_id = Column(Integer, ForeignKey('analysis_cluster.id'))
-    data = Column(String)
-    report = Column(String)
+    data = Column(Text)
+    report = Column(Text)
 
     research = relationship('Research', back_populates='cluster_set')
     analysis = relationship('AnalysisCluster', back_populates='object_set')


### PR DESCRIPTION
### Motivation
- Reduce risk of truncation and enable storing larger cluster payloads by switching `object_set.data` and `object_set.report` to a `Text` type in the DB. 
- Reduce DB storage footprint for very large cluster payloads by optionally compressing large JSON payloads before persisting.

### Description
- Added an Alembic migration `9b1f2a6c4d31_change_object_set_data_report_to_text.py` to alter `object_set.data` and `object_set.report` from `String` to `Text` (with downgrade reversing the change). 
- Updated ORM model `models_db/model_cluster.py` to use `Column(Text)` for `ObjectSet.data` and `ObjectSet.report` and keep `ClusterAutoTuningCache.top_results` as `Text`. 
- Introduced `_serialize_cluster_dataset` and `_deserialize_cluster_dataset` helpers in `cluster.py` that JSON-serialize datasets and, for payloads above ~10MB, compress with gzip and encode with base64 using the `gzjson:` prefix. 
- Replaced direct `json.loads`/`json.dumps` usage in `cluster.py` with the new helpers when reading and writing `ObjectSet.data`, and added `base64` and `gzip` imports and `CLUSTER_DATA_GZIP_PREFIX` constant. 

### Testing
- No automated tests were added for this change and no project test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0da70b7b8832fbb3409a477d5e0c2)