### PR TITLE
Implement unary Well Log feature calculator backend (stage 2)

### DIFF
--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import math
+import statistics
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Sequence
 
 FEATURE_CALCULATOR_CONFIG_VERSION = 1
 FEATURE_CALCULATOR_SUPPORTED_MODES = {"operation", "formula"}
@@ -10,6 +12,18 @@ FEATURE_CALCULATOR_DEPTH_GRID_POLICY = "strict_equal"
 FEATURE_CALCULATOR_INVALID_MATH_POLICY = "block"
 FEATURE_CALCULATOR_DEFAULT_OUTLIER_POLICY = "none"
 FEATURE_CALCULATOR_DEFAULT_NORMALIZATION_SCOPE = "whole_well"
+FEATURE_CALCULATOR_NORMALIZATION_SCOPES = {"whole_well", "interval"}
+FEATURE_CALCULATOR_UNARY_OPERATIONS = {
+    "log",
+    "abs",
+    "sqrt",
+    "derivative",
+    "rolling_mean",
+    "rolling_median",
+    "zscore",
+    "robust",
+    "minmax",
+}
 
 
 @dataclass(slots=True)
@@ -81,10 +95,28 @@ class FeatureCalculatorConfig:
 
 
 @dataclass(slots=True)
+class WellLogCurveSeries:
+    """One canonical curve resolved to a concrete WellLog curve in one well."""
+
+    well_id: int
+    canonical_id: int
+    canonical_name: str
+    depths: list[float]
+    values: list[float | None]
+    step: float
+    begin: float
+    end: float
+    source_curve_name: str
+    stats_depths: list[float] = field(default_factory=list)
+    stats_values: list[float | None] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class FeatureCalculatorEvaluationResult:
-    """Placeholder evaluation result for future calculator stages."""
+    """Calculation result for one well and one calculated Well Log feature."""
 
     values: list[float | None] = field(default_factory=list)
+    depths: list[float] = field(default_factory=list)
     errors: list[FeatureCalculatorError] = field(default_factory=list)
 
     @property
@@ -104,12 +136,18 @@ def _error(
     calculator_id: int | None = None,
     feature_name: str | None = None,
     severity: str = "error",
+    well_id: int | None = None,
+    well_name: str | None = None,
+    canonical_name: str | None = None,
 ) -> FeatureCalculatorError:
     return FeatureCalculatorError(
         code=code,
         message=message,
         calculator_id=calculator_id,
         feature_name=feature_name,
+        well_id=well_id,
+        well_name=well_name,
+        canonical_name=canonical_name,
         severity=severity,
     )
 
