### PR TITLE
Fix PCA parameter handling in cluster auto-tuning candidate runner

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -538,10 +538,19 @@ def run_cluster_candidate(
 
         try:
             if candidate["pca_enabled"]:
+                pca_mode = candidate["pca_mode"] or "variance_ratio"
+                pca_raw_value = candidate.get("pca_value")
+                pca_n_components = 20
+                pca_variance_ratio = 0.9
+                if pca_mode == "fixed_components":
+                    pca_n_components = int(float(pca_raw_value))
+                else:
+                    pca_variance_ratio = float(pca_raw_value)
                 data_for_cluster, pca_info = apply_pca(
                     preprocess_data,
-                    mode=candidate["pca_mode"] or "variance_ratio",
-                    variance_ratio=float(candidate["pca_value"])
+                    mode=pca_mode,
+                    n_components=pca_n_components,
+                    variance_ratio=pca_variance_ratio
                 )
                 pca_components_after = int(pca_info.get("components_after_pca", 0) or 0)
                 if pca_components_after < min_pca_components_value:


### PR DESCRIPTION
### Motivation
- AUTO cluster runs showed mismatches between displayed PCA mode (`fix=2`) and actual computed PCA components (`PCA comps=20`) because PCA arguments were not passed according to the selected mode. 
- That also allowed fixed-component candidates below the configured minimum (`min_pca_components`) to bypass validation.

### Description
- In `run_cluster_candidate` read `pca_mode` and raw `pca_value` and normalize them into `pca_n_components` and `pca_variance_ratio` depending on mode. 
- Call `apply_pca` with `mode`, `n_components`, and `variance_ratio` so the PCA run reflects the candidate configuration. 
- Keep and propagate `pca_components_after` from `apply_pca` and use it for the `min_pca_components` validation and result stats.
- Change affects `cluster.py` around the PCA application/validation path in the auto-tuning flow (`run_cluster_candidate` / `apply_pca`).

### Testing
- Successfully compiled the modified module with `python -m py_compile /workspace/geovel_1.0/cluster.py` (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72e5e17f8832f9d4b983957aab0cf)