### PR TITLE
Select listWidget_well item by id and open well log form

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -209,8 +209,25 @@ def open_cluster_well_interval_form(item: QListWidgetItem | None = None) -> None
         return
 
     try:
-        ui.comboBox_well.setCurrentText(str(well_id))
-        show_well_log()
+        selected_item = None
+        for idx in range(ui.listWidget_well.count()):
+            candidate = ui.listWidget_well.item(idx)
+            if candidate is None:
+                continue
+            candidate_well_id = str(candidate.text()).split(' id')[-1].strip()
+            if candidate_well_id == str(well_id):
+                selected_item = candidate
+                break
+
+        if selected_item is None:
+            raise RuntimeError(
+                f'Скважина id={well_id} не найдена в основном списке listWidget_well. '
+                f'Выберите её на вкладке скважин и повторите.'
+            )
+
+        ui.listWidget_well.setCurrentItem(selected_item)
+        from well_log import show_well_log as open_well_log_form
+        open_well_log_form()
     except Exception as exc:
         QMessageBox.warning(MainWindow, 'Интервал скважины', f'Не удалось открыть form_well_log: {exc}')
 


### PR DESCRIPTION
### Motivation
- Fix unreliable method of opening a well log by id that previously tried to set `ui.comboBox_well` text and call `show_well_log()`, which could fail if the combo text did not match the list format. 
- Provide clearer error handling when the target well is not present in the main `listWidget_well` so the user gets a helpful message.

### Description
- Replace setting `ui.comboBox_well.setCurrentText(...)` with code that searches `ui.listWidget_well` items for the matching well id, selects the corresponding `QListWidgetItem`, and sets it via `ui.listWidget_well.setCurrentItem(...)`.
- Import and call `show_well_log` from `well_log` as `open_well_log_form()` and raise a `RuntimeError` with a descriptive message if the well id is not found; all exceptions are reported via `QMessageBox.warning`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152d805f04832f8a26eeca36ca1880)