### PR TITLE
Make AUTO tuning memory-safe and more robust: transform-cache, sampling, feature reduction, stratified sampling & rescue grid

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -4,7 +4,8 @@ import gzip
 import hashlib
 import json
 import random
-from collections import Counter
+import gc
+from collections import Counter, OrderedDict
 from datetime import datetime, timezone
 from itertools import product
 from time import monotonic
@@ -13,6 +14,7 @@ from typing import Any, Dict, Literal, Optional, TypedDict
 import build_table
 from matplotlib.colors import BoundaryNorm, ListedColormap
 from scipy.interpolate import griddata
+from sklearn.random_projection import SparseRandomProjection
 from draw import draw_radarogram
 from func import *
 
@@ -65,6 +67,141 @@ cluster_auto_results_cache: list[CandidateResult] = []
 
 CLUSTER_DATA_GZIP_PREFIX = "gzjson:"
 GMM_COVARIANCE_TYPES = ("full", "diag", "tied", "spherical")
+AUTO_TRANSFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
+AUTO_TRANSFORM_CACHE_MAX_ITEM_BYTES = 128 * 1024 * 1024
+AUTO_SILHOUETTE_MAX_SAMPLES = 5000
+AUTO_TUNING_MAX_ROWS = 20000
+AUTO_TRANSFORM_CACHE_MAX_ROWS = 12000
+AUTO_TUNING_MAX_WORKING_SET_BYTES = 256 * 1024 * 1024
+AUTO_TUNING_MIN_ROWS = 256
+AUTO_TUNING_MAX_FEATURES = 512
+AUTO_TUNING_REDUCE_FEATURES_THRESHOLD = 10000
+AUTO_TUNING_FEATURE_REDUCTION_MODE = "auto"
+
+
+def _estimate_array_like_nbytes(value: Any) -> int:
+    """
+    Грубая оценка объема памяти array-like объекта в байтах.
+    """
+    if value is None:
+        return 0
+    if isinstance(value, np.ndarray):
+        return int(value.nbytes)
+    if hasattr(value, "nbytes"):
+        try:
+            return int(value.nbytes)  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    try:
+        return int(np.array(value).nbytes)
+    except Exception:
+        return 0
+
+
+def _estimate_transform_cache_item_nbytes(value: Any) -> int:
+    """
+    Оценивает объем одного элемента transform-cache.
+    """
+    if isinstance(value, tuple):
+        return int(sum(_estimate_array_like_nbytes(v) for v in value))
+    return _estimate_array_like_nbytes(value)
+
+
+def _trim_transform_cache(
+        transform_cache: "OrderedDict[tuple, Any]",
+        cache_sizes: "OrderedDict[tuple, int]",
+        cache_total_bytes: int,
+        *,
+        max_cache_bytes: int
+) -> int:
+    """
+    Поддерживает LRU-ограничение transform-cache по памяти.
+    """
+    while cache_total_bytes > max_cache_bytes and transform_cache:
+        evicted_key, _ = transform_cache.popitem(last=False)
+        cache_total_bytes -= int(cache_sizes.pop(evicted_key, 0))
+    return max(0, int(cache_total_bytes))
+
+
+def _sample_rows_for_auto_tuning(data, max_rows: int) -> Any:
+    """
+    Ограничивает число строк для AUTO-подбора, чтобы снизить риск OOM.
+    """
+    if data is None:
+        return data
+    try:
+        max_rows = max(2, int(max_rows))
+    except (TypeError, ValueError):
+        max_rows = AUTO_TUNING_MAX_ROWS
+    data_len = len(data)
+    if data_len <= max_rows:
+        return data
+    n_features = None
+    if data_len > 0:
+        try:
+            first_row = data[0]
+            n_features = len(first_row)
+        except Exception:
+            n_features = None
+    if n_features and n_features > 0:
+        approx_bytes_per_row = int(max(8, n_features * 8 * 6))
+        max_rows_by_memory = int(AUTO_TUNING_MAX_WORKING_SET_BYTES // approx_bytes_per_row)
+        max_rows = min(max_rows, max(2, max_rows_by_memory))
+    max_rows = max(2, min(max_rows, data_len))
+    if data_len <= max_rows:
+        return data
+    rng = np.random.default_rng(42)
+    sampled_idx = np.sort(rng.choice(data_len, size=max_rows, replace=False))
+    if isinstance(data, np.ndarray):
+        return data[sampled_idx]
+    return [data[int(i)] for i in sampled_idx]
+
+
+def _reduce_feature_space_for_auto_tuning(data, max_features: int) -> Any:
+    """
+    Ограничивает число признаков для AUTO-подбора при очень высокой размерности.
+    """
+    if data is None:
+        return data
+    try:
+        max_features = max(2, int(max_features))
+    except (TypeError, ValueError):
+        max_features = AUTO_TUNING_MAX_FEATURES
+
+    data_np = np.asarray(data, dtype=np.float64)
+    if data_np.ndim != 2:
+        return data
+    n_rows = int(data_np.shape[0])
+    n_features = int(data_np.shape[1])
+    if AUTO_TUNING_FEATURE_REDUCTION_MODE == "off":
+        return data_np
+    matrix_bytes = int(max(1, n_rows) * max(1, n_features) * 4)
+    if AUTO_TUNING_FEATURE_REDUCTION_MODE == "auto":
+        if (
+                n_features <= int(AUTO_TUNING_REDUCE_FEATURES_THRESHOLD)
+                and matrix_bytes <= int(AUTO_TUNING_MAX_WORKING_SET_BYTES)
+        ):
+            return data_np
+        # Оценка безопасной целевой размерности с учетом временных копий.
+        approx_copies_factor = 3
+        max_features_by_memory = int(
+            AUTO_TUNING_MAX_WORKING_SET_BYTES // max(1, n_rows * 4 * approx_copies_factor)
+        )
+        max_features = max(32, min(int(max_features), int(max_features_by_memory)))
+    if n_features <= int(max_features):
+        return data_np
+
+    if AUTO_TUNING_FEATURE_REDUCTION_MODE in {"random_projection", "auto"}:
+        projector = SparseRandomProjection(
+            n_components=max_features,
+            dense_output=True,
+            random_state=42
+        )
+        reduced = projector.fit_transform(data_np)
+        return np.asarray(reduced, dtype=np.float64)
+
+    feature_idx = np.linspace(0, n_features - 1, num=max_features, dtype=int)
+    return np.asarray(data_np[:, feature_idx], dtype=np.float64)
 
 
 def _serialize_cluster_dataset(data: list[list[Any]]) -> str:
@@ -314,7 +451,8 @@ def _apply_candidate_limit(
         candidates: list[CandidateConfig],
         *,
         max_candidates: Optional[int],
-        scope_label: str
+        scope_label: str,
+        random_seed: Optional[int] = None
 ) -> list[CandidateConfig]:
     """
     Применяет лимит кандидатов.
@@ -330,13 +468,87 @@ def _apply_candidate_limit(
         _set_auto_info(f"{scope_label}: размер search space = {total_candidates}.", "blue")
         return candidates
 
-    sampled_candidates = random.sample(candidates, max_candidates)
+    # Стратифицированная выборка: сохраняем представительство методов,
+    # чтобы случайный сэмпл не состоял только из "тяжелых"/неудачных кандидатов.
+    method_groups: Dict[str, list[CandidateConfig]] = {}
+    for candidate in candidates:
+        method_name = str(candidate.get("method", "unknown"))
+        method_groups.setdefault(method_name, []).append(candidate)
+
+    sampled_candidates: list[CandidateConfig] = []
+    methods = sorted(method_groups.keys())
+    if methods:
+        per_method_quota = max(1, max_candidates // len(methods))
+        if random_seed is None:
+            random_seed = random.SystemRandom().randrange(1, 2_147_483_647)
+        rng = random.Random(int(random_seed))
+        for method_name in methods:
+            method_candidates = method_groups.get(method_name, [])
+            take = min(len(method_candidates), per_method_quota)
+            if take > 0:
+                sampled_candidates.extend(rng.sample(method_candidates, take))
+        if len(sampled_candidates) < max_candidates:
+            sampled_signatures = {
+                _candidate_signature(candidate)
+                for candidate in sampled_candidates
+            }
+            remainder_pool = [
+                candidate for candidate in candidates
+                if _candidate_signature(candidate) not in sampled_signatures
+            ]
+            need = max_candidates - len(sampled_candidates)
+            if need > 0 and remainder_pool:
+                sampled_candidates.extend(rng.sample(remainder_pool, min(need, len(remainder_pool))))
+    else:
+        sampled_candidates = random.sample(candidates, max_candidates)
+
     _set_auto_info(
         f"{scope_label}: сгенерировано {total_candidates} кандидатов, "
-        f"случайно выбрано {max_candidates}.",
+        f"случайно выбрано {max_candidates} (seed={random_seed}).",
         "brown"
     )
     return sampled_candidates
+
+
+def _build_auto_rescue_candidates(max_clusters: int) -> list[CandidateConfig]:
+    """
+    Резервный небольшой набор "надежных" кандидатов, если основной сэмпл
+    не дал ни одной валидной конфигурации.
+    """
+    max_clusters = max(2, int(max_clusters))
+    rescue_candidates: list[CandidateConfig] = []
+    for scaler_mode, pca_enabled, k in product(
+            ("none", "standard", "robust"),
+            (False, True),
+            range(2, min(8, max_clusters) + 1)
+    ):
+        candidate = make_candidate_config(
+            scaler_mode=scaler_mode,
+            pca_enabled=pca_enabled,
+            pca_mode="variance_ratio" if pca_enabled else None,
+            pca_value=0.9 if pca_enabled else None,
+            method="kmeans",
+            method_params={
+                "kmeans_n_clusters": int(k),
+                "kmeans_n_init": 20
+            }
+        )
+        rescue_candidates.append(candidate)
+    return rescue_candidates
+
+
+def _summarize_candidate_failures(results: list[CandidateResult], top_n: int = 5) -> list[tuple[str, int]]:
+    """
+    Возвращает топ причин невалидности/ошибок кандидатов.
+    """
+    counter: Counter[str] = Counter()
+    for row in results:
+        status = str(row.get("status", ""))
+        if status == "ok":
+            continue
+        reason = str(row.get("error_text", "")).strip() or f"status={status}"
+        counter[reason] += 1
+    return counter.most_common(max(1, int(top_n)))
 
 
 def build_auto_search_space(
@@ -347,7 +559,8 @@ def build_auto_search_space(
         hdbscan_metric: str = "euclidean",
         hdbscan_metrics: Optional[list[str]] = None,
         scaler_only: bool = False,
-        pca_only: bool = False
+        pca_only: bool = False,
+        random_seed: Optional[int] = None
 ) -> list[CandidateConfig]:
     """
     Формирует coarse/fine пространство кандидатов для AUTO-подбора.
@@ -455,7 +668,8 @@ def build_auto_search_space(
     return _apply_candidate_limit(
         candidates,
         max_candidates=max_candidates,
-        scope_label=f"AUTO {mode}"
+        scope_label=f"AUTO {mode}",
+        random_seed=random_seed
     )
 
 
@@ -466,7 +680,8 @@ def run_cluster_candidate(
         candidate_id: str = "",
         clean_kwargs: Optional[Dict[str, Any]] = None,
         transform_cache: Optional[Dict[tuple, Any]] = None,
-        min_pca_components: int = 2
+        min_pca_components: int = 2,
+        max_silhouette_samples: int = AUTO_SILHOUETTE_MAX_SAMPLES
 ) -> CandidateResult:
     """
     Прогоняет одного кандидата AUTO-подбора без UI-зависимостей.
@@ -488,7 +703,9 @@ def run_cluster_candidate(
         clean_params.update(clean_kwargs)
 
     try:
+        base_data = _sample_rows_for_auto_tuning(base_data, AUTO_TUNING_MAX_ROWS)
         clear_data, _ = clean_features(data=base_data, **clean_params)
+        clear_data = _reduce_feature_space_for_auto_tuning(clear_data, AUTO_TUNING_MAX_FEATURES)
     except Exception as exc:
         return make_candidate_result(
             candidate_id=candidate_id,
@@ -497,7 +714,7 @@ def run_cluster_candidate(
             error_text=f"clean_features failed: {exc}"
         )
 
-    if not clear_data or len(clear_data) == 0:
+    if clear_data is None or len(clear_data) == 0:
         return make_candidate_result(
             candidate_id=candidate_id,
             candidate_config=candidate,
@@ -578,6 +795,8 @@ def run_cluster_candidate(
 
         if transform_cache is not None:
             transform_cache[transform_key] = (data_for_cluster, pca_components_after)
+            if hasattr(transform_cache, "move_to_end"):
+                transform_cache.move_to_end(transform_key, last=True)  # type: ignore[attr-defined]
     pca_stats: Dict[str, int] = {}
     if pca_components_after is not None:
         pca_stats["pca_components_after"] = int(pca_components_after)
@@ -596,12 +815,11 @@ def run_cluster_candidate(
             error_text=f"cluster_data failed: {exc}"
         )
 
-    labels_np = np.array(labels, dtype=int)
+    labels_np = np.asarray(labels, dtype=int)
     mask_eval = labels_np != -1
     labels_eval = labels_np[mask_eval]
-    x_eval = np.array(data_for_cluster, dtype=float)[mask_eval]
     unique_clusters_eval = np.unique(labels_eval)
-    n_samples_eval = int(len(x_eval))
+    n_samples_eval = int(np.count_nonzero(mask_eval))
 
     if n_samples_eval == 0:
         return make_candidate_result(
@@ -637,7 +855,8 @@ def run_cluster_candidate(
             labels,
             use_silhouette=True,
             use_db=True,
-            use_ch=True
+            use_ch=True,
+            max_silhouette_samples=max_silhouette_samples
         )
     except Exception as exc:
         return make_candidate_result(
@@ -956,7 +1175,8 @@ def run_auto_cluster_tuning(
         candidate_soft_timeout_sec: Optional[float] = None,
         min_pca_components: int = 2,
         weights: Optional[Dict[str, float]] = None,
-        clean_kwargs: Optional[Dict[str, Any]] = None
+        clean_kwargs: Optional[Dict[str, Any]] = None,
+        random_seed: Optional[int] = None
 ) -> Dict[str, Any]:
     """
     Orchestrator AUTO-подбора.
@@ -973,10 +1193,19 @@ def run_auto_cluster_tuning(
         hdbscan_metric=hdbscan_metric,
         hdbscan_metrics=hdbscan_metrics,
         scaler_only=scaler_only,
-        pca_only=pca_only
+        pca_only=pca_only,
+        random_seed=random_seed
     )
     coarse_results: list[CandidateResult] = []
-    transform_cache: Dict[tuple, Any] = {}
+    auto_cache_enabled = len(base_data) <= int(AUTO_TRANSFORM_CACHE_MAX_ROWS)
+    if not auto_cache_enabled:
+        _set_auto_info(
+            f"AUTO {mode}: transform-cache отключен для большого набора ({len(base_data)} строк).",
+            "brown"
+        )
+    transform_cache: Optional["OrderedDict[tuple, Any]"] = OrderedDict() if auto_cache_enabled else None
+    transform_cache_sizes: "OrderedDict[tuple, int]" = OrderedDict()
+    transform_cache_total_bytes = 0
     run_start_ts = monotonic()
     for idx, candidate in enumerate(coarse_candidates, start=1):
         if soft_timeout_sec is not None and (monotonic() - run_start_ts) > float(soft_timeout_sec):
@@ -1031,6 +1260,91 @@ def run_auto_cluster_tuning(
                 ).strip()
 
         coarse_results.append(result)
+        if transform_cache is not None and len(transform_cache_sizes) != len(transform_cache):
+            stale_keys = [key for key in list(transform_cache_sizes.keys()) if key not in transform_cache]
+            for key in stale_keys:
+                transform_cache_total_bytes -= int(transform_cache_sizes.pop(key, 0))
+            for key, value in list(transform_cache.items()):
+                if key in transform_cache_sizes:
+                    continue
+                cached_size = _estimate_transform_cache_item_nbytes(value)
+                if cached_size > AUTO_TRANSFORM_CACHE_MAX_ITEM_BYTES:
+                    transform_cache.pop(key, None)
+                    continue
+                if cached_size > 0:
+                    transform_cache_sizes[key] = cached_size
+                    transform_cache_total_bytes += cached_size
+            transform_cache_total_bytes = _trim_transform_cache(
+                transform_cache,
+                transform_cache_sizes,
+                transform_cache_total_bytes,
+                max_cache_bytes=AUTO_TRANSFORM_CACHE_MAX_BYTES
+            )
+        gc.collect()
+
+    has_valid_coarse = any(row.get("status") == "ok" for row in coarse_results)
+    if not has_valid_coarse:
+        _set_auto_info(
+            "AUTO: в основном наборе не найдено валидных конфигураций, запускаю резервный mini-grid.",
+            "brown"
+        )
+        rescue_candidates = _build_auto_rescue_candidates(max_clusters=max_clusters)
+        for idx, candidate in enumerate(rescue_candidates, start=1):
+            try:
+                result = run_cluster_candidate(
+                    base_data=base_data,
+                    candidate=candidate,
+                    candidate_id=f"R{idx:03d}",
+                    clean_kwargs=clean_kwargs,
+                    transform_cache=transform_cache,
+                    min_pca_components=min_pca_components
+                )
+            except Exception as exc:
+                result = make_candidate_result(
+                    candidate_id=f"R{idx:03d}",
+                    candidate_config=candidate,
+                    status="error",
+                    error_text=f"rescue candidate exception: {exc}"
+                )
+            coarse_results.append(result)
+        has_valid_after_rescue = any(row.get("status") == "ok" for row in coarse_results)
+        if not has_valid_after_rescue:
+            _set_auto_info(
+                "AUTO: rescue mini-grid не дал валидных конфигураций, повторяю с упрощенной очисткой.",
+                "brown"
+            )
+            relaxed_clean_kwargs = {
+                "use_non_finite": True,
+                "non_finite_mode": "impute",
+                "use_variance_threshold": False,
+                "use_correlation_filter": False
+            }
+            for idx, candidate in enumerate(rescue_candidates, start=1):
+                try:
+                    result = run_cluster_candidate(
+                        base_data=base_data,
+                        candidate=candidate,
+                        candidate_id=f"RR{idx:03d}",
+                        clean_kwargs=relaxed_clean_kwargs,
+                        transform_cache=transform_cache,
+                        min_pca_components=min_pca_components
+                    )
+                except Exception as exc:
+                    result = make_candidate_result(
+                        candidate_id=f"RR{idx:03d}",
+                        candidate_config=candidate,
+                        status="error",
+                        error_text=f"relaxed rescue exception: {exc}"
+                    )
+                coarse_results.append(result)
+        if not any(row.get("status") == "ok" for row in coarse_results):
+            top_failures = _summarize_candidate_failures(coarse_results, top_n=3)
+            if top_failures:
+                _set_auto_info(
+                    "AUTO: топ причин невалидности: "
+                    + "; ".join(f"{reason} ({count})" for reason, count in top_failures),
+                    "brown"
+                )
 
     ranked_coarse = rank_candidates(coarse_results, weights=weights)
     coarse_best_result = ranked_coarse[0] if ranked_coarse else None
@@ -1105,6 +1419,27 @@ def run_auto_cluster_tuning(
                 ).strip()
 
         fine_results.append(result)
+        if transform_cache is not None and len(transform_cache_sizes) != len(transform_cache):
+            stale_keys = [key for key in list(transform_cache_sizes.keys()) if key not in transform_cache]
+            for key in stale_keys:
+                transform_cache_total_bytes -= int(transform_cache_sizes.pop(key, 0))
+            for key, value in list(transform_cache.items()):
+                if key in transform_cache_sizes:
+                    continue
+                cached_size = _estimate_transform_cache_item_nbytes(value)
+                if cached_size > AUTO_TRANSFORM_CACHE_MAX_ITEM_BYTES:
+                    transform_cache.pop(key, None)
+                    continue
+                if cached_size > 0:
+                    transform_cache_sizes[key] = cached_size
+                    transform_cache_total_bytes += cached_size
+            transform_cache_total_bytes = _trim_transform_cache(
+                transform_cache,
+                transform_cache_sizes,
+                transform_cache_total_bytes,
+                max_cache_bytes=AUTO_TRANSFORM_CACHE_MAX_BYTES
+            )
+        gc.collect()
 
     combined_ranked = rank_candidates(coarse_results + fine_results, weights=weights)
     best_result = combined_ranked[0] if combined_ranked else coarse_best_result
@@ -1616,6 +1951,7 @@ def calculate_cluster_auto():
         "blue"
     )
     QApplication.processEvents()
+    auto_random_seed = random.SystemRandom().randrange(1, 2_147_483_647)
 
     if not force_recompute:
         cached_top_results = load_cluster_auto_tuning_cache(
@@ -1648,6 +1984,7 @@ def calculate_cluster_auto():
         weights=metric_weights,
         soft_timeout_sec=total_timeout_sec,
         candidate_soft_timeout_sec=candidate_timeout_sec,
+        random_seed=auto_random_seed,
         clean_kwargs={
             "use_non_finite": ui.checkBox_clust_clean_nan.isChecked(),
             "non_finite_mode": text_method_nan,
@@ -2950,7 +3287,8 @@ def evaluate_clustering(
         labels,
         use_silhouette=False,
         use_db=False,
-        use_ch=False
+        use_ch=False,
+        max_silhouette_samples: int = AUTO_SILHOUETTE_MAX_SAMPLES
 ):
     """
     Оценка качества кластеризации без эталонной разметки.
@@ -3012,8 +3350,23 @@ def evaluate_clustering(
     # Silhouette
     # --------------------------
     if use_silhouette:
-        val = float(silhouette_score(X_eval, labels_eval))
+        silhouette_sample_size = len(X_eval)
+        if max_silhouette_samples is not None:
+            try:
+                max_silhouette_samples = max(2, int(max_silhouette_samples))
+            except (TypeError, ValueError):
+                max_silhouette_samples = AUTO_SILHOUETTE_MAX_SAMPLES
+            silhouette_sample_size = min(silhouette_sample_size, int(max_silhouette_samples))
+        val = float(
+            silhouette_score(
+                X_eval,
+                labels_eval,
+                sample_size=silhouette_sample_size if silhouette_sample_size < len(X_eval) else None,
+                random_state=42
+            )
+        )
         results["metrics"]["silhouette"] = val
+        results["metrics"]["silhouette_n_samples"] = int(silhouette_sample_size)
 
         if val > 0.5:
             label = "Хорошо"


### PR DESCRIPTION
### Motivation
- Prevent OOMs and long-running candidates when AUTO tuning on large/high-dimensional datasets by bounding memory and work set sizes.
- Improve stability and reproducibility of candidate sampling and ranking by introducing a controllable random seed and preserving per-method representation.
- Provide recovery paths when the coarse search finds no valid configurations by adding a small rescue grid and failure summarization.
- Reduce cost of internal metrics (silhouette) on very large samples by limiting sampling size for stable evaluation.

### Description
- Added memory/tuning constants (e.g. `AUTO_TRANSFORM_CACHE_MAX_BYTES`, `AUTO_TUNING_MAX_ROWS`, `AUTO_TUNING_MAX_FEATURES`, `AUTO_SILHOUETTE_MAX_SAMPLES`) and imports `gc`, `OrderedDict`, and `SparseRandomProjection`.
- Implemented transform-cache accounting and LRU eviction helpers: `_estimate_array_like_nbytes`, `_estimate_transform_cache_item_nbytes`, and `_trim_transform_cache` and switched optional `transform_cache` to an `OrderedDict` with size tracking in `run_auto_cluster_tuning`.
- Added sampling and dimensionality-reduction helpers for AUTO tuning: `_sample_rows_for_auto_tuning` to cap rows, and `_reduce_feature_space_for_auto_tuning` which uses `SparseRandomProjection` (or uniform subsampling) to limit features when necessary; integrated these into `run_cluster_candidate` to avoid huge working sets.
- Made candidate sampling stratified by clustering `method` with `_apply_candidate_limit` now accepting `random_seed` to produce reproducible draws, and propagated `random_seed` through `build_auto_search_space` and `run_auto_cluster_tuning` (seed generated in `calculate_cluster_auto`).
- Added a small rescue mini-grid `_build_auto_rescue_candidates` and logic in `run_auto_cluster_tuning` to retry with a compact, reliable set of candidates and a relaxed-clean fallback when no valid coarse candidates are found, plus `_summarize_candidate_failures` to log top failure reasons.
- Improved transform cache hygiene in both coarse and fine phases: size estimation per entry, eviction of too-large items, periodic `gc.collect()` calls, and `move_to_end` usage when caching transforms in `run_cluster_candidate`.
- Minor robustness/perf changes: use `np.asarray`/`np.count_nonzero` instead of creating needless copies, and added `max_silhouette_samples` parameter plumbing to `run_cluster_candidate` and `evaluate_clustering` to limit silhouette computation and record `silhouette_n_samples` in metrics.

### Testing
- Ran the project test suite with `pytest -q` and the tests completed successfully.
- Executed a smoke integration run of `run_auto_cluster_tuning` on a synthetic dataset to validate sampling/feature-reduction and cache eviction paths; the tuning completed without exceptions and produced ranked results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74d4915e0832f81b6b3ca03dd3b9b)