### PR TITLE
Persist well-log AUTO clustering results and restore for Well Log context

### DIFF
--- a/alembic/versions/c2d3e4f5a6b7_add_well_log_auto_tuning_cache.py
+++ b/alembic/versions/c2d3e4f5a6b7_add_well_log_auto_tuning_cache.py
@@ -1,0 +1,49 @@
+"""add well log auto tuning cache
+
+Revision ID: c2d3e4f5a6b7
+Revises: 9b21c6e4a1f2
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c2d3e4f5a6b7'
+down_revision: Union[str, None] = '9b21c6e4a1f2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'well_log_cluster_auto_tuning_cache',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('dataset_id', sa.Integer(), nullable=False),
+        sa.Column('cache_key', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('top_results', sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(['dataset_id'], ['well_log_cluster_dataset.id']),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(
+        'ix_well_log_cluster_auto_tuning_cache_dataset_id',
+        'well_log_cluster_auto_tuning_cache',
+        ['dataset_id'],
+        unique=False
+    )
+    op.create_index(
+        'ix_well_log_cluster_auto_tuning_cache_cache_key',
+        'well_log_cluster_auto_tuning_cache',
+        ['cache_key'],
+        unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_well_log_cluster_auto_tuning_cache_cache_key', table_name='well_log_cluster_auto_tuning_cache')
+    op.drop_index('ix_well_log_cluster_auto_tuning_cache_dataset_id', table_name='well_log_cluster_auto_tuning_cache')
+    op.drop_table('well_log_cluster_auto_tuning_cache')

--- a/cluster/auto_cache.py
+++ b/cluster/auto_cache.py
@@ -21,7 +21,8 @@ def build_cluster_auto_tuning_cache_key(
         top_k: int,
         constraints: Optional[Dict[str, Any]],
         weights: Dict[str, float],
-        clean_kwargs: Dict[str, Any]
+        clean_kwargs: Dict[str, Any],
+        source_type: str = "gpr"
 ) -> str:
     """
     Формирует hash-ключ для сохранения/поиска результата AUTO-подбора.
@@ -39,8 +40,28 @@ def build_cluster_auto_tuning_cache_key(
         "constraints": _normalize_cache_payload(constraints or {}),
         "clean_kwargs": _normalize_cache_payload(clean_kwargs or {})
     }
+    source_type_norm = str(source_type or "gpr").strip().lower()
+    if source_type_norm != "gpr":
+        payload["source_type"] = source_type_norm
     payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+
+
+def _format_well_log_auto_diagnostics_for_cache(diagnostics: dict[str, Any]) -> str:
+    if not diagnostics:
+        return "—"
+    valid_wells = diagnostics.get("valid_well_count", "—")
+    valid_rows = diagnostics.get("valid_row_count", "—")
+    excluded = diagnostics.get("excluded_well_count", 0)
+    invalid = diagnostics.get("invalid_row_count", 0)
+    return f"wells={valid_wells}, rows={valid_rows}, excl={excluded}, invalid={invalid}"
+
+
+def _auto_tuning_cache_model(source_type: str = "gpr"):
+    source_type_norm = str(source_type or "gpr").strip().lower()
+    if source_type_norm == "well_log":
+        return WellLogClusterAutoTuningCache
+    return ClusterAutoTuningCache
 
 
 def _ensure_cluster_auto_tuning_run_state_table() -> None:
@@ -102,27 +123,30 @@ def _clear_auto_tuning_run_state(*, run_key: str, object_set_id: int) -> None:
     session.commit()
 
 
-def _ensure_cluster_auto_tuning_cache_table() -> None:
+def _ensure_cluster_auto_tuning_cache_table(source_type: str = "gpr") -> None:
     """
     Создает таблицу cache автоподбора (если ее еще нет).
     """
-    ClusterAutoTuningCache.__table__.create(bind=engine, checkfirst=True)
+    _auto_tuning_cache_model(source_type).__table__.create(bind=engine, checkfirst=True)
 
 
 def load_cluster_auto_tuning_cache(
         *,
         cache_key: str,
         clust_object_id: int,
-        top_k: int = 5
+        top_k: int = 5,
+        source_type: str = "gpr"
 ) -> list[CandidateResult]:
     """
     Загружает top-K настроек AUTO-подбора из persistent-cache.
     """
     try:
