### PR TITLE
Fix Well attribute usage in cluster dataset list loading

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -142,12 +142,12 @@ def load_cluster_well_dataset_state_to_form(dataset_id: int | None = None) -> No
         session.query(WellForCluster)
         .filter(WellForCluster.dataset_id == dataset_id)
         .join(Well, Well.id == WellForCluster.well_id)
-        .order_by(Well.title, Well.id)
+        .order_by(Well.name, Well.id)
         .all()
     )
     for row in wells:
-        title = row.well.title if row.well and row.well.title else f'well_id={row.well_id}'
-        text = f'{title} [{row.top_md:g} - {row.bottom_md:g}]'
+        well_name = row.well.name if row.well and row.well.name else f'well_id={row.well_id}'
+        text = f'{well_name} [{row.top_md:g} - {row.bottom_md:g}]'
         item = QListWidgetItem(text)
         item.setData(Qt.UserRole, row.well_id)
         list_well.addItem(item)


### PR DESCRIPTION
### Motivation
- Replace usage of non-existent `Well.title` with `Well.name` to prevent runtime attribute errors when loading cluster well datasets.

### Description
- In `load_cluster_well_dataset_state_to_form` (in `cluster.py`) replaced `.order_by(Well.title, Well.id)` with `.order_by(Well.name, Well.id)` and changed the displayed label construction to use `row.well.name` with the existing `well_id=<id>` fallback.

### Testing
- Ran `python -m py_compile cluster.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1050f65218832f8e2f37b6cfec4961)