### PR TITLE
Этап 3.1: подключена кнопка ALIAC и модальное окно управления canonical/alias

### DIFF
--- a/geovel.py
+++ b/geovel.py
@@ -154,6 +154,7 @@ ui.pushButton_prof_wells_excel.clicked.connect(profile_wells_to_Excel)
 ui.pushButton_all_prof_wells_excel.clicked.connect(all_profile_wells_to_Excel)
 ui.pushButton_rem_dupl_wells.clicked.connect(remove_duplicate_wells)
 ui.pushButton_wells_to_excel.clicked.connect(wells_to_excel)
+ui.pushButton_well_log_aliac.clicked.connect(show_canonical_aliases_manager)
 
 
 ui.pushButton_color.clicked.connect(change_color)

--- a/well_log.py
+++ b/well_log.py
@@ -1,10 +1,42 @@
 import pandas as pd
 
+from canonical_well_log_service import get_all_curve_names_with_frequency, get_canonical_well_logs_stats
 from filter_well import get_names_boundary
 from func import *
 from krige import draw_map
 from regression import update_list_reg, remove_all_param_geovel_reg, update_list_well_markup_reg
 from well import show_data_well
+
+
+def show_canonical_aliases_manager():
+    """Открывает модальную форму управления canonical/alias из раздела скважин."""
+    dialog = QtWidgets.QDialog(MainWindow)
+    dialog.setWindowTitle('Управление canonical/alias каротажа')
+    dialog.setModal(True)
+    dialog.setAttribute(Qt.WA_DeleteOnClose)
+
+    layout = QtWidgets.QVBoxLayout(dialog)
+    info_label = QtWidgets.QLabel(
+        'Форма управления canonical/alias открыта из раздела скважин (кнопка ALIAC).\n'
+        'Текущая реализация: точка входа и модальное окно.'
+    )
+    info_label.setWordWrap(True)
+    layout.addWidget(info_label)
+
+    stats = get_canonical_well_logs_stats()
+    curve_names = get_all_curve_names_with_frequency()
+    summary_label = QtWidgets.QLabel(
+        f'Canonical: {len(stats)} | Названий кривых в БД: {len(curve_names)}'
+    )
+    layout.addWidget(summary_label)
+
+    close_button = QtWidgets.QPushButton('Закрыть')
+    close_button.clicked.connect(dialog.accept)
+    layout.addWidget(close_button)
+
+    m_width, m_height = get_width_height_monitor()
+    dialog.resize(int(m_width / 3), int(m_height / 3))
+    dialog.exec_()
 
 
 def show_well_log():


### PR DESCRIPTION
### Motivation
- Реализовать точку входа в UI для управления каноническими названиями и алиасами каротажа (этап 3.1 плана). 

### Description
- Добавлена функция `show_canonical_aliases_manager()` в `well_log.py`, которая открывает модальное `QDialog` с краткой сводкой по справочнику canonical/alias. 
- Импортированы сервисные вызовы `get_canonical_well_logs_stats` и `get_all_curve_names_with_frequency` для отображения статистики в форме. 
- В `geovel.py` подключён обработчик `ui.pushButton_well_log_aliac.clicked.connect(show_canonical_aliases_manager)` для кнопки `ALIAC`. 
- Модальное окно содержит информационный текст, строку с подсчётом canonical/названий кривых и кнопку `Закрыть`, а также устанавливает разумный размер через `get_width_height_monitor()`.

### Testing
- Выполнена проверка синтаксиса командой `python -m py_compile geovel.py well_log.py`, которая завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10298dbbec832fa7f0d9598772111d)