### PR TITLE
Add cluster canonical preparation preview utility and tests

### DIFF
--- a/cluster_canonical_preparation.py
+++ b/cluster_canonical_preparation.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, TypedDict
+
+
+class CanonicalPreparationRow(TypedDict):
+    requested_name: str
+    canonical_name: str | None
+    normalized_name: str
+    status: str
+
+
+class CanonicalPreparationSummary(TypedDict):
+    total: int
+    resolved: int
+    unresolved: int
+
+
+def normalize_curve_name(curve_name: str | None) -> str:
+    """Normalize incoming curve name the same way as canonical resolver does."""
+    if curve_name is None:
+        return ""
+    return str(curve_name).strip().lower()
+
+
+def prepare_canonical_resolution_preview(
+    curve_names: Iterable[str | None],
+    resolver: Callable[[str | None], str | None],
+) -> tuple[list[CanonicalPreparationRow], CanonicalPreparationSummary]:
+    """
+    Build a dry-run preview for future cluster module canonical integration.
+
+    The function is intentionally side-effect free and can be used before
+    the main clustering integration block is implemented.
+    """
+    rows: list[CanonicalPreparationRow] = []
+    resolved_count = 0
+
+    for raw_name in curve_names:
+        normalized_name = normalize_curve_name(raw_name)
+        canonical_name = resolver(raw_name)
+        status = 'resolved' if canonical_name else 'unresolved'
+        if canonical_name:
+            resolved_count += 1
+        rows.append({
+            'requested_name': '' if raw_name is None else str(raw_name),
+            'canonical_name': canonical_name,
+            'normalized_name': normalized_name,
+            'status': status,
+        })
+
+    total_count = len(rows)
+    summary: CanonicalPreparationSummary = {
+        'total': total_count,
+        'resolved': resolved_count,
+        'unresolved': total_count - resolved_count,
+    }
+    return rows, summary

--- a/tests/test_cluster_canonical_preparation.py
+++ b/tests/test_cluster_canonical_preparation.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from cluster_canonical_preparation import (
+    normalize_curve_name,
+    prepare_canonical_resolution_preview,
+)
+
+
+def test_normalize_curve_name():
+    assert normalize_curve_name('  GR  ') == 'gr'
+    assert normalize_curve_name(None) == ''
+
+
+def test_prepare_preview_summary_and_statuses():
+    mapping = {
+        'gr': 'gamma',
+        'nphi': 'neutron',
+    }
+
+    def resolver(raw_name):
+        key = normalize_curve_name(raw_name)
+        return mapping.get(key)
+
+    rows, summary = prepare_canonical_resolution_preview(
+        [' GR ', 'NPHI', 'UNKNOWN', None],
+        resolver,
+    )
+
+    assert summary == {'total': 4, 'resolved': 2, 'unresolved': 2}
+    assert rows[0]['status'] == 'resolved'
+    assert rows[2]['status'] == 'unresolved'
+    assert rows[3]['requested_name'] == ''


### PR DESCRIPTION
### Motivation

- Provide a side-effect-free helper to preview how incoming curve names would be canonicalized before integrating canonical resolution into the clustering flow.
- Normalize incoming curve names consistently with the canonical resolver and produce a per-row status to aid manual review and debugging.

### Description

- Add `cluster_canonical_preparation.py` which defines `CanonicalPreparationRow` and `CanonicalPreparationSummary` `TypedDict`s and implements `normalize_curve_name` and `prepare_canonical_resolution_preview` utility functions.
- `normalize_curve_name` trims and lowercases inputs and treats `None` as an empty string, and `prepare_canonical_resolution_preview` accepts an iterable of raw names and a `resolver` callable to build a list of rows and an aggregate summary without side effects.
- Each preview row contains `requested_name`, `canonical_name`, `normalized_name`, and `status` (`resolved`/`unresolved`), and the summary contains `total`, `resolved`, and `unresolved` counts.

### Testing

- Add `tests/test_cluster_canonical_preparation.py` which asserts normalization behavior and that `prepare_canonical_resolution_preview` produces correct rows and summary for resolved/unresolved examples.
- Ran the test suite with `pytest tests/test_cluster_canonical_preparation.py` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103f00b718832fb6e0d4c61bd32000)