### PR TITLE
Import AUTO clustering constants from cluster.models to avoid NameError

### DIFF
--- a/cluster/auto_candidates.py
+++ b/cluster/auto_candidates.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
 from .common import *
+from .models import (
+    AUTO_CANDIDATE_HARD_TIMEOUT_SEC,
+    AUTO_PCA_PILOT_ENABLED,
+    AUTO_PCA_PILOT_MAX_ROWS,
+    AUTO_SILHOUETTE_MAX_SAMPLES,
+    AUTO_TUNING_MAX_FEATURES,
+    AUTO_TUNING_MAX_ROWS,
+    CandidateConfig,
+    CandidateMetrics,
+    CandidateResult,
+    CandidateStats,
+    GMM_COVARIANCE_TYPES,
+)
 
 def make_candidate_config(
         *,

--- a/cluster/core.py
+++ b/cluster/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from .common import *
+from .models import AUTO_SILHOUETTE_MAX_SAMPLES
 
 def cluster_data(
         data,

--- a/cluster/well_dataset.py
+++ b/cluster/well_dataset.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
 from .common import *
+from .models import (
+    AUTO_SILHOUETTE_ADAPTIVE_ALPHA,
+    AUTO_SILHOUETTE_COARSE_MAX_SAMPLES,
+    AUTO_SILHOUETTE_MAX_SAMPLES,
+    AUTO_SILHOUETTE_MIN_SAMPLES,
+    AutoTuningClusterSizeLimits,
+)
 
 def _set_cluster_well_collect_button_state(is_actual: bool) -> None:
     button = getattr(ui, 'pushButton_clust_collect_well_log', None)


### PR DESCRIPTION
### Motivation
- Several cluster modules referenced AUTO_* constants and TypedDicts that were previously injected via the package namespace and caused `NameError` when evaluated as default argument values during module import. 
- Making those constants explicit imports prevents runtime import-time errors for functions that use them as defaults (e.g. silhouette sample size). 

### Description
- Added explicit imports from `cluster.models` in `cluster/auto_candidates.py` for AUTO constants, `TypedDict` aliases and `GMM_COVARIANCE_TYPES` so default args and candidate factories resolve during import. 
- Added `AUTO_SILHOUETTE_MAX_SAMPLES` import in `cluster/core.py` to ensure the default `evaluate_clustering` parameter is defined at import time. 
- Added `AUTO_SILHOUETTE_ADAPTIVE_ALPHA`, `AUTO_SILHOUETTE_COARSE_MAX_SAMPLES`, `AUTO_SILHOUETTE_MAX_SAMPLES`, `AUTO_SILHOUETTE_MIN_SAMPLES` and `AutoTuningClusterSizeLimits` imports in `cluster/well_dataset.py` so `_compute_auto_silhouette_sample_size` uses defined constants. 

### Testing
- Ran `python -m py_compile cluster/auto_candidates.py cluster/core.py cluster/well_dataset.py` and the files compiled without errors. 
- Executed a stubbed-import smoke test that loads `cluster.auto_candidates`, `cluster.core`, and `cluster.well_dataset` with heavy optional dependencies replaced by minimal stubs and verified `AUTO_SILHOUETTE_MAX_SAMPLES` and silhouette sample-size calculation resolved correctly. 
- Ran `git diff --check` to validate no trailing whitespace or diff errors; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196c5e4730832fae39facdd474fe54)