### PR TITLE
Stage 3.3: highlight and filter unassigned curve names in alias manager

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -65,6 +65,8 @@ def show_canonical_aliases_manager():
     curves_search = QtWidgets.QLineEdit()
     curves_search.setPlaceholderText('Поиск по названию')
     curves_layout.addWidget(curves_search)
+    curves_unassigned_only = QtWidgets.QCheckBox('Только нераспределенные')
+    curves_layout.addWidget(curves_unassigned_only)
     curves_list = QtWidgets.QListWidget()
     curves_layout.addWidget(curves_list)
 
@@ -111,11 +113,13 @@ def show_canonical_aliases_manager():
                 continue
 
             is_assigned = curve_name.strip().lower() in assigned
+            if curves_unassigned_only.isChecked() and is_assigned:
+                continue
             status = 'распределен' if is_assigned else 'не распределен'
             item = QtWidgets.QListWidgetItem(f"{curve_name} | частота: {row['usage_count']} | {status}")
             item.setData(Qt.UserRole, curve_name)
             if not is_assigned:
-                item.setBackground(QtGui.QColor(255, 247, 208))
+                item.setBackground(QtGui.QColor(255, 228, 196))
             curves_list.addItem(item)
 
     def refresh_all(keep_canonical_id=None):
@@ -207,6 +211,7 @@ def show_canonical_aliases_manager():
     btn_del_alias.clicked.connect(on_del_alias)
     canonical_list.itemSelectionChanged.connect(refresh_aliases)
     curves_search.textChanged.connect(refresh_curves)
+    curves_unassigned_only.toggled.connect(refresh_curves)
     curves_list.itemDoubleClicked.connect(on_curve_double_click)
 
     refresh_all()


### PR DESCRIPTION
### Motivation
- Реализовать пункт 3.3 из `docs/cluster_canonical_aliases_implementation_plan.md`: визуально выделять и быстро фильтровать нераспределенные названия кривых в форме управления `aliac`.

### Description
- Добавлен чекбокс фильтра `Только нераспределенные` в панели всех названий кривых в диалоге управления canonical/alias в файле `well_log.py` (`show_canonical_aliases_manager`).
- Обновлена логика формирования списка кривых: при включенном фильтре скрываются уже привязанные к canonical названия (изменение в `refresh_curves`).
- Сохранена подсветка нераспределенных названий и изменён цвет подсветки для большей заметности (`QtGui.QColor(255, 228, 196)`).
- Подключён сигнал чекбокса `curves_unassigned_only.toggled` к `refresh_curves` для мгновенного обновления списка при переключении.

### Testing
- Выполнена компиляция файла с помощью `python -m py_compile well_log.py`, проверка завершилась успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1030cfe718832f9281feeb0ad65f27)