@@ -197,7 +235,7 @@ def parse_feature_calculator_config(calculator: Any) -> tuple[FeatureCalculatorC
 
 
 def validate_feature_calculator_config(config: FeatureCalculatorConfig) -> list[FeatureCalculatorError]:
-    """Stage-1 schema validation placeholder for a calculated-feature config."""
+    """Validate a calculated-feature config supported by the current MVP stages."""
     errors: list[FeatureCalculatorError] = []
     if config.version != FEATURE_CALCULATOR_CONFIG_VERSION:
         errors.append(_error("unsupported_config_version", f"Версия конфигурации {config.version} не поддерживается.", config.calculator_id, config.feature_name))
@@ -205,10 +243,17 @@ def validate_feature_calculator_config(config: FeatureCalculatorConfig) -> list[
         errors.append(_error("unsupported_mode", f"Режим '{config.mode}' не поддерживается.", config.calculator_id, config.feature_name))
     if not config.inputs:
         errors.append(_error("missing_inputs", "Не задан список входных canonical-кривых.", config.calculator_id, config.feature_name))
-    if config.mode == "operation" and not config.operation:
-        errors.append(_error("missing_operation", "Для mode=operation необходимо поле operation.", config.calculator_id, config.feature_name))
+    if config.mode == "operation":
+        if not config.operation:
+            errors.append(_error("missing_operation", "Для mode=operation необходимо поле operation.", config.calculator_id, config.feature_name))
+        elif str(config.operation).lower() not in FEATURE_CALCULATOR_UNARY_OPERATIONS:
+            errors.append(_error("unsupported_operation", f"Операция '{config.operation}' не поддерживается для unary backend.", config.calculator_id, config.feature_name))
+        if len(config.inputs) != 1:
+            errors.append(_error("invalid_inputs", "Операции этапа 2 поддерживают ровно одну входную canonical-кривую.", config.calculator_id, config.feature_name))
     if config.mode == "formula" and not config.expression:
         errors.append(_error("missing_expression", "Для mode=formula необходимо поле expression.", config.calculator_id, config.feature_name))
+    if config.normalization_scope not in FEATURE_CALCULATOR_NORMALIZATION_SCOPES:
+        errors.append(_error("unsupported_normalization_scope", "Разрешены только normalization_scope=whole_well или interval.", config.calculator_id, config.feature_name))
     if config.depth_grid_policy != FEATURE_CALCULATOR_DEPTH_GRID_POLICY:
         errors.append(_error("unsupported_depth_grid_policy", "В MVP разрешён только depth_grid_policy=strict_equal.", config.calculator_id, config.feature_name))
     if config.invalid_math_policy != FEATURE_CALCULATOR_INVALID_MATH_POLICY:
@@ -216,6 +261,369 @@ def validate_feature_calculator_config(config: FeatureCalculatorConfig) -> list[
     if config.outlier_policy != FEATURE_CALCULATOR_DEFAULT_OUTLIER_POLICY:
         errors.append(_error("unsupported_outlier_policy", "В MVP разрешён только outlier_policy=none.", config.calculator_id, config.feature_name))
     return errors
+
+
+def _finite_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _blocking_if_any_missing(values: Sequence[float | None], code: str, message: str) -> FeatureCalculatorError | None:
+    if any(value is None or not math.isfinite(value) for value in values):
+        return _error(code, message)
+    return None
+
+
+def _non_finite_result_error(values: Sequence[float | None]) -> FeatureCalculatorError | None:
+    if any(value is None or not math.isfinite(value) for value in values):
+        return _error("non_finite_result", "Результат содержит NaN/inf или пустые значения; расчёт признака заблокирован.")
+    return None
+
+
+def _copy_error_context(
+    error: FeatureCalculatorError,
+    *,
+    config: FeatureCalculatorConfig | None = None,
+    series: WellLogCurveSeries | None = None,
+    well_id: int | None = None,
+    canonical_name: str | None = None,
+) -> FeatureCalculatorError:
+    return FeatureCalculatorError(
+        code=error.code,
+        message=error.message,
+        calculator_id=config.calculator_id if config else error.calculator_id,
+        feature_name=config.feature_name if config else error.feature_name,
+        well_id=series.well_id if series else well_id or error.well_id,
+        well_name=error.well_name,
+        canonical_name=series.canonical_name if series else canonical_name or error.canonical_name,
+        severity=error.severity,
+    )
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    position = (len(sorted_values) - 1) * percentile
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+    if lower_index == upper_index:
+        return sorted_values[int(position)]
+    lower_value = sorted_values[lower_index]
+    upper_value = sorted_values[upper_index]
+    weight = position - lower_index
+    return lower_value + (upper_value - lower_value) * weight
+
+
+def _quartiles(values: Sequence[float]) -> tuple[float, float]:
+    return _percentile(values, 0.25), _percentile(values, 0.75)
+
+
+def apply_log(values: Sequence[float | None]) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    if any(value is None or not math.isfinite(value) or value <= 0 for value in values):
+        return [], [_error("invalid_math_domain", "log(X) определён только для положительных конечных значений.")]
+    result = [math.log(float(value)) for value in values]
+    return result, []
+
+
+def apply_abs(values: Sequence[float | None]) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "abs(X) требует конечные значения входной кривой.")
+    if source_error:
+        return [], [source_error]
+    return [abs(float(value)) for value in values], []
+
+
+def apply_sqrt(values: Sequence[float | None]) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    if any(value is None or not math.isfinite(value) or value < 0 for value in values):
+        return [], [_error("invalid_math_domain", "sqrt(X) определён только для неотрицательных конечных значений.")]
+    return [math.sqrt(float(value)) for value in values], []
+
+
+def apply_derivative(values: Sequence[float | None], step: float) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    if step <= 0 or not math.isfinite(step):
+        return [], [_error("invalid_step", "Для производной требуется положительный конечный шаг глубины.")]
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "dX/dz требует конечные значения входной кривой.")
+    if source_error:
+        return [], [source_error]
+    if len(values) < 2:
+        return [], [_error("not_enough_points", "Для производной требуется минимум две точки.")]
+    numeric = [float(value) for value in values]
+    if len(numeric) == 2:
+        slope = (numeric[1] - numeric[0]) / step
+        return [slope, slope], []
+    result: list[float] = [(numeric[1] - numeric[0]) / step]
+    result.extend((numeric[index + 1] - numeric[index - 1]) / (2 * step) for index in range(1, len(numeric) - 1))
+    result.append((numeric[-1] - numeric[-2]) / step)
+    return result, []
+
+
+def _validate_window(window: Any, values_count: int) -> tuple[int | None, FeatureCalculatorError | None]:
+    try:
+        window_size = int(window)
+    except (TypeError, ValueError):
+        return None, _error("invalid_window", "Параметр window должен быть целым числом.")
+    if window_size < 1:
+        return None, _error("invalid_window", "Параметр window должен быть больше нуля.")
+    if values_count < window_size:
+        return None, _error("not_enough_points", "Недостаточно точек для выбранного окна сглаживания.")
+    return window_size, None
+
+
+def apply_rolling_mean(values: Sequence[float | None], window: int = 3) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "rolling_mean требует конечные значения входной кривой.")
+    if source_error:
+        return [], [source_error]
+    window_size, window_error = _validate_window(window, len(values))
+    if window_error:
+        return [], [window_error]
+    numeric = [float(value) for value in values]
+    half_window = window_size // 2
+    result = []
+    for index in range(len(numeric)):
+        start = max(0, index - half_window)
+        end = min(len(numeric), start + window_size)
+        start = max(0, end - window_size)
+        result.append(sum(numeric[start:end]) / (end - start))
+    return result, []
+
+
+def apply_rolling_median(values: Sequence[float | None], window: int = 3) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "rolling_median требует конечные значения входной кривой.")
+    if source_error:
+        return [], [source_error]
+    window_size, window_error = _validate_window(window, len(values))
+    if window_error:
+        return [], [window_error]
+    numeric = [float(value) for value in values]
+    half_window = window_size // 2
+    result = []
+    for index in range(len(numeric)):
+        start = max(0, index - half_window)
+        end = min(len(numeric), start + window_size)
+        start = max(0, end - window_size)
+        result.append(float(statistics.median(numeric[start:end])))
+    return result, []
+
+
+def apply_zscore(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source = list(values if stats_values is None else stats_values)
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "zscore требует конечные значения расчётного интервала.")
+    stats_error = _blocking_if_any_missing(source, "non_finite_result", "zscore требует конечные значения области нормировки.")
+    if source_error or stats_error:
+        return [], [error for error in (source_error, stats_error) if error]
+    if len(source) < 2:
+        return [], [_error("not_enough_points", "Для zscore требуется минимум две точки.")]
+    mean = sum(float(value) for value in source) / len(source)
+    variance = sum((float(value) - mean) ** 2 for value in source) / len(source)
+    std = math.sqrt(variance)
+    if std == 0:
+        return [], [_error("zero_std", "Стандартное отклонение равно нулю; zscore невозможен.")]
+    return [(float(value) - mean) / std for value in values], []
+
+
+def apply_robust(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source = list(values if stats_values is None else stats_values)
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "robust требует конечные значения расчётного интервала.")
+    stats_error = _blocking_if_any_missing(source, "non_finite_result", "robust требует конечные значения области нормировки.")
+    if source_error or stats_error:
+        return [], [error for error in (source_error, stats_error) if error]
+    if len(source) < 2:
+        return [], [_error("not_enough_points", "Для robust-нормировки требуется минимум две точки.")]
+    numeric_source = [float(value) for value in source]
+    median_value = statistics.median(numeric_source)
+    q1, q3 = _quartiles(numeric_source)
+    iqr = q3 - q1
+    if iqr == 0:
+        return [], [_error("zero_iqr", "IQR равен нулю; robust-нормировка невозможна.")]
+    return [(float(value) - median_value) / iqr for value in values], []
+
+
+def apply_minmax(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    source = list(values if stats_values is None else stats_values)
+    source_error = _blocking_if_any_missing(values, "non_finite_result", "minmax требует конечные значения расчётного интервала.")
+    stats_error = _blocking_if_any_missing(source, "non_finite_result", "minmax требует конечные значения области нормировки.")
+    if source_error or stats_error:
+        return [], [error for error in (source_error, stats_error) if error]
+    min_value = min(float(value) for value in source)
+    max_value = max(float(value) for value in source)
+    value_range = max_value - min_value
+    if value_range == 0:
+        return [], [_error("zero_range", "Диапазон значений равен нулю; minmax невозможен.")]
+    return [(float(value) - min_value) / value_range for value in values], []
+
+
+def apply_unary_operation(
+    operation: str,
+    values: Sequence[float | None],
+    *,
+    step: float | None = None,
+    window: int = 3,
+    stats_values: Sequence[float | None] | None = None,
+) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    """Apply a stage-2 unary calculator operation as a pure function."""
+    normalized_operation = str(operation or "").strip().lower()
+    if normalized_operation == "log":
+        result = apply_log(values)
+    elif normalized_operation == "abs":
+        result = apply_abs(values)
+    elif normalized_operation == "sqrt":
+        result = apply_sqrt(values)
+    elif normalized_operation == "derivative":
+        result = apply_derivative(values, float(step or 0))
+    elif normalized_operation == "rolling_mean":
+        result = apply_rolling_mean(values, window)
+    elif normalized_operation == "rolling_median":
+        result = apply_rolling_median(values, window)
+    elif normalized_operation == "zscore":
+        result = apply_zscore(values, stats_values)
+    elif normalized_operation == "robust":
+        result = apply_robust(values, stats_values)
+    elif normalized_operation == "minmax":
+        result = apply_minmax(values, stats_values)
+    else:
+        return [], [_error("unsupported_operation", f"Операция '{operation}' не поддерживается.")]
+
+    result_values, errors = result
+    if errors:
+        return result_values, errors
+    non_finite_error = _non_finite_result_error(result_values)
+    if non_finite_error:
+        return [], [non_finite_error]
+    return result_values, []
+
+
+def _resolve_canonical(input_curve: FeatureCalculatorInput, db_session: Any) -> tuple[Any | None, FeatureCalculatorError | None]:
+    from models_db.model_cluster import CanonicalWellLog
+
+    query = db_session.query(CanonicalWellLog)
+    canonical = None
+    if input_curve.canonical_id is not None:
+        canonical = query.filter(CanonicalWellLog.id == int(input_curve.canonical_id)).first()
+    if canonical is None and input_curve.canonical_name:
+        canonical = query.filter(CanonicalWellLog.canonical_name_norm == input_curve.canonical_name.strip().casefold()).first()
+    if canonical is None:
+        label = input_curve.canonical_name or input_curve.canonical_id or "unknown"
+        return None, _error("missing_curve", f"Canonical-кривая '{label}' не найдена в справочнике.", canonical_name=str(label))
+    return canonical, None
+
+
+def _alias_names_for_canonical(canonical: Any, db_session: Any) -> set[str]:
+    from models_db.model_cluster import AliasWellLog
+
+    alias_rows = db_session.query(AliasWellLog.alias_name_norm).filter(AliasWellLog.canonical_id == canonical.id).all()
+    names = {str(row[0]).strip().casefold() for row in alias_rows if row[0]}
+    names.add(str(canonical.canonical_name).strip().casefold())
+    return names
+
+
+def _parse_curve_values(well_log: Any, canonical: Any) -> tuple[list[float | None], FeatureCalculatorError | None]:
+    if well_log.curve_data is None or str(well_log.curve_data).strip() == "":
+        return [], _error("empty_curve_data", f"Кривая '{well_log.curve_name}' не содержит curve_data.", canonical_name=canonical.canonical_name)
+    try:
+        raw_values = json.loads(well_log.curve_data)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        return [], _error("invalid_curve_json", f"curve_data кривой '{well_log.curve_name}' не является корректным JSON: {exc}", canonical_name=canonical.canonical_name)
+    if not isinstance(raw_values, list):
+        return [], _error("invalid_curve_json", f"curve_data кривой '{well_log.curve_name}' должен быть JSON-массивом.", canonical_name=canonical.canonical_name)
+    if not raw_values:
+        return [], _error("empty_curve_data", f"Кривая '{well_log.curve_name}' содержит пустой массив curve_data.", canonical_name=canonical.canonical_name)
+    return [_finite_float(value) for value in raw_values], None
+
+
+def _build_depths(begin: float, step: float, count: int) -> list[float]:
+    return [begin + index * step for index in range(count)]
+
+
+def _slice_curve(
+    depths: Sequence[float], values: Sequence[float | None], top_md: float, bottom_md: float
+) -> tuple[list[float], list[float | None]]:
+    sliced_depths: list[float] = []
+    sliced_values: list[float | None] = []
+    for depth, value in zip(depths, values):
+        if top_md <= depth <= bottom_md:
+            sliced_depths.append(float(depth))
+            sliced_values.append(value)
+    return sliced_depths, sliced_values
+
+
+def load_well_log_curve_series(
+    *,
+    well_id: int,
+    top_md: float,
+    bottom_md: float,
+    normalization_scope: str = FEATURE_CALCULATOR_DEFAULT_NORMALIZATION_SCOPE,
+    canonical_id: int | None = None,
+    canonical_name: str | None = None,
+    db_session: Any = None,
+) -> tuple[WellLogCurveSeries | None, list[FeatureCalculatorError]]:
+    """Resolve a canonical curve through aliases and load interval/statistics series for one well."""
+    from models_db.model import WellLog, session
+
+    if db_session is None:
+        db_session = session
+    input_curve = FeatureCalculatorInput(canonical_id=canonical_id, canonical_name=canonical_name)
+    canonical, canonical_error = _resolve_canonical(input_curve, db_session)
+    if canonical_error:
+        canonical_error.well_id = int(well_id)
+        return None, [canonical_error]
+
+    alias_names = _alias_names_for_canonical(canonical, db_session)
+    well_logs = db_session.query(WellLog).filter(WellLog.well_id == int(well_id)).all()
+    candidates = [row for row in well_logs if str(row.curve_name or "").strip().casefold() in alias_names]
+    if not candidates:
+        return None, [
+            _error(
+                "missing_curve",
+                f"В скважине id={well_id} не найдена кривая для canonical '{canonical.canonical_name}' с учётом алиасов.",
+                well_id=int(well_id),
+                canonical_name=canonical.canonical_name,
+            )
+        ]
+
+    candidate_errors: list[FeatureCalculatorError] = []
+    for well_log in candidates:
+        try:
+            begin = float(well_log.begin)
+            step = float(well_log.step)
+        except (TypeError, ValueError):
+            candidate_errors.append(_error("invalid_step", f"У кривой '{well_log.curve_name}' некорректные begin/step.", well_id=int(well_id), canonical_name=canonical.canonical_name))
+            continue
+        if step <= 0 or not math.isfinite(step):
+            candidate_errors.append(_error("invalid_step", f"У кривой '{well_log.curve_name}' неположительный или бесконечный step.", well_id=int(well_id), canonical_name=canonical.canonical_name))
+            continue
+        values, parse_error = _parse_curve_values(well_log, canonical)
+        if parse_error:
+            parse_error.well_id = int(well_id)
+            candidate_errors.append(parse_error)
+            continue
+        depths = _build_depths(begin, step, len(values))
+        interval_depths, interval_values = _slice_curve(depths, values, float(top_md), float(bottom_md))
+        if not interval_depths:
+            candidate_errors.append(_error("not_enough_points", f"В интервале [{top_md:g}, {bottom_md:g}] нет точек кривой '{well_log.curve_name}'.", well_id=int(well_id), canonical_name=canonical.canonical_name))
+            continue
+        stats_depths, stats_values = (depths, values) if normalization_scope == "whole_well" else (interval_depths, interval_values)
+        if normalization_scope not in FEATURE_CALCULATOR_NORMALIZATION_SCOPES:
+            return None, [_error("unsupported_normalization_scope", "Разрешены только normalization_scope=whole_well или interval.", well_id=int(well_id), canonical_name=canonical.canonical_name)]
+        return WellLogCurveSeries(
+            well_id=int(well_id),
+            canonical_id=int(canonical.id),
+            canonical_name=str(canonical.canonical_name),
+            depths=interval_depths,
+            values=interval_values,
+            step=step,
+            begin=begin,
+            end=float(well_log.end) if well_log.end is not None else depths[-1],
+            source_curve_name=str(well_log.curve_name or ""),
+            stats_depths=list(stats_depths),
+            stats_values=list(stats_values),
+        ), []
+
+    return None, candidate_errors or [_error("missing_curve", f"Не удалось загрузить кривая canonical '{canonical.canonical_name}'.", well_id=int(well_id), canonical_name=canonical.canonical_name)]
 
 
 def validate_feature_calculator_for_dataset(dataset_id: int, calculator_id: int) -> list[FeatureCalculatorError]:
@@ -238,19 +646,52 @@ def evaluate_feature_calculator_for_well(
     well_id: int,
     top_md: float,
     bottom_md: float,
+    *,
+    db_session: Any = None,
 ) -> FeatureCalculatorEvaluationResult:
-    """Stage-1 calculation placeholder that returns a controlled NotImplemented error."""
+    """Evaluate a stage-2 unary operation for one well and one interval."""
+    config_errors = validate_feature_calculator_config(config)
+    if config_errors:
+        return FeatureCalculatorEvaluationResult(errors=config_errors)
+    if config.mode != "operation":
+        return FeatureCalculatorEvaluationResult(
+            errors=[
+                _error(
+                    "unsupported_operation",
+                    "Formula mode будет реализован на следующем этапе; этап 2 поддерживает только mode=operation.",
+                    config.calculator_id,
+                    config.feature_name,
+                    well_id=int(well_id),
+                )
+            ]
+        )
+
+    input_curve = config.inputs[0]
+    series, load_errors = load_well_log_curve_series(
+        well_id=int(well_id),
+        canonical_id=input_curve.canonical_id,
+        canonical_name=input_curve.canonical_name,
+        top_md=float(top_md),
+        bottom_md=float(bottom_md),
+        normalization_scope=config.normalization_scope,
+        db_session=db_session,
+    )
+    if load_errors or series is None:
+        return FeatureCalculatorEvaluationResult(
+            errors=[_copy_error_context(error, config=config, well_id=int(well_id), canonical_name=input_curve.canonical_name) for error in load_errors]
+        )
+
+    window = config.raw_params.get("window", 3)
+    stats_values = series.stats_values if str(config.operation).lower() in {"zscore", "robust", "minmax"} else None
+    values, operation_errors = apply_unary_operation(
+        str(config.operation),
+        series.values,
+        step=series.step,
+        window=window,
+        stats_values=stats_values,
+    )
     return FeatureCalculatorEvaluationResult(
-        errors=[
-            FeatureCalculatorError(
-                code="not_implemented",
-                message=(
-                    "Расчёт Well Log признака ещё не реализован "
-                    f"для well_id={well_id}, interval=[{top_md:g}, {bottom_md:g}]."
-                ),
-                calculator_id=config.calculator_id,
-                feature_name=config.feature_name,
-                well_id=int(well_id),
-            )
-        ]
+        values=values,
+        depths=series.depths if not operation_errors else [],
+        errors=[_copy_error_context(error, config=config, series=series) for error in operation_errors],
     )

--- a/tests/test_well_feature_calculator_unary.py
+++ b/tests/test_well_feature_calculator_unary.py
@@ -1,0 +1,159 @@
+import importlib.util
+import math
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "cluster" / "well_feature_calculator.py"
+_SPEC = importlib.util.spec_from_file_location("well_feature_calculator", _MODULE_PATH)
+well_feature_calculator = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = well_feature_calculator
+_SPEC.loader.exec_module(well_feature_calculator)
+
+from well_feature_calculator import (
+    apply_abs,
+    apply_derivative,
+    apply_log,
+    apply_minmax,
+    apply_robust,
+    apply_rolling_mean,
+    apply_rolling_median,
+    apply_sqrt,
+    apply_unary_operation,
+    apply_zscore,
+)
+
+
+def assert_close_list(actual, expected, *, abs_tol=1e-9):
+    assert len(actual) == len(expected)
+    for actual_value, expected_value in zip(actual, expected):
+        assert math.isclose(actual_value, expected_value, abs_tol=abs_tol)
+
+
+def error_codes(errors):
+    return {error.code for error in errors}
+
+
+def test_log_positive_values():
+    values, errors = apply_log([1.0, math.e, math.e**2])
+
+    assert errors == []
+    assert_close_list(values, [0.0, 1.0, 2.0])
+
+
+@pytest.mark.parametrize("source", [[0.0, 1.0], [-1.0, 1.0]])
+def test_log_blocks_zero_and_negative_values(source):
+    values, errors = apply_log(source)
+
+    assert values == []
+    assert error_codes(errors) == {"invalid_math_domain"}
+
+
+def test_sqrt_positive_values():
+    values, errors = apply_sqrt([0.0, 4.0, 9.0])
+
+    assert errors == []
+    assert_close_list(values, [0.0, 2.0, 3.0])
+
+
+def test_sqrt_blocks_negative_values():
+    values, errors = apply_sqrt([1.0, -4.0])
+
+    assert values == []
+    assert error_codes(errors) == {"invalid_math_domain"}
+
+
+def test_abs_values():
+    values, errors = apply_abs([-2.0, 0.0, 3.0])
+
+    assert errors == []
+    assert_close_list(values, [2.0, 0.0, 3.0])
+
+
+def test_derivative_on_uniform_depth_grid():
+    values, errors = apply_derivative([0.0, 2.0, 6.0, 12.0], step=2.0)
+
+    assert errors == []
+    assert_close_list(values, [1.0, 1.5, 2.5, 3.0])
+
+
+def test_derivative_requires_two_points():
+    values, errors = apply_derivative([1.0], step=1.0)
+
+    assert values == []
+    assert error_codes(errors) == {"not_enough_points"}
+
+
+def test_rolling_mean_centered_window_with_edge_clamping():
+    values, errors = apply_rolling_mean([1.0, 2.0, 3.0, 4.0, 5.0], window=3)
+
+    assert errors == []
+    assert_close_list(values, [2.0, 2.0, 3.0, 4.0, 4.0])
+
+
+def test_rolling_median_centered_window_with_edge_clamping():
+    values, errors = apply_rolling_median([5.0, 1.0, 4.0, 2.0, 3.0], window=3)
+
+    assert errors == []
+    assert_close_list(values, [4.0, 4.0, 2.0, 3.0, 3.0])
+
+
+def test_zscore_uses_population_std():
+    values, errors = apply_zscore([1.0, 2.0, 3.0])
+
+    assert errors == []
+    assert_close_list(values, [-math.sqrt(1.5), 0.0, math.sqrt(1.5)])
+
+
+def test_zscore_can_use_separate_whole_well_stats():
+    values, errors = apply_zscore([2.0, 3.0], stats_values=[1.0, 2.0, 3.0])
+
+    assert errors == []
+    assert_close_list(values, [0.0, math.sqrt(1.5)])
+
+
+def test_robust_median_iqr_normalization():
+    values, errors = apply_robust([1.0, 2.0, 3.0, 4.0])
+
+    assert errors == []
+    assert_close_list(values, [-1.0, -1.0 / 3.0, 1.0 / 3.0, 1.0])
+
+
+def test_minmax_normalization():
+    values, errors = apply_minmax([2.0, 4.0, 6.0])
+
+    assert errors == []
+    assert_close_list(values, [0.0, 0.5, 1.0])
+
+
+@pytest.mark.parametrize(
+    ("operation", "function", "expected_code"),
+    [
+        ("zscore", apply_zscore, "zero_std"),
+        ("robust", apply_robust, "zero_iqr"),
+        ("minmax", apply_minmax, "zero_range"),
+    ],
+)
+def test_normalization_zero_stat_errors(operation, function, expected_code):
+    values, errors = function([5.0, 5.0, 5.0])
+
+    assert values == []
+    assert error_codes(errors) == {expected_code}
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), None])
+def test_nan_inf_and_none_block_calculation(bad_value):
+    values, errors = apply_unary_operation("abs", [1.0, bad_value])
+
+    assert values == []
+    assert error_codes(errors) == {"non_finite_result"}
+
+
+def test_unsupported_operation_error():
+    values, errors = apply_unary_operation("divide", [1.0, 2.0])
+
+    assert values == []
+    assert error_codes(errors) == {"unsupported_operation"}


