### PR TITLE
Этап 2.4: добавить резолвер canonical имени каротажа

### DIFF
--- a/canonical_well_log_service.py
+++ b/canonical_well_log_service.py
@@ -224,3 +224,25 @@ def get_unassigned_curve_names() -> List[Dict[str, object]]:
         }
         for curve_name, usage_count in rows
     ]
+
+
+def resolve_canonical(curve_name: Optional[str]) -> Optional[str]:
+    """Resolve raw curve name to canonical name using alias mapping."""
+    if curve_name is None:
+        return None
+
+    normalized_curve_name = curve_name.strip().lower()
+    if not normalized_curve_name:
+        return None
+
+    row = (
+        session.query(CanonicalWellLog.canonical_name)
+        .join(AliasWellLog, AliasWellLog.canonical_id == CanonicalWellLog.id)
+        .filter(AliasWellLog.alias_name_norm == normalized_curve_name)
+        .first()
+    )
+
+    if row is None:
+        return None
+
+    return row[0]


### PR DESCRIPTION
### Motivation
- Реализовать этап 2.4 плана: обеспечить стабильный backend-резолвер для преобразования исходных названий кривых в канонические имена, используемые в кластерном модуле и форме управления.

### Description
- Добавлена функция `resolve_canonical(curve_name: Optional[str]) -> Optional[str]` в `canonical_well_log_service.py`, которая нормализует вход (`strip` + `lower`), выполняет `JOIN` через `AliasWellLog` -> `CanonicalWellLog` по полю `alias_name_norm` и возвращает `canonical_name` или `None` при отсутствии соответствия.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile canonical_well_log_service.py`, проверка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101b4b34f8832f95cf1c4c3164a6a3)