### PR TITLE
Implement backend reference lists for canonical alias form (stage 2.3)

### DIFF
--- a/canonical_well_log_service.py
+++ b/canonical_well_log_service.py
@@ -165,3 +165,62 @@ def remove_alias_from_canonical(canonical_id: int, alias_name: str) -> None:
 
     session.delete(alias)
     session.commit()
+
+
+def get_aliases_for_canonical(canonical_id: int) -> List[str]:
+    canonical = session.query(CanonicalWellLog).filter(CanonicalWellLog.id == canonical_id).first()
+    if canonical is None:
+        raise CanonicalWellLogNotFoundError(f'Canonical well log with id={canonical_id} not found')
+
+    rows = (
+        session.query(AliasWellLog.alias_name)
+        .filter(AliasWellLog.canonical_id == canonical_id)
+        .order_by(AliasWellLog.alias_name)
+        .all()
+    )
+    return [row[0] for row in rows]
+
+
+def get_all_curve_names_from_db() -> List[Dict[str, object]]:
+    rows = (
+        session.query(
+            WellLog.curve_name,
+            func.count(WellLog.id).label('usage_count')
+        )
+        .filter(WellLog.curve_name.isnot(None), func.trim(WellLog.curve_name) != '')
+        .group_by(WellLog.curve_name)
+        .order_by(func.count(WellLog.id).desc(), WellLog.curve_name.asc())
+        .all()
+    )
+
+    return [
+        {
+            'curve_name': curve_name,
+            'usage_count': int(usage_count),
+        }
+        for curve_name, usage_count in rows
+    ]
+
+
+def get_unassigned_curve_names() -> List[Dict[str, object]]:
+    alias_norm_subquery = session.query(AliasWellLog.alias_name_norm)
+
+    rows = (
+        session.query(
+            WellLog.curve_name,
+            func.count(WellLog.id).label('usage_count')
+        )
+        .filter(WellLog.curve_name.isnot(None), func.trim(WellLog.curve_name) != '')
+        .filter(~func.lower(func.trim(WellLog.curve_name)).in_(alias_norm_subquery))
+        .group_by(WellLog.curve_name)
+        .order_by(func.count(WellLog.id).desc(), WellLog.curve_name.asc())
+        .all()
+    )
+
+    return [
+        {
+            'curve_name': curve_name,
+            'usage_count': int(usage_count),
+        }
+        for curve_name, usage_count in rows
+    ]


### PR DESCRIPTION
### Motivation
- Provide backend endpoints required by the `aliac` form to list aliases for a canonical, all distinct curve names and the set of unassigned curve names so the UI can display reference lists and frequency counts.
- Fulfill stage 2.3 of `docs/cluster_canonical_aliases_implementation_plan.md` by moving these reference queries into the service layer.

### Description
- Added `get_aliases_for_canonical(canonical_id: int) -> List[str]` which validates the canonical exists and returns its aliases ordered alphabetically using `AliasWellLog.alias_name`.
- Added `get_all_curve_names_from_db() -> List[Dict[str, object]]` which returns distinct `WellLog.curve_name` values with `usage_count` and orders by frequency then name.
- Added `get_unassigned_curve_names() -> List[Dict[str, object]]` which returns curve names not mapped to any alias using a subquery on `AliasWellLog.alias_name_norm` and includes `usage_count` with the same ordering.
- Queries use normalization/trim checks and SQLAlchemy `func` for counts and normalization to match existing storage rules.

### Testing
- Compiled the module with `python -m py_compile canonical_well_log_service.py` successfully.
- No automated unit tests were added or executed beyond the successful Python byte-compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1018ff43fc832fa48f4a5aaa948c67)