### PR DESCRIPTION
### Motivation
- Реализовать backend-ядро этапа 2 конструктора расчётных признаков для Well Log: поддержка операций над одной canonical-кривой без formula mode. 
- Обеспечить безопасные pure-функции операций, строгую валидацию конфигурации и загрузку кривых с учётом алиасов. 

### Description
- Добавлен набор dataclass-структур и расширенная схема конфигурации в `cluster/well_feature_calculator.py`, включая `WellLogCurveSeries`, подробные `FeatureCalculatorError` и `FeatureCalculatorEvaluationResult`.
- Реализованы pure-функции унарных операций: `log`, `abs`, `sqrt`, `derivative`, `rolling_mean`, `rolling_median`, `zscore`, `robust`, `minmax`, а также общий `apply_unary_operation` с детализированными блокирующими ошибками.
- Добавлена функция загрузки и разрешения canonical-кривой `load_well_log_curve_series` с поддержкой алиасов, парсингом `curve_data`, построением глубинной сетки и выбором области статистики для `normalization_scope`.
- Обновлён `validate_feature_calculator_config` для ограничений этапа 2 и расширен `evaluate_feature_calculator_for_well`, чтобы загружать кривую и выполнять унарную операцию с учётом `window` и области нормировки.
- Добавлены unit-тесты в `tests/test_well_feature_calculator_unary.py` покрывающие успешные сценарии и ошибки (domain errors, zero-stat errors, non-finite inputs, unsupported operation).

### Testing
- Выполнена проверка компиляции: `python -m py_compile cluster/well_feature_calculator.py tests/test_well_feature_calculator_unary.py` (успешно).
- Запущены unit-тесты конкретного модуля: `pytest -q tests/test_well_feature_calculator_unary.py` — все тесты прошли (`21 passed`).
- Полный запуск `pytest -q` в текущем окружении не завершился из-за отсутствующих внешних зависимостей (`sqlalchemy`, `numpy`), что не относится к изменениям этого PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e98660980832fa2f21840ca1c248b)