### PR TITLE
Подтверждаемая очистка результатов автоподбора кластеров

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -2051,6 +2051,42 @@ def render_auto_results_table(results: list[CandidateResult]) -> None:
     table.resizeColumnsToContents()
 
 
+
+
+def clear_cluster_auto_tune_results_with_confirm() -> None:
+    """
+    Очищает таблицу результатов AUTO-подбора после подтверждения пользователя.
+    """
+    table = getattr(ui, "tableWidget_cluster_auto_result", None)
+    if table is None:
+        return
+
+    global cluster_auto_results_cache
+    has_cached_results = len(cluster_auto_results_cache) > 0
+    has_table_results = table.rowCount() > 0
+
+    if not (has_cached_results or has_table_results):
+        set_info("AUTO: таблица результатов уже пустая.", "brown")
+        return
+
+    reply = QMessageBox.warning(
+        ui,
+        "Очистка результатов AUTO",
+        "Вы действительно хотите очистить результаты автоподбора?\nЭто действие удалит строки из таблицы и кэш текущей сессии.",
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.No
+    )
+
+    if reply != QMessageBox.Yes:
+        set_info("AUTO: очистка результатов отменена пользователем.", "brown")
+        return
+
+    cluster_auto_results_cache = []
+    table.clear()
+    table.setRowCount(0)
+    table.setColumnCount(0)
+    set_info("AUTO: результаты автоподбора очищены.", "green")
+
 def apply_selected_auto_result_from_table(row_idx: int, _column_idx: int) -> None:
     """
     По двойному клику в таблице AUTO применяет выбранный вариант к настройкам UI.

--- a/geovel.py
+++ b/geovel.py
@@ -562,6 +562,7 @@ ui.pushButton_clust_prev_prof.clicked.connect(draw_prev_cluster_profile)
 ui.pushButton_clust_next_prof.clicked.connect(draw_next_cluster_profile)
 ui.pushButton_clust_auto.clicked.connect(calculate_cluster_auto)
 ui.pushButton_clust_auto_batch.clicked.connect(calculate_cluster_auto_batch)
+ui.pushButton_cluster_clear_result_auto_tune.clicked.connect(clear_cluster_auto_tune_results_with_confirm)
 ui.tableWidget_cluster_auto_result.cellDoubleClicked.connect(apply_selected_auto_result_from_table)
 
 


### PR DESCRIPTION
### Motivation
- Добавить защищённую от случайного удаления очистку результатов AUTO-подбора кластеров с явным подтверждением пользователем.

### Description
- Добавлена функция `clear_cluster_auto_tune_results_with_confirm()` в `cluster.py`, которая проверяет наличие данных, показывает `QMessageBox` с выбором Yes/No и при подтверждении очищает `tableWidget_cluster_auto_result` и `cluster_auto_results_cache`, а также выводит сообщение через `set_info`.
- Подключён обработчик к кнопке `pushButton_cluster_clear_result_auto_tune` в `geovel.py` (подключение `clear_cluster_auto_tune_results_with_confirm`).

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile cluster.py geovel.py`, сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06e07089d0832faabd588fef39ae59)