### PR TITLE
Harden well-log clustering schema: add constraints, indexes, and migration

### DIFF
--- a/alembic/versions/b1e2c3d4f5a6_well_log_cluster_schema_hardening.py
+++ b/alembic/versions/b1e2c3d4f5a6_well_log_cluster_schema_hardening.py
@@ -1,0 +1,122 @@
+"""well log cluster schema hardening
+
+Revision ID: b1e2c3d4f5a6
+Revises: 9b1f2a6c4d31
+Create Date: 2026-05-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1e2c3d4f5a6'
+down_revision: Union[str, None] = '9b1f2a6c4d31'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('well_log_cluster_dataset', schema=None) as batch_op:
+        batch_op.alter_column('name', existing_type=sa.String(), nullable=False)
+        batch_op.alter_column('created_by', new_column_name='created_at', existing_type=sa.DateTime(), nullable=False)
+
+    with op.batch_alter_table('well_for_cluster', schema=None) as batch_op:
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('well_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('top_md', existing_type=sa.Float(), nullable=False)
+        batch_op.alter_column('bottom_md', existing_type=sa.Float(), nullable=False)
+        batch_op.create_index('ix_well_for_cluster_dataset_id', ['dataset_id'], unique=False)
+        batch_op.create_index('ix_well_for_cluster_well_id', ['well_id'], unique=False)
+        batch_op.create_unique_constraint('uq_well_for_cluster_dataset_well', ['dataset_id', 'well_id'])
+
+    with op.batch_alter_table('canonical_well_log', schema=None) as batch_op:
+        batch_op.alter_column('canonical_name', existing_type=sa.String(), nullable=False)
+        batch_op.create_index('ix_canonical_well_log_canonical_name', ['canonical_name'], unique=True)
+
+    with op.batch_alter_table('alias_well_log', schema=None) as batch_op:
+        batch_op.alter_column('alias_name', existing_type=sa.String(), nullable=False)
+        batch_op.alter_column('canonical_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_index('ix_alias_well_log_alias_name', ['alias_name'], unique=True)
+        batch_op.create_index('ix_alias_well_log_canonical_id', ['canonical_id'], unique=False)
+
+    with op.batch_alter_table('feature_calculator', schema=None) as batch_op:
+        batch_op.alter_column('feature_name', existing_type=sa.String(), nullable=False)
+        batch_op.alter_column('used_canonical_well_log', existing_type=sa.Text(), nullable=False)
+        batch_op.alter_column('transform_type', existing_type=sa.String(), nullable=False)
+        batch_op.alter_column('params_json', existing_type=sa.Text(), nullable=False)
+        batch_op.alter_column('created_at', existing_type=sa.DateTime(), nullable=False)
+        batch_op.create_index('ix_feature_calculator_feature_name', ['feature_name'], unique=True)
+
+    with op.batch_alter_table('cluster_well_log_parameter', schema=None) as batch_op:
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('canonical_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_index('ix_cluster_well_log_parameter_dataset_id', ['dataset_id'], unique=False)
+        batch_op.create_index('ix_cluster_well_log_parameter_canonical_id', ['canonical_id'], unique=False)
+        batch_op.create_unique_constraint('uq_cluster_well_log_param_dataset_canonical', ['dataset_id', 'canonical_id'])
+
+    with op.batch_alter_table('cluster_well_log_parameter_from_calculator', schema=None) as batch_op:
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('calculator_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.create_index('ix_cluster_well_log_parameter_from_calculator_dataset_id', ['dataset_id'], unique=False)
+        batch_op.create_index('ix_cluster_well_log_parameter_from_calculator_calculator_id', ['calculator_id'], unique=False)
+        batch_op.create_unique_constraint('uq_cluster_well_log_param_calc_dataset_calculator', ['dataset_id', 'calculator_id'])
+
+    with op.batch_alter_table('cluster_well_log_dataset_data', schema=None) as batch_op:
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column('data', existing_type=sa.Text(), nullable=False)
+        batch_op.create_index('ix_cluster_well_log_dataset_data_dataset_id', ['dataset_id'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('cluster_well_log_dataset_data', schema=None) as batch_op:
+        batch_op.drop_index('ix_cluster_well_log_dataset_data_dataset_id')
+        batch_op.alter_column('data', existing_type=sa.Text(), nullable=True)
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=True)
+
+    with op.batch_alter_table('cluster_well_log_parameter_from_calculator', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_cluster_well_log_param_calc_dataset_calculator', type_='unique')
+        batch_op.drop_index('ix_cluster_well_log_parameter_from_calculator_calculator_id')
+        batch_op.drop_index('ix_cluster_well_log_parameter_from_calculator_dataset_id')
+        batch_op.alter_column('calculator_id', existing_type=sa.Integer(), nullable=True)
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=True)
+
+    with op.batch_alter_table('cluster_well_log_parameter', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_cluster_well_log_param_dataset_canonical', type_='unique')
+        batch_op.drop_index('ix_cluster_well_log_parameter_canonical_id')
+        batch_op.drop_index('ix_cluster_well_log_parameter_dataset_id')
+        batch_op.alter_column('canonical_id', existing_type=sa.Integer(), nullable=True)
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=True)
+
+    with op.batch_alter_table('feature_calculator', schema=None) as batch_op:
+        batch_op.drop_index('ix_feature_calculator_feature_name')
+        batch_op.alter_column('created_at', existing_type=sa.DateTime(), nullable=True)
+        batch_op.alter_column('params_json', existing_type=sa.Text(), nullable=True)
+        batch_op.alter_column('transform_type', existing_type=sa.String(), nullable=True)
+        batch_op.alter_column('used_canonical_well_log', existing_type=sa.Text(), nullable=True)
+        batch_op.alter_column('feature_name', existing_type=sa.String(), nullable=True)
+
+    with op.batch_alter_table('alias_well_log', schema=None) as batch_op:
+        batch_op.drop_index('ix_alias_well_log_canonical_id')
+        batch_op.drop_index('ix_alias_well_log_alias_name')
+        batch_op.alter_column('canonical_id', existing_type=sa.Integer(), nullable=True)
+        batch_op.alter_column('alias_name', existing_type=sa.String(), nullable=True)
+
+    with op.batch_alter_table('canonical_well_log', schema=None) as batch_op:
+        batch_op.drop_index('ix_canonical_well_log_canonical_name')
+        batch_op.alter_column('canonical_name', existing_type=sa.String(), nullable=True)
+
+    with op.batch_alter_table('well_for_cluster', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_well_for_cluster_dataset_well', type_='unique')
+        batch_op.drop_index('ix_well_for_cluster_well_id')
+        batch_op.drop_index('ix_well_for_cluster_dataset_id')
+        batch_op.alter_column('bottom_md', existing_type=sa.Float(), nullable=True)
+        batch_op.alter_column('top_md', existing_type=sa.Float(), nullable=True)
+        batch_op.alter_column('well_id', existing_type=sa.Integer(), nullable=True)
+        batch_op.alter_column('dataset_id', existing_type=sa.Integer(), nullable=True)
+
+    with op.batch_alter_table('well_log_cluster_dataset', schema=None) as batch_op:
+        batch_op.alter_column('created_at', new_column_name='created_by', existing_type=sa.DateTime(), nullable=True)
+        batch_op.alter_column('name', existing_type=sa.String(), nullable=True)

--- a/models_db/model_cluster.py
+++ b/models_db/model_cluster.py
@@ -65,23 +65,27 @@ class WellLogClusterDataset(Base):
     __tablename__ = 'well_log_cluster_dataset'
 
     id = Column(Integer, primary_key=True)
-    name = Column(String)
-    created_by = Column(DateTime, default=datetime.datetime.now())
+    name = Column(String, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
 
-    well_for_cluster = relationship('WellForCluster', back_populates='well_cluster_set')
-    cluster_well_log_param = relationship('ClusterWellLogParameter', back_populates='well_cluster_set')
-    cluster_well_log_param_from_calculator = relationship('ClusterWellLogParameterFromCalculator', back_populates='well_cluster_set')
-    data = relationship('WellLogClusterDatasetData', back_populates='well_cluster_set')
+    well_for_cluster = relationship('WellForCluster', back_populates='well_cluster_set', cascade='all, delete-orphan')
+    cluster_well_log_param = relationship('ClusterWellLogParameter', back_populates='well_cluster_set', cascade='all, delete-orphan')
+    cluster_well_log_param_from_calculator = relationship('ClusterWellLogParameterFromCalculator', back_populates='well_cluster_set', cascade='all, delete-orphan')
+    data = relationship('WellLogClusterDatasetData', back_populates='well_cluster_set', cascade='all, delete-orphan')
 
 
 class WellForCluster(Base):
     __tablename__ = 'well_for_cluster'
 
     id = Column(Integer, primary_key=True)
-    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'))
-    well_id = Column(Integer, ForeignKey('well.id'))
-    top_md = Column(Float)
-    bottom_md = Column(Float)
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    well_id = Column(Integer, ForeignKey('well.id'), nullable=False, index=True)
+    top_md = Column(Float, nullable=False)
+    bottom_md = Column(Float, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('dataset_id', 'well_id', name='uq_well_for_cluster_dataset_well'),
+    )
 
     well_cluster_set = relationship('WellLogClusterDataset', back_populates='well_for_cluster')
     well = relationship('Well', back_populates='well_for_cluster')
@@ -91,10 +95,10 @@ class CanonicalWellLog(Base):
     __tablename__ = 'canonical_well_log'
 
     id = Column(Integer, primary_key=True)
-    canonical_name = Column(String)
+    canonical_name = Column(String, nullable=False, unique=True, index=True)
     description = Column(String)
 
-    alias_name = relationship('AliasWellLog', back_populates='canonical_name')
+    aliases = relationship('AliasWellLog', back_populates='canonical_log', cascade='all, delete-orphan')
     cluster_well_log_param = relationship('ClusterWellLogParameter', back_populates='canonical_name')
 
 
@@ -102,22 +106,22 @@ class AliasWellLog(Base):
     __tablename__ = 'alias_well_log'
 
     id = Column(Integer, primary_key=True)
-    alias_name = Column(String)
-    canonical_id = Column(Integer, ForeignKey('canonical_well_log.id'))
+    alias_name = Column(String, nullable=False, unique=True, index=True)
+    canonical_id = Column(Integer, ForeignKey('canonical_well_log.id'), nullable=False, index=True)
 
-    canonical_name = relationship('CanonicalWellLog', back_populates='alias_name')
+    canonical_log = relationship('CanonicalWellLog', back_populates='aliases')
 
 
 class FeatureCalculator(Base):
     __tablename__ = 'feature_calculator'
 
     id = Column(Integer, primary_key=True)
-    feature_name = Column(String)
+    feature_name = Column(String, nullable=False, unique=True, index=True)
     expression = Column(Text)
-    used_canonical_well_log = Column(Text)
-    transform_type = Column(String)
-    params_json = Column(Text)
-    created_at = Column(DateTime)
+    used_canonical_well_log = Column(Text, nullable=False)
+    transform_type = Column(String, nullable=False)
+    params_json = Column(Text, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
 
     cluster_well_log_param_from_calculator = relationship('ClusterWellLogParameterFromCalculator', back_populates='calculator')
 
@@ -126,8 +130,12 @@ class ClusterWellLogParameter(Base):
     __tablename__ = 'cluster_well_log_parameter'
 
     id = Column(Integer, primary_key=True)
-    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'))
-    canonical_id = Column(Integer, ForeignKey('canonical_well_log.id'))
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    canonical_id = Column(Integer, ForeignKey('canonical_well_log.id'), nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint('dataset_id', 'canonical_id', name='uq_cluster_well_log_param_dataset_canonical'),
+    )
 
     well_cluster_set = relationship('WellLogClusterDataset', back_populates='cluster_well_log_param')
     canonical_name = relationship('CanonicalWellLog', back_populates='cluster_well_log_param')
@@ -137,8 +145,12 @@ class ClusterWellLogParameterFromCalculator(Base):
     __tablename__ = 'cluster_well_log_parameter_from_calculator'
 
     id = Column(Integer, primary_key=True)
-    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'))
-    calculator_id = Column(Integer, ForeignKey('feature_calculator.id'))
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    calculator_id = Column(Integer, ForeignKey('feature_calculator.id'), nullable=False, index=True)
+
+    __table_args__ = (
+        UniqueConstraint('dataset_id', 'calculator_id', name='uq_cluster_well_log_param_calc_dataset_calculator'),
+    )
 
     well_cluster_set = relationship('WellLogClusterDataset', back_populates='cluster_well_log_param_from_calculator')
     calculator = relationship('FeatureCalculator', back_populates='cluster_well_log_param_from_calculator')
@@ -148,11 +160,10 @@ class WellLogClusterDatasetData(Base):
     __tablename__ = 'cluster_well_log_dataset_data'
 
     id = Column(Integer, primary_key=True)
-    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'))
-    data = Column(Text)
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    data = Column(Text, nullable=False)
 
     well_cluster_set = relationship('WellLogClusterDataset', back_populates='data')
-
 
 
 


### PR DESCRIPTION
### Motivation
- Improve data integrity and query performance for well-log clustering by enforcing non-nullable columns, adding indexes and unique constraints, and standardizing timestamp fields and cascade behavior.

### Description
- Add an Alembic migration `b1e2c3d4f5a6` that renames `created_by` to `created_at`, makes multiple columns `nullable=False`, and creates indexes and unique constraints across clustering tables with a full `downgrade` path.
- Update ORM models in `models_db/model_cluster.py` to match the migration by setting `nullable=False`, adding `default=datetime.datetime.utcnow` for timestamps, adding `index=True`, and introducing `UniqueConstraint`s and `__table_args__` where appropriate.
- Add `cascade='all, delete-orphan'` to dataset relationships and rename/clarify relationship attributes (e.g., `aliases`/`canonical_log`) to reflect ownership semantics and improve cascade deletes.
- Make `canonical_name`, `alias_name`, and `feature_name` unique/indexed and add composite uniqueness for dataset vs canonical/calculator associations.

### Testing
- Ran the project's unit test suite with `pytest`; all tests passed.
- Executed the migration workflow with `alembic upgrade head` and then `alembic downgrade -1` against a local test database; both operations completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed9ea112c832f934272b201040234)