### PR TITLE
Fix AUTO candidate limit toggle lookup

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -1510,6 +1510,7 @@ def calculate_cluster_auto():
     force_recompute = bool(force_recompute_toggle.isChecked()) if force_recompute_toggle is not None else False
 
     limit_candidates_toggle = _get_ui_control_by_names(
+        "checkBox_cluster_auto_limit200",
         "checkBox_cluster_auto_limit_candidates",
         "checkBox_cluster_auto_limit_200"
     )


### PR DESCRIPTION
### Motivation
- Исправить поведение автоподбора параметров кластеризации, где при снятой галочке `limit 200` всё равно срабатывала выборка 200 кандидатов из-за несовпадающего имени UI-контрола.

### Description
- Добавлено первичное разрешение имени чекбокса `checkBox_cluster_auto_limit200` в функции `calculate_cluster_auto()` с сохранением поиска по устаревшим именам, чтобы корректно определять, включён ли лимит кандидатов.

### Testing
- Запущена проверка синтаксиса `python -m py_compile cluster.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63088c764832f81fee200510794b7)