### PR TITLE
Fix cluster interval bounds in Well Log tab

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -961,10 +961,8 @@ def show_well_log():
 
             depth = float(ui_wl.doubleSpinBox_depth.value())
             interval = abs(float(ui_wl.doubleSpinBox_interval.value()))
-            top_md = depth - interval
+            top_md = depth
             bottom_md = depth + interval
-            if bottom_md < top_md:
-                top_md, bottom_md = bottom_md, top_md
 
             row.top_md = top_md
             row.bottom_md = bottom_md


### PR DESCRIPTION
### Motivation
- Исправить некорректное сохранение интервала во вкладке `Well Log`, которое раньше задавало интервал симметрично вокруг значения глубины вместо того, чтобы начинаться с выбранной глубины и простираться вниз на длину интервала.

### Description
- В функции `save_interval_to_cluster_dataset` в `well_log.py` заменено присвоение границ интервала на `top_md = depth` и `bottom_md = depth + interval`, удалена логика симметричного вычитания и последующего обмена границ.

### Testing
- Автоматических тестов не запускалось; изменение было проверено просмотром `git diff` и закоммичено успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182cd405b8832fa87f98550018fa1a)