-        _ensure_cluster_auto_tuning_cache_table()
+        _ensure_cluster_auto_tuning_cache_table(source_type)
+        cache_model = _auto_tuning_cache_model(source_type)
+        id_filter = {"dataset_id" if cache_model is WellLogClusterAutoTuningCache else "object_set_id": int(clust_object_id)}
         row = (
-            session.query(ClusterAutoTuningCache)
-            .filter_by(cache_key=str(cache_key), object_set_id=int(clust_object_id))
+            session.query(cache_model)
+            .filter_by(cache_key=str(cache_key), **id_filter)
             .first()
         )
         if row is None or not row.top_results:
@@ -141,13 +165,20 @@ def save_cluster_auto_tuning_cache(
         cache_key: str,
         clust_object_id: int,
         top_results: list[CandidateResult],
-        top_k: int = 5
+        top_k: int = 5,
+        source_type: str = "gpr",
+        dataset_title: str = "",
+        data_hash: str = "",
+        auto_mode: str = "",
+        diagnostics: Optional[dict[str, Any]] = None
 ) -> None:
     """
     Сохраняет top-K настроек AUTO-подбора (только конфигурации кандидатов).
     """
     try:
-        _ensure_cluster_auto_tuning_cache_table()
+        _ensure_cluster_auto_tuning_cache_table(source_type)
+        cache_model = _auto_tuning_cache_model(source_type)
+        source_type_norm = str(source_type or "gpr").strip().lower() or "gpr"
         compact_top_results: list[dict] = []
         for idx, result in enumerate((top_results or [])[:max(1, int(top_k))], start=1):
             result_row = result or {}
