### PR TITLE
Enforce AUTO max cluster limit

### DIFF
--- a/cluster/auto_candidates.py
+++ b/cluster/auto_candidates.py
@@ -317,7 +317,8 @@ def run_cluster_candidate(
         metrics_cache: Optional[Dict[str, CandidateMetrics]] = None,
         min_pca_components: int = 2,
         max_silhouette_samples: int = AUTO_SILHOUETTE_MAX_SAMPLES,
-        min_cluster_samples: int = 1
+        min_cluster_samples: int = 1,
+        max_clusters: Optional[int] = None
 ) -> CandidateResult:
     """
     Прогоняет одного кандидата AUTO-подбора без UI-зависимостей.
@@ -568,13 +569,34 @@ def run_cluster_candidate(
         min_cluster_samples_value = max(1, int(min_cluster_samples))
     except (TypeError, ValueError):
         min_cluster_samples_value = 1
+    try:
+        max_clusters_value = max(2, int(max_clusters)) if max_clusters is not None else None
+    except (TypeError, ValueError):
+        max_clusters_value = None
+
+    n_clusters_result = int(cluster_info.get("n_clusters", len(unique_clusters_eval)) or 0)
+
+    if max_clusters_value is not None and n_clusters_result > max_clusters_value:
+        return make_candidate_result(
+            candidate_id=candidate_id,
+            candidate_config=candidate,
+            stats=CandidateStats(
+                n_clusters=n_clusters_result,
+                noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
+                n_samples_eval=n_samples_eval,
+                partition_hash=partition_hash,
+                **pca_stats
+            ),
+            status="invalid",
+            error_text=f"n_clusters {n_clusters_result} > max_clusters {max_clusters_value}"
+        )
 
     if n_samples_eval == 0:
         return make_candidate_result(
             candidate_id=candidate_id,
             candidate_config=candidate,
             stats=CandidateStats(
-                n_clusters=int(cluster_info.get("n_clusters", 0)),
+                n_clusters=n_clusters_result,
                 noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
                 n_samples_eval=0,
                 partition_hash=partition_hash,
@@ -590,7 +612,7 @@ def run_cluster_candidate(
             candidate_id=candidate_id,
             candidate_config=candidate,
             stats=CandidateStats(
-                n_clusters=int(cluster_info.get("n_clusters", 0)),
+                n_clusters=n_clusters_result,
                 noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
                 n_samples_eval=n_samples_eval,
                 partition_hash=partition_hash,
@@ -607,7 +629,7 @@ def run_cluster_candidate(
             candidate_id=candidate_id,
             candidate_config=candidate,
             stats=CandidateStats(
-                n_clusters=int(cluster_info.get("n_clusters", 0)),
+                n_clusters=n_clusters_result,
                 noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
                 n_samples_eval=n_samples_eval,
                 partition_hash=partition_hash,
@@ -629,7 +651,7 @@ def run_cluster_candidate(
                     calinski_harabasz=float(cached_metrics.get("calinski_harabasz"))
                 ),
                 stats=CandidateStats(
-                    n_clusters=int(cluster_info.get("n_clusters", 0)),
+                    n_clusters=n_clusters_result,
                     noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
                     n_samples_eval=n_samples_eval,
                     partition_hash=partition_hash,
@@ -662,7 +684,7 @@ def run_cluster_candidate(
             candidate_id=candidate_id,
             candidate_config=candidate,
             stats=CandidateStats(
-                n_clusters=int(cluster_info.get("n_clusters", 0)),
+                n_clusters=n_clusters_result,
                 noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
                 n_samples_eval=n_samples_eval,
                 partition_hash=partition_hash,
@@ -685,7 +707,7 @@ def run_cluster_candidate(
         candidate_config=candidate,
         metrics=metric_payload,
         stats=CandidateStats(
-            n_clusters=int(cluster_info.get("n_clusters", 0)),
+            n_clusters=n_clusters_result,
             noise_fraction=float(cluster_info.get("noise_fraction", 0.0)),
             n_samples_eval=n_samples_eval,
             partition_hash=partition_hash,
@@ -768,7 +790,8 @@ def score_candidate(
 
 def rank_candidates(
         results: list[CandidateResult],
-        weights: Optional[Dict[str, float]] = None
+        weights: Optional[Dict[str, float]] = None,
+        max_clusters: Optional[int] = None
 ) -> list[CandidateResult]:
     """
     Выставляет score и возвращает отсортированный список кандидатов.
