### PR TITLE
Show wells for selected curve and open well log from canonical aliases manager

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -70,9 +70,20 @@ def show_canonical_aliases_manager():
     curves_list = QtWidgets.QListWidget()
     curves_layout.addWidget(curves_list)
 
+
+    wells_box = QtWidgets.QGroupBox('Скважины по выбранной кривой')
+    wells_layout = QtWidgets.QVBoxLayout(wells_box)
+    wells_hint = QtWidgets.QLabel('Выберите кривую в списке справа')
+    wells_layout.addWidget(wells_hint)
+    wells_list = QtWidgets.QListWidget()
+    wells_layout.addWidget(wells_list)
+    btn_open_well_log = QtWidgets.QPushButton('Открыть well logging form')
+    wells_layout.addWidget(btn_open_well_log)
+
     content_layout.addWidget(canonical_box, 1)
     content_layout.addWidget(alias_box, 1)
     content_layout.addWidget(curves_box, 1)
+    content_layout.addWidget(wells_box, 1)
 
     close_button = QtWidgets.QPushButton('Закрыть')
     close_button.clicked.connect(dialog.accept)
@@ -122,6 +133,48 @@ def show_canonical_aliases_manager():
                 item.setBackground(QtGui.QColor(255, 228, 196))
             curves_list.addItem(item)
 
+
+    def get_wells_for_curve(curve_name):
+        if not curve_name:
+            return []
+        return (
+            session.query(Well.id, Well.name)
+            .join(WellLog, WellLog.well_id == Well.id)
+            .filter(WellLog.curve_name == curve_name)
+            .distinct()
+            .order_by(Well.name.asc(), Well.id.asc())
+            .all()
+        )
+
+    def refresh_wells_for_selected_curve():
+        wells_list.clear()
+        curve_item = curves_list.currentItem()
+        if curve_item is None:
+            return
+
+        curve_name = curve_item.data(Qt.UserRole)
+        wells = get_wells_for_curve(curve_name)
+        for well_id, well_name in wells:
+            item = QtWidgets.QListWidgetItem(f'{well_name} id{well_id}')
+            item.setData(Qt.UserRole, int(well_id))
+            wells_list.addItem(item)
+
+    def open_selected_well_log():
+        selected = wells_list.currentItem()
+        if selected is None:
+            QMessageBox.information(dialog, 'Скважины', 'Выберите скважину из списка')
+            return
+
+        target_well_id = str(selected.data(Qt.UserRole))
+        for row in range(ui.listWidget_well.count()):
+            if ui.listWidget_well.item(row).text().split(' id')[-1] == target_well_id:
+                ui.listWidget_well.setCurrentRow(row)
+                dialog.accept()
+                show_well_log()
+                return
+
+        QMessageBox.warning(dialog, 'Скважины', 'Скважина не найдена в текущем фильтре списка скважин')
+
     def refresh_all(keep_canonical_id=None):
         canonical_list.clear()
         stats = get_canonical_well_logs_stats()
@@ -138,6 +191,7 @@ def show_canonical_aliases_manager():
             canonical_list.setCurrentRow(min(selected_row, canonical_list.count() - 1))
         refresh_aliases()
         refresh_curves()
+        refresh_wells_for_selected_curve()
 
     def handle_error(exc):
         QMessageBox.critical(dialog, 'Ошибка', str(exc))
@@ -237,6 +291,9 @@ def show_canonical_aliases_manager():
     curves_search.textChanged.connect(refresh_curves)
     curves_unassigned_only.toggled.connect(refresh_curves)
     curves_list.itemDoubleClicked.connect(on_curve_double_click)
+    curves_list.itemSelectionChanged.connect(refresh_wells_for_selected_curve)
+    btn_open_well_log.clicked.connect(open_selected_well_log)
+    wells_list.itemDoubleClicked.connect(lambda _: open_selected_well_log())
 
     refresh_all()
 


### PR DESCRIPTION
### Motivation
- Provide a way to see which wells contain a selected curve and quickly open the well log form from the canonical aliases manager UI.

### Description
- Added a new `wells_box` UI group with `wells_list`, hint label, and a `btn_open_well_log` button to the canonical aliases manager dialog. 
- Implemented `get_wells_for_curve` which queries `session.query(Well.id, Well.name)` joined with `WellLog` and returns distinct wells for a given curve name. 
- Implemented `refresh_wells_for_selected_curve` to populate the `wells_list` when a curve is selected and wired `curves_list.itemSelectionChanged` to this refresh. 
- Implemented `open_selected_well_log` to select the target well in the main well list (`ui.listWidget_well`), close the dialog, and call `show_well_log()`, with appropriate `QMessageBox` feedback when no selection or when the well isn't found in the current well list filter. 
- Hooked `btn_open_well_log.clicked` and double-click on `wells_list` to `open_selected_well_log`, and ensured `refresh_all` calls `refresh_wells_for_selected_curve` so the wells pane stays in sync. 

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1037a44f70832f93c315a51cb34d6e)