### PR TITLE
Stabilize AUTO cluster tuning for large object sets

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -2232,6 +2232,16 @@ def calculate_cluster_auto():
         set_info("AUTO: пустой набор данных для подбора.", "brown")
         return
 
+    original_rows_count = len(base_data)
+    sampled_base_data = _sample_rows_for_auto_tuning(base_data, AUTO_TUNING_MAX_ROWS)
+    sampled_rows_count = len(sampled_base_data) if sampled_base_data is not None else 0
+    if sampled_rows_count < original_rows_count:
+        set_info(
+            f"AUTO: для устойчивости расчетов использована подвыборка {sampled_rows_count}/{original_rows_count} строк.",
+            "brown"
+        )
+    base_data = sampled_base_data
+
     sample_limits = calculate_auto_min_cluster_sample_limits(len(base_data), min_value=1)
 
     auto_mode = "COARSE" if ui.radioButton_cluster_coarse_auto.isChecked() else "FINE"
@@ -2529,6 +2539,16 @@ def calculate_cluster_auto_batch() -> None:
             failed += 1
             set_info(f"AUTO BATCH {auto_mode} [{idx}/{total_objects}] {object_name}: FAILED (пустой набор данных).", "brown")
             continue
+
+        original_rows_count = len(base_data)
+        base_data = _sample_rows_for_auto_tuning(base_data, AUTO_TUNING_MAX_ROWS)
+        sampled_rows_count = len(base_data) if base_data is not None else 0
+        if sampled_rows_count < original_rows_count:
+            set_info(
+                f"AUTO BATCH {auto_mode} [{idx}/{total_objects}] {object_name}: "
+                f"использована подвыборка {sampled_rows_count}/{original_rows_count} строк.",
+                "brown"
+            )
 
         sample_limits = calculate_auto_min_cluster_sample_limits(len(base_data), min_value=1)
         min_cluster_samples = int(sample_limits["recommended_default_value"])


### PR DESCRIPTION
### Motivation
- AUTO tuning on very large ObjectSets could cause high peak memory usage and lead to process termination with exit code 137 (SIGKILL), so we need to bound workset size before heavy pipeline stages.

### Description
- Add an early pre-sampling step in `calculate_cluster_auto()` that calls `_sample_rows_for_auto_tuning(...)` and replaces `base_data` with the sampled subset when the original row count exceeds `AUTO_TUNING_MAX_ROWS`.
- Emit a user-facing `set_info(...)` message when sampling is applied that shows `sampled_rows/original_rows` so operators can see that AUTO ran on a sub-sample.
- Apply the same pre-sampling guard to `calculate_cluster_auto_batch()` for each object to avoid repeated memory spikes during batch runs.
- Recompute `sample_limits` after sampling so subsequent logic (e.g. `min_cluster_samples`) uses the sampled row count.

### Testing
- Ran `python -m py_compile cluster.py` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06edbcf7fc832fbf284c5a64504680)