### PR TITLE
Add normalized name fields and ORM integrity hooks for canonical/alias well logs

### DIFF
--- a/alembic/versions/9b21c6e4a1f2_add_normalized_names_for_well_log_aliases.py
+++ b/alembic/versions/9b21c6e4a1f2_add_normalized_names_for_well_log_aliases.py
@@ -1,0 +1,54 @@
+"""add normalized names for well log aliases
+
+Revision ID: 9b21c6e4a1f2
+Revises: b1e2c3d4f5a6
+Create Date: 2026-05-22 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9b21c6e4a1f2'
+down_revision = 'b1e2c3d4f5a6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('canonical_well_log', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('canonical_name_norm', sa.String(), nullable=True))
+
+    op.execute("""
+        UPDATE canonical_well_log
+        SET canonical_name_norm = lower(trim(canonical_name))
+        WHERE canonical_name IS NOT NULL
+    """)
+
+    with op.batch_alter_table('canonical_well_log', schema=None) as batch_op:
+        batch_op.alter_column('canonical_name_norm', existing_type=sa.String(), nullable=False)
+        batch_op.create_index('ix_canonical_well_log_canonical_name_norm', ['canonical_name_norm'], unique=True)
+
+    with op.batch_alter_table('alias_well_log', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('alias_name_norm', sa.String(), nullable=True))
+
+    op.execute("""
+        UPDATE alias_well_log
+        SET alias_name_norm = lower(trim(alias_name))
+        WHERE alias_name IS NOT NULL
+    """)
+
+    with op.batch_alter_table('alias_well_log', schema=None) as batch_op:
+        batch_op.alter_column('alias_name_norm', existing_type=sa.String(), nullable=False)
+        batch_op.create_index('ix_alias_well_log_alias_name_norm', ['alias_name_norm'], unique=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('alias_well_log', schema=None) as batch_op:
+        batch_op.drop_index('ix_alias_well_log_alias_name_norm')
+        batch_op.drop_column('alias_name_norm')
+
+    with op.batch_alter_table('canonical_well_log', schema=None) as batch_op:
+        batch_op.drop_index('ix_canonical_well_log_canonical_name_norm')
+        batch_op.drop_column('canonical_name_norm')

--- a/models_db/model_cluster.py
+++ b/models_db/model_cluster.py
@@ -96,6 +96,7 @@ class CanonicalWellLog(Base):
 
     id = Column(Integer, primary_key=True)
     canonical_name = Column(String, nullable=False, unique=True, index=True)
+    canonical_name_norm = Column(String, nullable=False, unique=True, index=True)
     description = Column(String)
 
     aliases = relationship('AliasWellLog', back_populates='canonical_log', cascade='all, delete-orphan')
@@ -107,10 +108,41 @@ class AliasWellLog(Base):
 
     id = Column(Integer, primary_key=True)
     alias_name = Column(String, nullable=False, unique=True, index=True)
+    alias_name_norm = Column(String, nullable=False, unique=True, index=True)
     canonical_id = Column(Integer, ForeignKey('canonical_well_log.id'), nullable=False, index=True)
 
     canonical_log = relationship('CanonicalWellLog', back_populates='aliases')
 
+
+
+
+def _normalize_well_log_name(value):
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized.casefold()
+
+
+@event.listens_for(CanonicalWellLog, 'before_insert')
+@event.listens_for(CanonicalWellLog, 'before_update')
+def _sync_canonical_name_norm(mapper, connection, target):
+    if target.canonical_name is None:
+        raise ValueError('canonical_name cannot be empty')
+    target.canonical_name = target.canonical_name.strip()
+    if not target.canonical_name:
+        raise ValueError('canonical_name cannot be empty')
+    target.canonical_name_norm = _normalize_well_log_name(target.canonical_name)
+
+
+@event.listens_for(AliasWellLog, 'before_insert')
+@event.listens_for(AliasWellLog, 'before_update')
+def _sync_alias_name_norm(mapper, connection, target):
+    if target.alias_name is None:
+        raise ValueError('alias_name cannot be empty')
+    target.alias_name = target.alias_name.strip()
+    if not target.alias_name:
+        raise ValueError('alias_name cannot be empty')
+    target.alias_name_norm = _normalize_well_log_name(target.alias_name)
 
 class FeatureCalculator(Base):
     __tablename__ = 'feature_calculator'


### PR DESCRIPTION
### Motivation
- Enforce Stage 1.2 data-integrity rules from `docs/cluster_canonical_aliases_implementation_plan.md` to prevent duplicates that differ only by trim/case and to ensure non-empty names. 
- Provide a durable DB-level and ORM-level mechanism so alias/canonical lookups can be case- and whitespace-insensitive. 
- Make future `resolve_canonical` and clustering logic robust against name normalization issues. 

### Description
- Added `canonical_name_norm` and `alias_name_norm` columns to the `CanonicalWellLog` and `AliasWellLog` ORM models in `models_db/model_cluster.py` to store normalized (trimmed + casefolded) values. 
- Implemented ORM event listeners (`before_insert`/`before_update`) to trim, validate non-empty, and populate the normalized shadow fields for `canonical_name` and `alias_name`. 
- Added an Alembic migration `alembic/versions/9b21c6e4a1f2_add_normalized_names_for_well_log_aliases.py` that backfills normalized values using `lower(trim(...))`, marks the new columns `NOT NULL`, and creates unique indexes `ix_canonical_well_log_canonical_name_norm` and `ix_alias_well_log_alias_name_norm`. 

### Testing
- Ran static compilation checks with `python -m py_compile models_db/model_cluster.py alembic/versions/9b21c6e4a1f2_add_normalized_names_for_well_log_aliases.py`, which succeeded. 
- No DB migration was executed in CI here; the migration file was created and its SQL backfill/DDL statements are included for deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100c9f2a14832f8d739f69159e39d7)