### PR TITLE
Implement Stage 2.2 alias CRUD in canonical well log backend service

### DIFF
--- a/canonical_well_log_service.py
+++ b/canonical_well_log_service.py
@@ -120,3 +120,48 @@ def get_canonical_well_logs_stats() -> List[Dict[str, object]]:
         })
 
     return result
+
+
+def add_alias_to_canonical(canonical_id: int, alias_name: str) -> AliasWellLog:
+    alias_name = _clean_name(alias_name)
+
+    canonical = session.query(CanonicalWellLog).filter(CanonicalWellLog.id == canonical_id).first()
+    if canonical is None:
+        raise CanonicalWellLogNotFoundError(f'Canonical well log with id={canonical_id} not found')
+
+    alias = AliasWellLog(alias_name=alias_name, canonical_id=canonical_id)
+    session.add(alias)
+
+    try:
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise CanonicalWellLogConflictError(
+            f'Alias name "{alias_name}" is already assigned to another canonical'
+        ) from exc
+
+    return alias
+
+
+def remove_alias_from_canonical(canonical_id: int, alias_name: str) -> None:
+    alias_name = _clean_name(alias_name)
+
+    canonical = session.query(CanonicalWellLog).filter(CanonicalWellLog.id == canonical_id).first()
+    if canonical is None:
+        raise CanonicalWellLogNotFoundError(f'Canonical well log with id={canonical_id} not found')
+
+    alias = (
+        session.query(AliasWellLog)
+        .filter(
+            AliasWellLog.canonical_id == canonical_id,
+            AliasWellLog.alias_name_norm == func.lower(func.trim(alias_name))
+        )
+        .first()
+    )
+    if alias is None:
+        raise CanonicalWellLogNotFoundError(
+            f'Alias name "{alias_name}" is not assigned to canonical with id={canonical_id}'
+        )
+
+    session.delete(alias)
+    session.commit()


### PR DESCRIPTION
### Motivation
- Provide backend CRUD operations for well-log aliases as required by Stage 2.2 so the UI and clustering pipeline can manage alias->canonical mappings with proper validation and uniqueness handling.

### Description
- Updated `canonical_well_log_service.py` to add `add_alias_to_canonical(canonical_id, alias_name)` which validates the alias name, ensures the `CanonicalWellLog` exists, creates an `AliasWellLog`, and converts DB uniqueness `IntegrityError` into `CanonicalWellLogConflictError` on conflicts.
- Added `remove_alias_from_canonical(canonical_id, alias_name)` which validates the alias name, ensures the canonical exists, looks up the alias by normalized name within the given canonical, and deletes it or raises `CanonicalWellLogNotFoundError` when not found.

### Testing
- Compiled the module with `python -m py_compile canonical_well_log_service.py` and it succeeded.
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1015fae9bc832f8aa03d38347266c1)