@@ -174,8 +205,7 @@ def save_cluster_auto_tuning_cache(
                 except Exception:
                     return None
 
-            compact_top_results.append(
-                {
+            compact_row = {
                     "candidate_id": str(result_row.get("candidate_id") or f"T{idx:02d}"),
                     "candidate_config": cfg,
                     "metrics": {
@@ -193,17 +223,29 @@ def save_cluster_auto_tuning_cache(
                     "status": str(result_row.get("status") or "ok"),
                     "error_text": str(result_row.get("error_text") or "")
                 }
-            )
+            if source_type_norm != "gpr":
+                compact_row.update({
+                    "source_type": source_type_norm,
+                    "dataset_id": int(clust_object_id),
+                    "dataset_title": str(dataset_title or ""),
+                    "data_hash": str(data_hash or ""),
+                    "auto_mode": str(auto_mode or "").upper(),
+                    "well_log_diagnostics": dict(diagnostics or {}),
+                    "well_log_diagnostics_text": _format_well_log_auto_diagnostics_for_cache(dict(diagnostics or {})),
+                })
+            compact_top_results.append(compact_row)
         if not compact_top_results:
             return
+        id_field = "dataset_id" if cache_model is WellLogClusterAutoTuningCache else "object_set_id"
+        id_filter = {id_field: int(clust_object_id)}
         existing_row = (
-            session.query(ClusterAutoTuningCache)
-            .filter_by(cache_key=str(cache_key), object_set_id=int(clust_object_id))
+            session.query(cache_model)
+            .filter_by(cache_key=str(cache_key), **id_filter)
             .first()
         )
         if existing_row is None:
-            existing_row = ClusterAutoTuningCache(
-                object_set_id=int(clust_object_id),
+            existing_row = cache_model(
+                **id_filter,
                 cache_key=str(cache_key)
             )
             session.add(existing_row)

--- a/cluster/auto_runner.py
+++ b/cluster/auto_runner.py
@@ -671,8 +671,71 @@ def remember_auto_results_for_context(run_context: ClusterRunContext, results: l
     cluster_auto_results_by_context[_auto_context_cache_key(run_context)] = list(results or [])
 
 
+def _cache_row_matches_source_type(cache_row: Any, source_type: str) -> bool:
+    try:
+        payload = json.loads(cache_row.top_results or "[]")
+    except Exception:
+        return False
+    if not isinstance(payload, list) or not payload:
+        return False
+    row_source_type = str((payload[0] or {}).get("source_type") or "gpr").strip().lower()
+    return row_source_type == str(source_type or "gpr").strip().lower()
+
+
+def load_saved_auto_results_for_context(run_context: ClusterRunContext) -> bool:
+    """Загружает последнюю сохраненную AUTO-таблицу для текущего GPR/Well Log контекста."""
+    source_type = str(run_context.get("source_type") or "gpr").strip().lower()
+    dataset_id = int(run_context.get("dataset_id", 0) or 0)
+    if dataset_id <= 0:
+        render_auto_results_table([])
+        return False
+    try:
+        _ensure_cluster_auto_tuning_cache_table(source_type)
+        cache_model = _auto_tuning_cache_model(source_type)
+        id_filter = {"dataset_id" if cache_model is WellLogClusterAutoTuningCache else "object_set_id": dataset_id}
+        cache_rows = (
+            session.query(cache_model)
+            .filter_by(**id_filter)
+            .order_by(cache_model.created_at.desc())
+            .all()
+        )
+    except Exception as exc:
+        render_auto_results_table([])
+        set_info(f"AUTO: ошибка чтения сохраненного результата: {exc}", "brown")
+        return False
+
+    for cache_row in cache_rows:
+        if not _cache_row_matches_source_type(cache_row, source_type):
+            continue
+        try:
+            cached_results = json.loads(cache_row.top_results or "[]")
+        except Exception as exc:
+            render_auto_results_table([])
+            set_info(f"AUTO: ошибка распаковки сохраненного результата: {exc}", "brown")
+            return False
+        if not isinstance(cached_results, list):
+            continue
+
+        if source_type == "well_log":
+            cached_results = enrich_auto_results_for_context(
+                cached_results,
+                run_context,
+                auto_mode=str((cached_results[0] or {}).get("auto_mode") or "")
+            )
+        render_auto_results_table(cached_results)
+        remember_auto_results_for_context(run_context, cached_results)
+        set_info(
+            f"AUTO: загружены сохраненные top-{len(cached_results)} настройки для выбранного набора.",
+            "green"
+        )
+        return True
+
+    render_auto_results_table([])
+    return False
+
+
 def refresh_cluster_auto_results_for_active_context() -> None:
-    """Перерисовывает общую AUTO-таблицу для текущей вкладки/dataset, если есть runtime-кэш."""
+    """Перерисовывает общую AUTO-таблицу для текущей вкладки/dataset из runtime/persistent cache."""
     run_context = build_cluster_run_context(show_errors=False)
     if run_context is None:
         render_auto_results_table([])
@@ -681,10 +744,7 @@ def refresh_cluster_auto_results_for_active_context() -> None:
     if cached_results is not None:
         render_auto_results_table(cached_results)
         return
-    if run_context.get("source_type") == "gpr":
-        load_saved_auto_results_for_selected_object()
-        return
-    render_auto_results_table([])
+    load_saved_auto_results_for_context(run_context)
 
 
 def render_auto_results_table(results: list[CandidateResult]) -> None:
@@ -795,7 +855,7 @@ def clear_cluster_auto_tune_results_with_confirm() -> None:
     reply = QMessageBox.warning(
         MainWindow,
         "Очистка результатов AUTO",
-        "Вы действительно хотите очистить результаты автоподбора?\nЭто действие удалит строки из таблицы и кэш текущей сессии.",
+        "Вы действительно хотите очистить результаты автоподбора?\nЭто действие удалит строки из таблицы, runtime-cache и сохраненный кэш текущего набора.",
         QMessageBox.Yes | QMessageBox.No,
         QMessageBox.No
     )
@@ -811,19 +871,27 @@ def clear_cluster_auto_tune_results_with_confirm() -> None:
     table.setRowCount(0)
     table.setColumnCount(0)
 
-    clust_object_id = get_curr_clust_object_id()
-    if clust_object_id:
-        try:
-            (
-                session.query(ClusterAutoTuningCache)
-                .filter_by(object_set_id=int(clust_object_id))
-                .delete(synchronize_session=False)
-            )
-            session.commit()
-        except Exception as exc:
-            session.rollback()
-            set_info(f"AUTO: таблица очищена, но не удалось удалить сохраненный кэш: {exc}", "brown")
-            return
+    if active_context is not None:
+        dataset_id = int(active_context.get("dataset_id", 0) or 0)
+        source_type = str(active_context.get("source_type") or "gpr").strip().lower()
+        if dataset_id > 0:
+            try:
+                _ensure_cluster_auto_tuning_cache_table(source_type)
+                cache_model = _auto_tuning_cache_model(source_type)
+                id_filter = {"dataset_id" if cache_model is WellLogClusterAutoTuningCache else "object_set_id": dataset_id}
+                cache_rows = (
+                    session.query(cache_model)
+                    .filter_by(**id_filter)
+                    .all()
+                )
+                for cache_row in cache_rows:
+                    if _cache_row_matches_source_type(cache_row, source_type):
+                        session.delete(cache_row)
+                session.commit()
+            except Exception as exc:
+                session.rollback()
+                set_info(f"AUTO: таблица очищена, но не удалось удалить сохраненный кэш: {exc}", "brown")
+                return
 
     set_info("AUTO: результаты автоподбора очищены.", "green")
 
@@ -958,11 +1026,16 @@ def calculate_cluster_auto():
 
     source_type = str(run_context["source_type"])
     dataset_id = int(run_context["dataset_id"])
-    use_persistent_auto_cache = source_type == "gpr"
-    if use_persistent_auto_cache:
+    use_persistent_auto_cache = source_type in {"gpr", "well_log"}
+    if source_type == "gpr":
         clust_object = session.query(ObjectSet).filter_by(id=dataset_id).first()
         if clust_object is None:
             set_info(f"AUTO: объект id={dataset_id} не найден.", "brown")
+            return
+    elif source_type == "well_log":
+        dataset = session.query(WellLogClusterDataset).filter_by(id=dataset_id).first()
+        if dataset is None:
+            set_info(f"AUTO: Well Log dataset id={dataset_id} не найден.", "brown")
             return
 
     base_data = run_context["raw_rows"]
@@ -1072,7 +1145,8 @@ def calculate_cluster_auto():
             "non_finite_mode": text_method_nan,
             "use_variance_threshold": ui.checkBox_clust_clear_vartresh.isChecked(),
             "use_correlation_filter": ui.checkBox_clust_clear_corr.isChecked()
-        }
+        },
+        source_type=source_type
     )
 
     render_auto_results_table([])
@@ -1099,7 +1173,8 @@ def calculate_cluster_auto():
         cached_top_results = load_cluster_auto_tuning_cache(
             cache_key=cache_key,
             clust_object_id=dataset_id,
-            top_k=top_k
+            top_k=top_k,
+            source_type=source_type
         )
         if cached_top_results:
             enriched_cached_results = enrich_auto_results_for_context(cached_top_results, run_context, auto_mode=auto_mode)
@@ -1130,8 +1205,8 @@ def calculate_cluster_auto():
         candidate_soft_timeout_sec=candidate_timeout_sec,
         random_seed=auto_random_seed,
         min_cluster_samples=min_cluster_samples,
-        run_key=cache_key,
-        object_set_id=dataset_id if use_persistent_auto_cache else None,
+        run_key=cache_key if source_type == "gpr" else None,
+        object_set_id=dataset_id if source_type == "gpr" else None,
         clean_kwargs={
             "use_non_finite": ui.checkBox_clust_clean_nan.isChecked(),
             "non_finite_mode": text_method_nan,
@@ -1147,7 +1222,12 @@ def calculate_cluster_auto():
             cache_key=cache_key,
             clust_object_id=dataset_id,
             top_results=top_results,
-            top_k=top_k
+            top_k=top_k,
+            source_type=source_type,
+            dataset_title=str(run_context.get("dataset_title", "")),
+            data_hash=str(run_context.get("data_hash", "")),
+            auto_mode=auto_mode,
+            diagnostics=dict(run_context.get("diagnostics", {}) or {})
         )
     remember_auto_results_for_context(run_context, enriched_top_results)
     render_auto_results_table(enriched_top_results)

--- a/cluster/objects.py
+++ b/cluster/objects.py
@@ -270,23 +270,29 @@ def load_saved_auto_results_for_selected_object() -> None:
     """
     При выборе ObjectSet подгружает последнюю сохраненную таблицу AUTO-кластеризации (если есть).
     """
+    run_context = build_cluster_run_context(show_errors=False)
+    if run_context is not None:
+        load_saved_auto_results_for_context(run_context)
+        return
+
     clust_object_id = get_curr_clust_object_id()
     if not clust_object_id:
         render_auto_results_table([])
         return
 
     try:
-        cache_row = (
+        cache_rows = (
             session.query(ClusterAutoTuningCache)
             .filter_by(object_set_id=int(clust_object_id))
             .order_by(ClusterAutoTuningCache.created_at.desc())
-            .first()
+            .all()
         )
     except Exception as exc:
         render_auto_results_table([])
         set_info(f"AUTO: ошибка чтения сохраненного результата: {exc}", "brown")
         return
 
+    cache_row = next((row for row in cache_rows if _cache_row_matches_source_type(row, "gpr")), None)
     if cache_row is None or not cache_row.top_results:
         render_auto_results_table([])
         return

--- a/cluster/well_dataset.py
+++ b/cluster/well_dataset.py
@@ -51,6 +51,9 @@ def update_cluster_well_dataset_combobox(select_dataset_id: int | None = None) -
         combo.setCurrentIndex(index_to_select)
     combo.blockSignals(False)
     load_cluster_well_dataset_state_to_form(combo.currentData())
+    refresh_results = globals().get("refresh_cluster_auto_results_for_active_context")
+    if callable(refresh_results):
+        refresh_results()
 
 
 def load_cluster_well_dataset_state_to_form(dataset_id: int | None = None) -> None:
@@ -501,7 +504,7 @@ def remove_cluster_well_dataset() -> None:
         MainWindow,
         'Подтверждение удаления',
         f'Удалить набор "{dataset.name}"?\n\n'
-        'Будут удалены связанные скважины, интервалы, каротажи и собранные данные.',
+        'Будут удалены связанные скважины, интервалы, каротажи, собранные данные и AUTO-результаты.',
         QMessageBox.Yes | QMessageBox.No,
         QMessageBox.No
     )

--- a/models_db/model_cluster.py
+++ b/models_db/model_cluster.py
@@ -39,6 +39,18 @@ class ClusterAutoTuningCache(Base):
     object_set = relationship('ObjectSet', back_populates='auto_tuning_cache')
 
 
+class WellLogClusterAutoTuningCache(Base):
+    __tablename__ = 'well_log_cluster_auto_tuning_cache'
+
+    id = Column(Integer, primary_key=True)
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    cache_key = Column(String, nullable=False, unique=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    top_results = Column(Text, nullable=False)
+
+    well_cluster_set = relationship('WellLogClusterDataset', back_populates='auto_tuning_cache')
+
+
 class ClusterAutoTuningRunState(Base):
     __tablename__ = 'cluster_auto_tuning_run_state'
 
@@ -72,6 +84,7 @@ class WellLogClusterDataset(Base):
     cluster_well_log_param = relationship('ClusterWellLogParameter', back_populates='well_cluster_set', cascade='all, delete-orphan')
     cluster_well_log_param_from_calculator = relationship('ClusterWellLogParameterFromCalculator', back_populates='well_cluster_set', cascade='all, delete-orphan')
     data = relationship('WellLogClusterDatasetData', back_populates='well_cluster_set', cascade='all, delete-orphan')
+    auto_tuning_cache = relationship('WellLogClusterAutoTuningCache', back_populates='well_cluster_set', cascade='all, delete-orphan')
 
 
 class WellForCluster(Base):


### PR DESCRIPTION
### Motivation
- The AUTO clustering results table for Well Log was not restored after application restart because well-log results were mixed with GPR `ObjectSet` cache and loading logic only covered GPR objects.
- Introduce a persistent, source-aware cache so saved AUTO results for Well Log datasets survive restarts and are shown when a Well Log dataset is selected.

### Description
- Added a new SQLAlchemy model `WellLogClusterAutoTuningCache` and corresponding Alembic migration `alembic/versions/c2d3e4f5a6b7_add_well_log_auto_tuning_cache.py` to store top-K AUTO results per Well Log `dataset_id`.
- Made cache functions source-aware by extending `build_cluster_auto_tuning_cache_key`, `load_cluster_auto_tuning_cache` and `save_cluster_auto_tuning_cache` with a `source_type` flag and by selecting the appropriate cache model for `gpr` vs `well_log` in `cluster/auto_cache.py`.
- Restored persistent-load flow for the active context: `load_saved_auto_results_for_context` loads last matching cache row for the current source and dataset, `refresh_cluster_auto_results_for_active_context` now uses that, and `update_cluster_well_dataset_combobox` triggers refresh after selecting a Well Log dataset (files: `cluster/auto_runner.py`, `cluster/objects.py`, `cluster/well_dataset.py`).
- Scoped cache clearing to the active source/dataset so deleting/clearing removes only matching persistent rows and added metadata (dataset title/hash, auto mode, diagnostics) when saving Well Log results.

### Testing
- Performed static checks by compiling changed modules with `python -m py_compile cluster/auto_cache.py cluster/auto_runner.py cluster/objects.py cluster/well_dataset.py models_db/model_cluster.py alembic/versions/c2d3e4f5a6b7_add_well_log_auto_tuning_cache.py` and all compiled successfully.
- Ran unit tests `pytest -q tests/test_cluster_canonical_preparation.py` and they passed (`2 passed`).
- Verified git staging and created the Alembic migration file; attempting to import the DB models for a runtime smoke-check failed in this environment due to `sqlalchemy` not being installed, which does not affect the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d2875a8ec832f8a1fb0cfdd639fac)