### PR TITLE
Add UX validation guards in canonical alias manager

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -143,8 +143,20 @@ def show_canonical_aliases_manager():
         QMessageBox.critical(dialog, 'Ошибка', str(exc))
 
     def on_add_canonical():
+        canonical_name = canonical_name_input.text().strip()
+        if not canonical_name:
+            QMessageBox.information(dialog, 'Добавление canonical', 'Нельзя добавить пустой canonical')
+            return
+
+        normalized_canonical = canonical_name.lower()
+        for idx in range(canonical_list.count()):
+            list_item = canonical_list.item(idx)
+            if list_item.text().strip().lower() == normalized_canonical:
+                QMessageBox.information(dialog, 'Добавление canonical', 'Такое canonical уже существует')
+                return
+
         try:
-            canonical = create_canonical_well_log(canonical_name_input.text())
+            canonical = create_canonical_well_log(canonical_name)
             canonical_name_input.clear()
             refresh_all(keep_canonical_id=canonical.id)
         except CanonicalWellLogServiceError as exc:
@@ -182,6 +194,18 @@ def show_canonical_aliases_manager():
         alias_name = alias_input.text().strip()
         if not alias_name and curves_list.currentItem() is not None:
             alias_name = curves_list.currentItem().data(Qt.UserRole)
+
+        alias_name = (alias_name or '').strip()
+        if not alias_name:
+            QMessageBox.information(dialog, 'Добавление alias', 'Нельзя добавить пустой alias')
+            return
+
+        normalized_alias = alias_name.lower()
+        for idx in range(alias_list.count()):
+            list_item = alias_list.item(idx)
+            if list_item.text().strip().lower() == normalized_alias:
+                QMessageBox.information(dialog, 'Добавление alias', 'Такой alias уже добавлен в выбранный canonical')
+                return
 
         try:
             add_alias_to_canonical(canonical_id, alias_name)


### PR DESCRIPTION
### Motivation
- Implement Stage 3.4 (UX validations) from `docs/cluster_canonical_aliases_implementation_plan.md` to make the `aliac` form more robust.
- Prevent invalid or duplicate inputs on the client-side to reduce unnecessary backend errors and improve user feedback.

### Description
- Added non-empty validation for canonical creation and show a user message when the input is empty using `QMessageBox`.
- Added client-side duplicate check for canonical names (normalized with `strip().lower()`) before calling `create_canonical_well_log`.
- Added non-empty validation for alias creation and a duplicate check within the selected canonical before calling `add_alias_to_canonical`.
- Preserved existing refresh logic by calling `refresh_all(keep_canonical_id=...)` after successful create/delete operations so all lists stay synchronized.

### Testing
- Ran `python -m py_compile well_log.py` and the file compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10334b6668832f86c9d2a49fb0be83)