### PR TITLE
Fix opening well interval form from cluster list and refresh cluster dataset after saving interval

### DIFF
--- a/cluster.py
+++ b/cluster.py
@@ -209,8 +209,25 @@ def open_cluster_well_interval_form(item: QListWidgetItem | None = None) -> None
         return
 
     try:
-        ui.comboBox_well.setCurrentText(str(well_id))
-        show_well_log()
+        selected_item = None
+        for idx in range(ui.listWidget_well.count()):
+            candidate = ui.listWidget_well.item(idx)
+            if candidate is None:
+                continue
+            candidate_well_id = str(candidate.text()).split(' id')[-1].strip()
+            if candidate_well_id == str(well_id):
+                selected_item = candidate
+                break
+
+        if selected_item is None:
+            raise RuntimeError(
+                f'Скважина id={well_id} не найдена в основном списке listWidget_well. '
+                f'Выберите её на вкладке скважин и повторите.'
+            )
+
+        ui.listWidget_well.setCurrentItem(selected_item)
+        from well_log import show_well_log as open_well_log_form
+        open_well_log_form()
     except Exception as exc:
         QMessageBox.warning(MainWindow, 'Интервал скважины', f'Не удалось открыть form_well_log: {exc}')
 

--- a/well_log.py
+++ b/well_log.py
@@ -968,6 +968,14 @@ def show_well_log():
             row.top_md = top_md
             row.bottom_md = bottom_md
             session.commit()
+
+            update_list_well(select_well=True, selected_well_id=get_well_id())
+            try:
+                from cluster import load_cluster_well_dataset_state_to_form
+                load_cluster_well_dataset_state_to_form(int(dataset_id))
+            except Exception:
+                pass
+
             set_info(f'Интервал [{top_md:g} - {bottom_md:g}] сохранен в cluster dataset id={int(dataset_id)}.', 'green')
 
 


### PR DESCRIPTION
### Motivation
- Improve reliability when opening a well interval form from the cluster list by selecting the matching `listWidget_well` entry instead of manipulating the combobox text.
- Ensure the cluster dataset UI reflects interval changes immediately after saving an interval from the well log form.

### Description
- Replace the previous `ui.comboBox_well.setCurrentText(...)` approach in `open_cluster_well_interval_form` with a search through `ui.listWidget_well` to find and select the item whose text contains the target well id, and then call `show_well_log` via an explicit import. 
- Add a helpful `RuntimeError` and user-facing `QMessageBox` when the well id is not found in `listWidget_well`.
- After saving an interval in `show_well_log`, call `update_list_well(select_well=True, selected_well_id=get_well_id())` and attempt to call `load_cluster_well_dataset_state_to_form(int(dataset_id))` to refresh the cluster dataset state, while ignoring any exceptions during that refresh.

### Testing
- Ran the project's automated test suite (`pytest`) and the tests completed successfully. 
- Executed automated UI-related smoke checks that exercise opening a well interval from the cluster list and saving an interval, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152d805f04832f8a26eeca36ca1880)