### PR TITLE
Restrict profile search to current GeoradarObject when adding wells by radius

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -396,12 +396,21 @@ def add_wells_to_cluster_dataset_from_radius() -> None:
         QMessageBox.warning(MainWindow, 'ADD WELLS', 'Не удалось получить исследование выбранного ObjectSet.')
         return
 
+    # Профили берем по текущему GeoradarObject (а не по ObjectSet):
+    # это исключает попадание скважин из профилей других объектов.
+    current_object_id = get_object_id()
+    if not current_object_id:
+        QMessageBox.warning(MainWindow, 'ADD WELLS', 'Не выбран текущий GeoradarObject.')
+        return
+
     profiles = (
         session.query(Profile)
-        .filter(Profile.research_id == int(clust_object.research_id))
+        .join(Research, Profile.research_id == Research.id)
+        .filter(Research.object_id == int(current_object_id))
         .order_by(Profile.id)
         .all()
     )
+
     if not profiles:
         QMessageBox.information(MainWindow, 'ADD WELLS', 'У текущего объекта нет профилей для поиска скважин.')
         return


### PR DESCRIPTION
### Motivation
- Prevent wells from profiles belonging to other objects being added to a cluster dataset by using the current GeoradarObject as the source of profiles instead of the ObjectSet's research.

### Description
- Retrieve `current_object_id` via `get_object_id()` and show a warning if it's not selected, and change the profiles query to `join(Research)` and filter on `Research.object_id == int(current_object_id)` instead of filtering by `Profile.research_id == clust_object.research_id` so only profiles for the current GeoradarObject are considered.

### Testing
- Ran the automated test suite with `pytest` including cluster-related tests and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144d04c9d4832f9d1feb2b47214c2a)