### PR TITLE
Этап 2.4: выбор интервала по двойному клику и сохранение в cluster dataset

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -147,7 +147,21 @@ def load_cluster_well_dataset_state_to_form(dataset_id: int | None = None) -> No
     )
     for row in wells:
         well_name = row.well.name if row.well and row.well.name else f'well_id={row.well_id}'
-        text = f'{well_name} [{row.top_md:g} - {row.bottom_md:g}]'
+        marker_text = ''
+        full_interval = (
+            session.query(func.min(WellLog.begin), func.max(WellLog.end))
+            .filter(WellLog.well_id == row.well_id)
+            .first()
+        )
+        if full_interval and full_interval[0] is not None and full_interval[1] is not None:
+            full_top = float(full_interval[0])
+            full_bottom = float(full_interval[1])
+            if full_bottom < full_top:
+                full_top, full_bottom = full_bottom, full_top
+            if abs(float(row.top_md) - full_top) > 1e-9 or abs(float(row.bottom_md) - full_bottom) > 1e-9:
+                marker_text = ' ✓interval'
+
+        text = f'{well_name} [{row.top_md:g} - {row.bottom_md:g}]{marker_text}'
         item = QListWidgetItem(text)
         item.setData(Qt.UserRole, row.well_id)
         list_well.addItem(item)
@@ -177,6 +191,28 @@ def load_cluster_well_dataset_state_to_form(dataset_id: int | None = None) -> No
         item = QListWidgetItem(f'{feature_name} [calc]')
         item.setData(Qt.UserRole, ('calculator', row.calculator_id))
         list_log.addItem(item)
+
+
+def open_cluster_well_interval_form(item: QListWidgetItem | None = None) -> None:
+    """
+    Этап 2.4:
+    Двойной клик по скважине набора открывает form_well_log для этой скважины.
+    """
+    if item is None:
+        return
+
+    well_id = item.data(Qt.UserRole)
+    try:
+        well_id = int(well_id)
+    except (TypeError, ValueError):
+        QMessageBox.warning(MainWindow, 'Интервал скважины', 'Не удалось определить id выбранной скважины.')
+        return
+
+    try:
+        ui.comboBox_well.setCurrentText(str(well_id))
+        show_well_log()
+    except Exception as exc:
+        QMessageBox.warning(MainWindow, 'Интервал скважины', f'Не удалось открыть form_well_log: {exc}')
 
 
 def create_cluster_well_dataset() -> None:

--- a/geovel.py
+++ b/geovel.py
@@ -572,6 +572,7 @@ ui.pushButton_cluster_add_wells_from_radius.clicked.connect(add_wells_to_cluster
 ui.pushButton_cluster_remove_well.clicked.connect(remove_selected_wells_from_cluster_dataset)
 ui.pushButton_cluster_clear_list_well.clicked.connect(clear_all_wells_from_cluster_dataset)
 ui.comboBox_cluster_well_set.currentIndexChanged.connect(lambda _: load_cluster_well_dataset_state_to_form(ui.comboBox_cluster_well_set.currentData()))
+ui.listWidget_cluster_list_well.itemDoubleClicked.connect(open_cluster_well_interval_form)
 
 
 time = datetime.datetime.now()

--- a/well_log.py
+++ b/well_log.py
@@ -933,6 +933,43 @@ def show_well_log():
             session.commit()
             show_data_well()
 
+        def save_interval_to_cluster_dataset():
+            cluster_combo = getattr(ui, 'comboBox_cluster_well_set', None)
+            if cluster_combo is None:
+                QMessageBox.warning(WellLogForm, 'CLUSTER INTERVAL', 'Не найден combobox набора cluster_well.')
+                return
+
+            dataset_id = cluster_combo.currentData()
+            if dataset_id is None:
+                QMessageBox.warning(WellLogForm, 'CLUSTER INTERVAL', 'Сначала выберите набор каротажа во вкладке Cluster.')
+                return
+
+            well_id = get_well_id()
+            row = (
+                session.query(WellForCluster)
+                .filter(WellForCluster.dataset_id == int(dataset_id), WellForCluster.well_id == int(well_id))
+                .first()
+            )
+            if row is None:
+                QMessageBox.warning(
+                    WellLogForm,
+                    'CLUSTER INTERVAL',
+                    'Текущая скважина не добавлена в выбранный набор. Сначала выполните ADD WELL/ADD WELLS.'
+                )
+                return
+
+            depth = float(ui_wl.doubleSpinBox_depth.value())
+            interval = abs(float(ui_wl.doubleSpinBox_interval.value()))
+            top_md = depth - interval
+            bottom_md = depth + interval
+            if bottom_md < top_md:
+                top_md, bottom_md = bottom_md, top_md
+
+            row.top_md = top_md
+            row.bottom_md = bottom_md
+            session.commit()
+            set_info(f'Интервал [{top_md:g} - {bottom_md:g}] сохранен в cluster dataset id={int(dataset_id)}.', 'green')
+
 
         ui_wl.pushButton_add_well_log.clicked.connect(load_well_log)
         ui_wl.pushButton_add_xls.clicked.connect(load_well_log_xls)
@@ -953,6 +990,7 @@ def show_well_log():
         ui_wl.pushButton_clean.clicked.connect(clean_double_well_logging)
         ui_wl.pushButton_uf_to_bound.clicked.connect(uf_to_well_boundary)
         ui_wl.pushButton_mosh_pesch_to_data.clicked.connect(m_ss_to_well_data)
+        ui_wl.pushButton_add_interval_to_cluster.clicked.connect(save_interval_to_cluster_dataset)
 
         update_list_well_log()
 


### PR DESCRIPTION
### Motivation
- Реализовать этап 2.4 плана разработки вкладки скважинного каротажа: открыть форму каротажа по двойному клику на скважине из набора и позволить сохранять выбранный интервал в набор для кластеризации.

### Description
- Добавлен обработчик двойного клика `open_cluster_well_interval_form` для `listWidget_cluster_list_well`, который устанавливает текущую скважину в `ui.comboBox_well` и вызывает `show_well_log` (файл `cluster.py`).
- В `form_well_log` реализована функция `save_interval_to_cluster_dataset`, привязанная к `pushButton_add_interval_to_cluster`, которая проверяет выбранный `dataset`, гарантирует, что скважина добавлена в набор, и записывает интервал в `WellForCluster.top_md`/`bottom_md` как `[depth - interval, depth + interval]` (файл `well_log.py`).
- В `load_cluster_well_dataset_state_to_form` добавлена логика вычисления полного диапазона каротажа по скважине и отображения маркера `✓interval`, если сохранённый интервал набора отличается от полного диапазона (файл `cluster.py`).
- Подключена обработка двойного клика в UI и связка обработчиков в `geovel.py` (`listWidget_cluster_list_well.itemDoubleClicked.connect(open_cluster_well_interval_form)`).

### Testing
- Выполнена компиляция файлов с помощью `python -m py_compile cluster.py well_log.py geovel.py`, которая прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105bdef430832fabccfc56d157af52)