@@ -780,6 +803,11 @@ def rank_candidates(
     4) ниже noise_fraction
     """
     ranked: list[CandidateResult] = []
+    try:
+        max_clusters_value = max(2, int(max_clusters)) if max_clusters is not None else None
+    except (TypeError, ValueError):
+        max_clusters_value = None
+
     for result in results:
         result_copy = CandidateResult(
             candidate_id=result["candidate_id"],
@@ -791,6 +819,14 @@ def rank_candidates(
             error_text=result.get("error_text", "")
         )
 
+        stats = result_copy.get("stats", CandidateStats())
+        try:
+            n_clusters_result = int(stats.get("n_clusters", 0) or 0)
+        except (TypeError, ValueError):
+            n_clusters_result = 0
+
+        if max_clusters_value is not None and n_clusters_result > max_clusters_value:
+            continue
         if result_copy["status"] == "ok":
             result_copy["score"] = score_candidate(
                 result_copy.get("metrics", CandidateMetrics()),
@@ -900,13 +936,18 @@ def build_fine_search_space(
         *,
         top_k: int = 5,
         max_candidates: Optional[int] = 200,
-        hdbscan_metrics: Optional[list[str]] = None
+        hdbscan_metrics: Optional[list[str]] = None,
+        max_clusters: Optional[int] = None
 ) -> list[CandidateConfig]:
     """
     Строит локальное fine-пространство вокруг top-K coarse-кандидатов.
     """
     fine_candidates: list[CandidateConfig] = []
     seen_signatures = set()
+    try:
+        max_clusters_value = max(2, int(max_clusters)) if max_clusters is not None else None
+    except (TypeError, ValueError):
+        max_clusters_value = None
 
     for result in top_results[:max(1, int(top_k))]:
         if result.get("status") != "ok":
@@ -955,7 +996,10 @@ def build_fine_search_space(
         if base_method == "kmeans":
             base_k = int(base_method_params.get("kmeans_n_clusters", 4))
             base_n_init = int(base_method_params.get("kmeans_n_init", 10))
-            for k in range(max(2, base_k - 2), base_k + 3):
+            upper_k = base_k + 2
+            if max_clusters_value is not None:
+                upper_k = min(upper_k, max_clusters_value)
+            for k in range(max(2, base_k - 2), upper_k + 1):
                 for n_init in sorted({base_n_init, 20, base_n_init + 10}):
                     method_variants.append({
                         "kmeans_n_clusters": int(k),
@@ -975,7 +1019,10 @@ def build_fine_search_space(
         elif base_method == "gmm":
             base_n = int(base_method_params.get("gmm_n_components", 4))
             base_cov = str(base_method_params.get("gmm_covariance_type", "full"))
-            for n_components in range(max(2, base_n - 2), base_n + 3):
+            upper_n_components = base_n + 2
+            if max_clusters_value is not None:
+                upper_n_components = min(upper_n_components, max_clusters_value)
+            for n_components in range(max(2, base_n - 2), upper_n_components + 1):
                 method_variants.append({
                     "gmm_n_components": int(n_components),
                     "gmm_covariance_type": base_cov

--- a/cluster/auto_runner.py
+++ b/cluster/auto_runner.py
@@ -98,6 +98,7 @@ def run_auto_cluster_tuning(
                 min_pca_components=min_pca_components,
                 max_silhouette_samples=coarse_silhouette_samples,
                 min_cluster_samples=min_cluster_samples,
+                max_clusters=max_clusters,
                 hard_timeout_sec=candidate_soft_timeout_sec
             )
         except Exception as exc:
@@ -175,6 +176,7 @@ def run_auto_cluster_tuning(
                     min_pca_components=min_pca_components,
                     max_silhouette_samples=coarse_silhouette_samples,
                     min_cluster_samples=min_cluster_samples,
+                    max_clusters=max_clusters,
                     hard_timeout_sec=candidate_soft_timeout_sec
                 )
             except Exception as exc:
@@ -220,6 +222,7 @@ def run_auto_cluster_tuning(
                         min_pca_components=min_pca_components,
                         max_silhouette_samples=coarse_silhouette_samples,
                         min_cluster_samples=min_cluster_samples,
+                        max_clusters=max_clusters,
                         hard_timeout_sec=candidate_soft_timeout_sec
                     )
                 except Exception as exc:
@@ -250,7 +253,7 @@ def run_auto_cluster_tuning(
 
     if restored_raw_results:
         coarse_results = list(restored_raw_results) + coarse_results
-    ranked_coarse = rank_candidates(coarse_results, weights=weights)
+    ranked_coarse = rank_candidates(coarse_results, weights=weights, max_clusters=max_clusters)
     coarse_best_result = ranked_coarse[0] if ranked_coarse else None
     coarse_top_diverse = select_diverse_top_results(
         ranked_coarse,
@@ -295,7 +298,8 @@ def run_auto_cluster_tuning(
         fine_seed_results,
         top_k=fine_seed_count,
         max_candidates=max_candidates,
-        hdbscan_metrics=hdbscan_metrics
+        hdbscan_metrics=hdbscan_metrics,
+        max_clusters=max_clusters
     )
     fine_results: list[CandidateResult] = []
     for idx, candidate in enumerate(fine_candidates, start=1):
@@ -325,6 +329,7 @@ def run_auto_cluster_tuning(
                 min_pca_components=min_pca_components,
                 max_silhouette_samples=_compute_auto_silhouette_sample_size(len(base_data), stage="fine", estimated_n_clusters=max_clusters),
                 min_cluster_samples=min_cluster_samples,
+                max_clusters=max_clusters,
                 hard_timeout_sec=candidate_soft_timeout_sec
             )
         except Exception as exc:
@@ -384,7 +389,7 @@ def run_auto_cluster_tuning(
     if run_key and object_set_id is not None and (coarse_results or fine_results):
         _save_auto_tuning_run_state(run_key=str(run_key), object_set_id=int(object_set_id), random_seed=int(random_seed or 42), sampled_indices=np.arange(len(base_data), dtype=int), completed_candidate_ids=completed_candidate_ids, coarse_results=coarse_results, fine_results=fine_results)
 
-    combined_ranked = rank_candidates(coarse_results + fine_results, weights=weights)
+    combined_ranked = rank_candidates(coarse_results + fine_results, weights=weights, max_clusters=max_clusters)
     best_result = combined_ranked[0] if combined_ranked else coarse_best_result
     combined_top_diverse = select_diverse_top_results(
         combined_ranked,
@@ -400,7 +405,7 @@ def run_auto_cluster_tuning(
         "top_results": combined_top_diverse,
         "raw_results": coarse_results + fine_results,
         "coarse_results": ranked_coarse,
-        "fine_results": rank_candidates(fine_results, weights=weights),
+        "fine_results": rank_candidates(fine_results, weights=weights, max_clusters=max_clusters),
         "coarse_best_result": coarse_best_result
     }
 
@@ -1177,6 +1182,12 @@ def calculate_cluster_auto():
             source_type=source_type
         )
         if cached_top_results:
+            cached_top_results = select_diverse_top_results(
+                rank_candidates(cached_top_results, weights=metric_weights, max_clusters=max_clusters),
+                top_k=top_k,
+                diversity_key="partition_hash"
+            )
+        if cached_top_results:
             enriched_cached_results = enrich_auto_results_for_context(cached_top_results, run_context, auto_mode=auto_mode)
             remember_auto_results_for_context(run_context, enriched_cached_results)
             render_auto_results_table(enriched_cached_results)
@@ -1417,6 +1428,12 @@ def calculate_cluster_auto_batch() -> None:
                 clust_object_id=object_id,
                 top_k=top_k
             )
+            if cached_top_results:
+                cached_top_results = select_diverse_top_results(
+                    rank_candidates(cached_top_results, weights=metric_weights, max_clusters=max_clusters),
+                    top_k=top_k,
+                    diversity_key="partition_hash"
+                )
             if cached_top_results:
                 skipped_cached += 1
                 best_cached = cached_top_results[0] if cached_top_results else {}

--- a/tests/test_cluster_auto_max_clusters.py
+++ b/tests/test_cluster_auto_max_clusters.py
@@ -1,0 +1,181 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+class ArrayStub(list):
+    def __ne__(self, other):
+        return ArrayStub([item != other for item in self])
+
+    def __getitem__(self, key):
+        if isinstance(key, list):
+            return ArrayStub([item for item, keep in zip(self, key) if keep])
+        return super().__getitem__(key)
+
+
+class NumpyStub:
+    @staticmethod
+    def asarray(value, dtype=None):
+        return ArrayStub(value)
+
+    @staticmethod
+    def unique(value):
+        return ArrayStub(sorted(set(value)))
+
+    @staticmethod
+    def count_nonzero(value):
+        return sum(1 for item in value if item)
+
+    @staticmethod
+    def isfinite(value):
+        return value not in {float("inf"), float("-inf")} and value == value
+
+    class linalg:
+        @staticmethod
+        def matrix_rank(value):
+            return 1
+
+
+def load_auto_candidates_module():
+    common = types.ModuleType("cluster.common")
+    common.__dict__.update(
+        {
+            "__future__": None,
+            "Any": object,
+            "Dict": dict,
+            "Literal": lambda *args, **kwargs: object,
+            "Optional": object,
+            "TypedDict": dict,
+            "Counter": dict,
+            "OrderedDict": dict,
+            "product": __import__("itertools").product,
+        }
+    )
+    models = types.ModuleType("cluster.models")
+    models.__dict__.update(
+        {
+            "CandidateConfig": dict,
+            "CandidateMetrics": dict,
+            "CandidateResult": dict,
+            "CandidateStats": dict,
+            "GMM_COVARIANCE_TYPES": ("full", "diag", "tied", "spherical"),
+            "AUTO_CANDIDATE_HARD_TIMEOUT_SEC": 1,
+            "AUTO_PCA_PILOT_ENABLED": False,
+            "AUTO_PCA_PILOT_MAX_ROWS": 10,
+            "AUTO_SILHOUETTE_MAX_SAMPLES": 100,
+            "AUTO_TUNING_MAX_FEATURES": 10,
+            "AUTO_TUNING_MAX_ROWS": 100,
+        }
+    )
+    package = types.ModuleType("cluster")
+    package.__path__ = [str(Path("cluster").resolve())]
+    sys.modules["cluster"] = package
+    sys.modules["cluster.common"] = common
+    sys.modules["cluster.models"] = models
+
+    spec = importlib.util.spec_from_file_location(
+        "cluster.auto_candidates",
+        Path("cluster/auto_candidates.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cluster.auto_candidates"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def auto_candidates(monkeypatch):
+    module = load_auto_candidates_module()
+    monkeypatch.setattr(module, "_sample_rows_for_auto_tuning", lambda data, max_rows: data, raising=False)
+    monkeypatch.setattr(module, "_reduce_feature_space_for_auto_tuning", lambda data, max_features: data, raising=False)
+    monkeypatch.setattr(module, "clean_features", lambda data, **kwargs: (data, {}), raising=False)
+    monkeypatch.setattr(module, "preprocess_features", lambda data, mode: data, raising=False)
+    monkeypatch.setattr(module, "_build_partition_hash", lambda labels: "hash", raising=False)
+    monkeypatch.setattr(module, "np", NumpyStub, raising=False)
+    return module
+
+
+def test_run_cluster_candidate_rejects_result_above_max_clusters(auto_candidates, monkeypatch):
+    monkeypatch.setattr(
+        auto_candidates,
+        "cluster_data",
+        lambda data, method, **kwargs: ([0, 1, 2, 3, 4], {"n_clusters": 5, "noise_fraction": 0.0}),
+        raising=False,
+    )
+    evaluate_called = False
+
+    def evaluate_clustering(*args, **kwargs):
+        nonlocal evaluate_called
+        evaluate_called = True
+        return {"metrics": {"silhouette": 0.5, "davies_bouldin": 1.0, "calinski_harabasz": 10.0}}
+
+    monkeypatch.setattr(auto_candidates, "evaluate_clustering", evaluate_clustering, raising=False)
+
+    result = auto_candidates.run_cluster_candidate(
+        [[float(i)] for i in range(5)],
+        {"scaler_mode": "none", "pca_enabled": False, "pca_mode": None, "pca_value": None, "method": "hdbscan", "method_params": {}},
+        max_clusters=4,
+    )
+
+    assert result["status"] == "invalid"
+    assert result["stats"]["n_clusters"] == 5
+    assert result["error_text"] == "n_clusters 5 > max_clusters 4"
+    assert evaluate_called is False
+
+
+def test_rank_candidates_removes_cached_result_above_max_clusters(auto_candidates):
+    result = {
+        "candidate_id": "C001",
+        "candidate_config": {"scaler_mode": "none", "pca_enabled": False, "pca_mode": None, "pca_value": None, "method": "hdbscan", "method_params": {}},
+        "metrics": {"silhouette": 0.9, "davies_bouldin": 0.1, "calinski_harabasz": 100.0},
+        "stats": {"n_clusters": 6, "noise_fraction": 0.0},
+        "score": None,
+        "status": "ok",
+        "error_text": "",
+    }
+
+    ranked = auto_candidates.rank_candidates([result], max_clusters=4)
+
+    assert ranked == []
+
+
+def test_build_fine_search_space_clamps_kmeans_and_gmm_to_max_clusters(auto_candidates):
+    top_results = [
+        {
+            "status": "ok",
+            "candidate_config": {
+                "scaler_mode": "none",
+                "pca_enabled": False,
+                "pca_mode": None,
+                "pca_value": None,
+                "method": "kmeans",
+                "method_params": {"kmeans_n_clusters": 4, "kmeans_n_init": 10},
+            },
+        },
+        {
+            "status": "ok",
+            "candidate_config": {
+                "scaler_mode": "none",
+                "pca_enabled": False,
+                "pca_mode": None,
+                "pca_value": None,
+                "method": "gmm",
+                "method_params": {"gmm_n_components": 4, "gmm_covariance_type": "full"},
+            },
+        },
+    ]
+
+    candidates = auto_candidates.build_fine_search_space(
+        top_results,
+        top_k=2,
+        max_candidates=None,
+        max_clusters=4,
+    )
+
+    for candidate in candidates:
+        params = candidate["method_params"]
+        assert params.get("kmeans_n_clusters", 0) <= 4
+        assert params.get("gmm_n_components", 0) <= 4


### PR DESCRIPTION
### Motivation
- Prevent AUTO-tuning from returning or applying candidate configurations that produce more clusters than the user-configured `max_clusters` (e.g. UI spinbox), which currently allows results with 5+ clusters even if `max_clusters` is 4.
- Ensure FINE-stage neighborhood generation does not propose KMeans/GMM candidates that exceed the configured `max_clusters` ceiling.

### Description
- Reject candidates in `run_cluster_candidate` early when the actual `cluster_info["n_clusters"]` exceeds the provided `max_clusters`, returning status `invalid` and descriptive `error_text`. (`cluster/auto_candidates.py` — `run_cluster_candidate`).
- Propagate the `max_clusters` parameter through the AUTO pipeline and to isolated candidate runs (coarse, rescue, relaxed rescue and fine) so the limit is enforced at all stages. (`cluster/auto_runner.py`).
- Filter out cached/previous `top_results` and ranking entries that exceed `max_clusters` by passing `max_clusters` into `rank_candidates` and excluding over-limit rows before building the leaderboard. (`cluster/auto_candidates.py`, `cluster/auto_runner.py`).
- Clamp FINE-stage search neighborhoods for KMeans and GMM so local variants do not generate `k`/`n_components` above `max_clusters`; HDBSCAN remains runtime-validated because its cluster count is not fixed by parameter. (`cluster/auto_candidates.py` — `build_fine_search_space`).
- Add regression tests `tests/test_cluster_auto_max_clusters.py` covering rejection of over-limit candidate results, filtering cached results above the limit, and clamping of FINE search space (KMeans/GMM).

### Testing
- Ran `pytest -q tests/test_cluster_auto_max_clusters.py` and all tests passed (3 passed).
- Ran `python -m py_compile cluster/auto_candidates.py cluster/auto_runner.py tests/test_cluster_auto_max_clusters.py` and compilation succeeded.
- Added unit tests exercise the new `max_clusters` handling for candidate rejection, ranking/cache filtering and fine-space clamping; they ran locally and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d584559b0832fa2f9a9d9421396f5)