### PR TITLE
Align cluster map points with cleaned rows (use kept_row_indices)

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -3769,9 +3769,22 @@ def calculate_cluster():
         "blue"
     )
 
+    map_data = [data[row_idx] for row_idx in kept_row_indices if 0 <= row_idx < len(data)]
+    if len(map_data) != len(labels_for_output):
+        set_info(
+            f"Внимание: карта кластеров построена по усеченному набору точек "
+            f"(labels={len(labels_for_output)}, map_data={len(map_data)}).",
+            "brown"
+        )
+        map_len = min(len(map_data), len(labels_for_output))
+        map_data = map_data[:map_len]
+        labels_for_map = labels_for_output[:map_len]
+    else:
+        labels_for_map = labels_for_output
+
     plot_cluster_map(
-        labels_for_output,
-        data,
+        labels_for_map,
+        map_data,
         show_interpolation=show_interpolation,
         interpolation_resolution=interpolation_resolution,
         settings_caption=(


### PR DESCRIPTION
### Motivation
- The cluster map was plotted using the original `data` while labels corresponded to the cleaned/filtered rows, causing visual misalignment and identical-looking maps across different runs.
- Fix ensures the plotted points match the rows that produced the computed `labels` (especially important when `clean_features` drops rows).

### Description
- Build `map_data` from `kept_row_indices` so map points come only from rows that survived feature cleaning (`map_data = [data[row_idx] for row_idx in kept_row_indices ...]`).
- Add a safety guard that logs a `set_info` warning when `map_data` and `labels` lengths differ and truncates both to the common minimum (`labels_for_map` and `map_data`).
- Pass the aligned `labels_for_map` and `map_data` into `plot_cluster_map` instead of the full `data`, preserving interpolation and caption behavior.
- The change is localized to `calculate_cluster()` in `cluster.py` and leaves evaluation/smoothing logic unchanged.

### Testing
- Automated syntax check `python -m py_compile cluster.py` completed successfully.
- No other automated tests were present or run for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a83c4978832f84e9495a3c5bd406)