### PR TITLE
Добавить агрегатор названий каротажных кривых с частотностью (этап 1.3)

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -96,6 +96,42 @@ AUTO_CANDIDATE_HARD_TIMEOUT_SEC: Optional[float] = None
 AUTO_CHECKPOINT_SAVE_EVERY = 10
 
 
+def get_available_well_log_curve_names_with_frequency() -> list[dict[str, int | str]]:
+    """
+    Возвращает все уникальные названия каротажных кривых из БД с частотностью.
+
+    Используется как источник «всех возможных названий» для формы
+    управления canonical/alias (этап 1.3).
+    """
+    rows = (
+        session.query(WellLog.curve_name, func.count(WellLog.id))
+        .filter(WellLog.curve_name.isnot(None))
+        .group_by(WellLog.curve_name)
+        .all()
+    )
+
+    aggregated: dict[str, dict[str, int | str]] = {}
+    for curve_name, count in rows:
+        raw_name = str(curve_name)
+        normalized_name = raw_name.strip()
+        if not normalized_name:
+            continue
+        normalized_key = normalized_name.casefold()
+        bucket = aggregated.get(normalized_key)
+        if bucket is None:
+            aggregated[normalized_key] = {
+                'curve_name': normalized_name,
+                'frequency': int(count),
+            }
+            continue
+        bucket['frequency'] = int(bucket['frequency']) + int(count)
+
+    return sorted(
+        aggregated.values(),
+        key=lambda item: (-int(item['frequency']), str(item['curve_name']).casefold(), str(item['curve_name']))
+    )
+
+
 def _compute_auto_silhouette_sample_size(
         n_rows: int,
         *,


### PR DESCRIPTION
### Motivation
- Реализовать пункт этапа 1.3 плана: обеспечить источник «всех возможных названий» каротажных кривых с частотностью для формы управления canonical/alias и приоритизации в UI.

### Description
- Добавлена функция `get_available_well_log_curve_names_with_frequency()` в `cluster.py`, которая извлекает `WellLog.curve_name` из БД, группирует и считает количество вхождений, отбрасывает пустые значения и нормализует строки через `strip()` + `casefold()` для агрегации вариантов.
- Функция аккумулирует частоты по нормализованным ключам и возвращает список словарей с полями `curve_name` и `frequency`, отсортированный по убыванию частоты и затем по имени для удобства UX.

### Testing
- Выполнена компиляция файла командой `python -m compileall cluster.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1010f69d48832f90e6150664160a04)