### PR TITLE
Change cluster CALC flow to update radarograms before map dialog

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -4027,19 +4027,6 @@ def calculate_cluster():
     map_y = [float(row[2]) for row in map_data]
     map_title = f"Cluster {ui.comboBox_clust_obj.currentText().split(' id')[0]}"
 
-    set_info(
-        "Открыто окно настроек карты кластеров. Выберите параметры и нажмите DRAW.",
-        "blue"
-    )
-    draw_map(
-        map_x,
-        map_y,
-        labels_for_map,
-        map_title,
-        color_marker=False,
-        initial_map_mode="categorical"
-    )
-
     print(labels_for_output)
     print(clust_info)
 
@@ -4127,5 +4114,20 @@ def calculate_cluster():
                 profile_labels=profile_labels,
                 use_relief=True
             )
+        else:
+            set_info("Профиль не выбран: результаты кластеров на радарограмме не обновлены.", "brown")
     else:
         set_info("Не удалось автоматически выбрать исследование/профиль для отрисовки кластеров.", "brown")
+
+    set_info(
+        "Открыто окно настроек карты кластеров. Выберите параметры и нажмите DRAW.",
+        "blue"
+    )
+    draw_map(
+        map_x,
+        map_y,
+        labels_for_map,
+        map_title,
+        color_marker=False,
+        initial_map_mode="categorical"
+    )


### PR DESCRIPTION
### Motivation
- Порядок действий после нажатия CALC мешал работе: окно настройки карты блокировало интерфейс и препятствовало моментальному просмотру результатов на радарограммах.

### Description
- Перенёс вызов `draw_map(...)` в конец функции `calculate_cluster()` чтобы сначала выполнить синхронизацию UI и перерисовку радарограмм (`draw_radarogram()` и `draw_cluster_profile_result(...)`), а затем открыть окно карты.
- Удалил прежний ранний запуск карты и добавил информирующее сообщение через `set_info(...)`, если профиль не выбран, чтобы не прерывать обновление радарограмм.
- Сохранение меток и кэш профилей (`save_cluster_profile_cache(...)`) и расчёт метрик кластеризации оставлены без изменений.

### Testing
- Выполнен поиск по коду через `rg` чтобы подтвердить места изменения и зависимые вызовы (успешно). 
- Проверил дифф изменений командой `git diff -- cluster.py` чтобы убедиться в корректной перестановке кода (успешно). 
- Зафиксировал изменения через `git commit -m "Change cluster CALC flow to update radarograms before map dialog"` и коммит прошёл успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032add14b8832fa50670c62f6f1b10)