### PR TITLE
Fix import of curve names function in well_log.py

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from canonical_well_log_service import get_all_curve_names_with_frequency, get_canonical_well_logs_stats
+from canonical_well_log_service import get_all_curve_names_from_db, get_canonical_well_logs_stats
 from filter_well import get_names_boundary
 from func import *
 from krige import draw_map
@@ -24,7 +24,7 @@ def show_canonical_aliases_manager():
     layout.addWidget(info_label)
 
     stats = get_canonical_well_logs_stats()
-    curve_names = get_all_curve_names_with_frequency()
+    curve_names = get_all_curve_names_from_db()
     summary_label = QtWidgets.QLabel(
         f'Canonical: {len(stats)} | Названий кривых в БД: {len(curve_names)}'
     )


### PR DESCRIPTION
### Motivation
- Исправить падение при импорте `well_log.py`, вызванное отсутствием функции `get_all_curve_names_with_frequency` в `canonical_well_log_service.py` и привести использование к реальному API.

### Description
- Заменён импорт `get_all_curve_names_with_frequency` на существующую функцию `get_all_curve_names_from_db` и обновлён вызов в `show_canonical_aliases_manager()` в файле `well_log.py`.

### Testing
- Собраны файлы через `python -m py_compile well_log.py canonical_well_log_service.py`, компиляция прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102d7fc960832f8ce0be0c701bd9c1)