### PR TITLE
Implement convex-hull clipping mask for categorical maps

### DIFF
--- a/krige.py
+++ b/krige.py
@@ -44,12 +44,21 @@ def _build_categorical_palette(labels):
 
 
 def _inside_hull_mask(xx, yy, points):
+    """Build a boolean mask for grid cells inside the data coverage area.
+
+    Stage 2.2 baseline uses convex hull clipping. If hull construction fails
+    (e.g. degenerate geometry), keep previous behaviour and do not clip.
+    """
     if len(points) < 3:
         return np.ones_like(xx, dtype=bool)
+
     try:
-        hull = Delaunay(points)
+        hull = ConvexHull(points)
+        hull_points = points[hull.vertices]
+        triangulation = Delaunay(hull_points)
         flat_points = np.column_stack([xx.ravel(), yy.ravel()])
-        return hull.find_simplex(flat_points) >= 0
+        inside_flat = triangulation.find_simplex(flat_points) >= 0
+        return inside_flat.reshape(xx.shape)
     except Exception:
         return np.ones_like(xx, dtype=bool)
 


### PR DESCRIPTION
### Motivation
- Implement stage 2.2 "clip to data area" baseline for categorical map mode and fix a mask shape issue so clipping does not produce a flat/incorrect mask for the interpolation grid.

### Description
- Rewrote `_inside_hull_mask` in `krige.py` to build a `ConvexHull(points)`, triangulate hull vertices with `Delaunay`, run `find_simplex` on the flattened grid and `reshape` the result back to `xx.shape`, and added a short docstring describing the behaviour.
- Kept previous safe fallback behaviour so that if hull/triangulation fails (degenerate geometry or other errors), the function returns a full-True mask and clipping is effectively disabled.

### Testing
- Ran a syntax check with `python -m py_compile krige.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0ef082e4832fa62e364c14b3a03e)