### PR TITLE
Этап 1.2: удаление набора каротажа с каскадной очисткой

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -152,6 +152,50 @@ def create_cluster_well_dataset() -> None:
     set_info(f'Добавлен набор каротажа "{dataset_name}"', 'green')
 
 
+def remove_cluster_well_dataset() -> None:
+    """
+    Этап 1.2:
+    - подтверждает удаление набора;
+    - удаляет набор и все зависимые сущности (каскад ORM);
+    - обновляет combobox и выбирает ближайший доступный набор.
+    """
+    combo = getattr(ui, 'comboBox_cluster_well_set', None)
+    if combo is None:
+        return
+
+    current_dataset_id = combo.currentData()
+    if current_dataset_id is None:
+        QMessageBox.information(MainWindow, 'Удаление набора', 'Нет выбранного набора для удаления.')
+        return
+
+    dataset = session.query(WellLogClusterDataset).filter_by(id=current_dataset_id).first()
+    if dataset is None:
+        update_cluster_well_dataset_combobox()
+        QMessageBox.warning(MainWindow, 'Удаление набора', 'Выбранный набор не найден. Список будет обновлен.')
+        return
+
+    answer = QMessageBox.question(
+        MainWindow,
+        'Подтверждение удаления',
+        f'Удалить набор "{dataset.name}"?\n\n'
+        'Будут удалены связанные скважины, интервалы, каротажи и собранные данные.',
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.No
+    )
+    if answer != QMessageBox.Yes:
+        return
+
+    current_index = combo.currentIndex()
+    session.delete(dataset)
+    session.commit()
+
+    next_index = current_index if current_index >= 0 else 0
+    update_cluster_well_dataset_combobox()
+    if combo.count() > 0:
+        combo.setCurrentIndex(min(next_index, combo.count() - 1))
+    set_info(f'Набор каротажа "{dataset.name}" удален', 'green')
+
+
 def get_available_well_log_curve_names_with_frequency() -> list[dict[str, int | str]]:
     """
     Возвращает все уникальные названия каротажных кривых из БД с частотностью.

--- a/geovel.py
+++ b/geovel.py
@@ -566,6 +566,7 @@ ui.pushButton_clust_auto_batch.clicked.connect(calculate_cluster_auto_batch)
 ui.pushButton_cluster_clear_result_auto_tune.clicked.connect(clear_cluster_auto_tune_results_with_confirm)
 ui.tableWidget_cluster_auto_result.cellDoubleClicked.connect(apply_selected_auto_result_from_table)
 ui.pushButton_cluster_create_well_set.clicked.connect(create_cluster_well_dataset)
+ui.pushButton_cluster_remove_well_set.clicked.connect(remove_cluster_well_dataset)
 
 
 time = datetime.datetime.now()


### PR DESCRIPTION
### Motivation
- Реализовать возможность безопасного удаления набора каротажа из UI с очисткой всех зависимых сущностей и синхронизацией combobox (этап 1.2 плана). 

### Description
- Добавлена функция `remove_cluster_well_dataset()` в `cluster.py`, которая проверяет выбранный набор, показывает диалог подтверждения и удаляет набор через ORM (`session.delete(dataset)`), задействуя каскадные связи для зависимых сущностей. 
- После удаления выполняется пересборка `comboBox_cluster_well_set` с выбором ближайшего доступного элемента по индексу или очисткой списка. 
- Добавлены информативные сообщения пользователю для случаев: нет выбранного набора, набор не найден и успешное удаление. 
- Подключен обработчик кнопки `pushButton_cluster_remove_well_set` в `geovel.py` для вызова нового метода из UI.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile cluster.py geovel.py` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104cfdbc20832fa31148eb413c0c02)