### PR TITLE
Fix AUTO cluster results clearing to delete persisted cache

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -2183,6 +2183,21 @@ def clear_cluster_auto_tune_results_with_confirm() -> None:
     table.clear()
     table.setRowCount(0)
     table.setColumnCount(0)
+
+    clust_object_id = get_curr_clust_object_id()
+    if clust_object_id:
+        try:
+            (
+                session.query(ClusterAutoTuningCache)
+                .filter_by(object_set_id=int(clust_object_id))
+                .delete(synchronize_session=False)
+            )
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            set_info(f"AUTO: таблица очищена, но не удалось удалить сохраненный кэш: {exc}", "brown")
+            return
+
     set_info("AUTO: результаты автоподбора очищены.", "green")
 
 def apply_selected_auto_result_from_table(row_idx: int, _column_idx: int) -> None:


### PR DESCRIPTION
### Motivation
- Clearing AUTO-tuning in the UI only removed the in-memory cache and table rows, while persisted `ClusterAutoTuningCache` rows for the selected `ObjectSet` remained and were reloaded on next open.

### Description
- Updated `clear_cluster_auto_tune_results_with_confirm` in `cluster.py` to also delete persisted rows from `ClusterAutoTuningCache` for the currently selected `ObjectSet` after clearing the UI table and `cluster_auto_results_cache`.
- Added `session.commit()` after the deletion and `session.rollback()` plus a `set_info(...)` warning when the DB deletion fails to keep transactional safety and inform the user.
- Kept existing early-return behavior and UI cleanup when there are no results or the user cancels.

### Testing
- Ran `python -m py_compile cluster.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071f7a4d48832fa89da1c1c9eec0ac)