### PR TITLE
Fix form_well_log opening from cluster well interval double-click

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -209,7 +209,23 @@ def open_cluster_well_interval_form(item: QListWidgetItem | None = None) -> None
         return
 
     try:
-        ui.comboBox_well.setCurrentText(str(well_id))
+        selected_item = None
+        for idx in range(ui.listWidget_well.count()):
+            candidate = ui.listWidget_well.item(idx)
+            if candidate is None:
+                continue
+            candidate_well_id = str(candidate.text()).split(' id')[-1].strip()
+            if candidate_well_id == str(well_id):
+                selected_item = candidate
+                break
+
+        if selected_item is None:
+            raise RuntimeError(
+                f'Скважина id={well_id} не найдена в основном списке listWidget_well. '
+                f'Выберите её на вкладке скважин и повторите.'
+            )
+
+        ui.listWidget_well.setCurrentItem(selected_item)
         show_well_log()
     except Exception as exc:
         QMessageBox.warning(MainWindow, 'Интервал скважины', f'Не удалось открыть form_well_log: {exc}')


### PR DESCRIPTION
### Motivation
- Исправить сбой при двойном клике по скважине набора, из-за которого появлялась ошибка `"'Ui_MainWindow' object has no attribute 'comboBox_well'"` и форма `form_well_log` не открывалась.
- Обеспечить открытие формы через основной путь выбора скважины в приложении, а не через несуществующий виджет.

### Description
- Заменён прямой вызов `ui.comboBox_well.setCurrentText(...)` в `open_cluster_well_interval_form` на поиск соответствующего элемента в `ui.listWidget_well` и установку его как текущего через `ui.listWidget_well.setCurrentItem(...)`.
- Добавлена логика извлечения id из текста элемента списка (по шаблону `" id"`) и сравнения с `well_id` для однозначного соответствия.
- При отсутствии скважины в основном списке теперь выбрасывается понятный `RuntimeError` с инструкцией выбрать скважину на вкладке скважин.

### Testing
- Проверка синтаксиса: `python -m py_compile cluster.py` — успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152d805f04832f8a26eeca36ca1880)