### PR TITLE
Integrate Well Log calculator features into COLLECT

### DIFF
--- a/cluster/well_dataset.py
+++ b/cluster/well_dataset.py
@@ -920,7 +920,50 @@ def clear_all_wells_from_cluster_dataset() -> None:
 
 
 
+def _format_feature_calculator_error(error: Any) -> str:
+    feature_name = getattr(error, 'feature_name', None) or (
+        f"calculator_id={getattr(error, 'calculator_id', None)}" if getattr(error, 'calculator_id', None) is not None else 'calculator'
+    )
+    well_label = getattr(error, 'well_name', None) or (
+        f"well_id={getattr(error, 'well_id', None)}" if getattr(error, 'well_id', None) is not None else 'dataset'
+    )
+    canonical_name = getattr(error, 'canonical_name', None)
+    code = getattr(error, 'code', 'error')
+    message = getattr(error, 'message', str(error))
+    canonical_part = f" / {canonical_name}" if canonical_name else ''
+    return f"{feature_name} / {well_label}{canonical_part}: [{code}] {message}"
+
+
+def _show_calculator_collect_errors(errors: list[Any], *, title: str = 'COLLECT WELL LOG') -> None:
+    preview_limit = 10
+    preview_lines = [_format_feature_calculator_error(error) for error in errors[:preview_limit]]
+    suffix = ''
+    if len(errors) > preview_limit:
+        suffix = f"\n… ещё {len(errors) - preview_limit} ошибок; полный список записан в окно информации."
+    message = (
+        f"COLLECT WELL LOG заблокирован: {len(errors)} ошибки расчёта признаков.\n"
+        + "\n".join(f"{index}) {line}" for index, line in enumerate(preview_lines, start=1))
+        + suffix
+    )
+    full_log = (
+        f"COLLECT WELL LOG заблокирован: {len(errors)} ошибки расчёта признаков.\n"
+        + "\n".join(
+            f"{index}) {_format_feature_calculator_error(error)}"
+            for index, error in enumerate(errors, start=1)
+        )
+    )
+    QMessageBox.critical(MainWindow, title, message)
+    set_info(full_log.replace('\n', '<br>'), 'red')
+
+
 def collect_cluster_well_log_dataset_data() -> None:
+    from .well_feature_calculator import (
+        FeatureCalculatorError,
+        evaluate_feature_calculator_for_well,
+        parse_feature_calculator_config,
+        validate_calculators_for_dataset,
+    )
+
     combo = getattr(ui, 'comboBox_cluster_well_set', None)
     if combo is None:
         return
@@ -936,15 +979,22 @@ def collect_cluster_well_log_dataset_data() -> None:
         QMessageBox.critical(MainWindow, 'COLLECT WELL LOG', 'В наборе нет скважин для сборки data.')
         return
 
-    params = (
+    canonical_params = (
         session.query(ClusterWellLogParameter)
         .join(CanonicalWellLog, CanonicalWellLog.id == ClusterWellLogParameter.canonical_id)
         .filter(ClusterWellLogParameter.dataset_id == dataset_id)
         .order_by(CanonicalWellLog.canonical_name)
         .all()
     )
-    if not params:
-        QMessageBox.critical(MainWindow, 'COLLECT WELL LOG', 'В наборе нет выбранных параметров каротажа.')
+    calculator_params = (
+        session.query(ClusterWellLogParameterFromCalculator)
+        .filter(ClusterWellLogParameterFromCalculator.dataset_id == dataset_id)
+        .join(FeatureCalculator, FeatureCalculator.id == ClusterWellLogParameterFromCalculator.calculator_id)
+        .order_by(FeatureCalculator.feature_name, FeatureCalculator.id)
+        .all()
+    )
+    if not canonical_params and not calculator_params:
+        QMessageBox.critical(MainWindow, 'COLLECT WELL LOG', 'В наборе нет выбранных canonical или calculator параметров каротажа.')
         return
 
     wells_without_interval = [row.well.name if row.well else str(row.well_id) for row in wells if row.top_md >= row.bottom_md]
@@ -952,18 +1002,37 @@ def collect_cluster_well_log_dataset_data() -> None:
         QMessageBox.warning(MainWindow, 'COLLECT WELL LOG', 'У части скважин некорректные интервалы. Исправьте интервалы и повторите.')
         return
 
+    preflight_errors = validate_calculators_for_dataset(dataset_id, db_session=session)
+    if preflight_errors:
+        _show_calculator_collect_errors(preflight_errors)
+        _set_cluster_well_collect_button_state(False)
+        return
+
+    calculator_configs = []
+    for row in calculator_params:
+        if row.calculator is None:
+            continue
+        config, parse_errors = parse_feature_calculator_config(row.calculator)
+        if parse_errors:
+            _show_calculator_collect_errors(parse_errors)
+            _set_cluster_well_collect_button_state(False)
+            return
+        if config is not None:
+            calculator_configs.append((row.calculator, config))
+
     aliases = session.query(AliasWellLog.alias_name_norm, AliasWellLog.canonical_id).all()
     alias_to_canonical = {str(name): int(cid) for name, cid in aliases}
 
-    log_feature_columns = [row.canonical_name.canonical_name for row in params if row.canonical_name]
-    columns = ['well_id_depth', WELL_LOG_CLUSTER_SAMPLE_INDEX_FEATURE_NAME] + log_feature_columns
+    canonical_feature_columns = [row.canonical_name.canonical_name for row in canonical_params if row.canonical_name]
+    calculator_feature_columns = [row.calculator.feature_name for row in calculator_params if row.calculator]
+    columns = ['well_id_depth', WELL_LOG_CLUSTER_SAMPLE_INDEX_FEATURE_NAME] + canonical_feature_columns + calculator_feature_columns
     rows = [columns]
+    collect_errors: list[Any] = []
 
     for wf in wells:
         top_md = float(wf.top_md)
         bottom_md = float(wf.bottom_md)
-        # сбор по глубине
-        depth_map = {}
+        depth_map: dict[float, dict[int, Any]] = {}
         for wl in session.query(WellLog).filter(WellLog.well_id == wf.well_id).all():
             if wl.curve_data is None or wl.step in (None, 0):
                 continue
@@ -985,25 +1054,76 @@ def collect_cluster_well_log_dataset_data() -> None:
                 if depth < top_md or depth > bottom_md:
                     continue
                 rounded_depth = round(depth, 6)
-                key = (rounded_depth)
-                if key not in depth_map:
-                    depth_map[key] = {}
-                depth_map[key][canonical_id] = value
+                depth_map.setdefault(rounded_depth, {})[canonical_id] = value
 
-        for sample_index, depth in enumerate(sorted(depth_map.keys())):
+        calculator_value_map: dict[float, dict[int, Any]] = {}
+        for calculator, config in calculator_configs:
+            result = evaluate_feature_calculator_for_well(
+                config,
+                well_id=int(wf.well_id),
+                top_md=top_md,
+                bottom_md=bottom_md,
+                db_session=session,
+            )
+            if result.errors:
+                collect_errors.extend(result.errors)
+                continue
+            for depth, value in zip(result.depths, result.values):
+                calculator_value_map.setdefault(round(float(depth), 6), {})[int(calculator.id)] = value
+
+        combined_depths = sorted(set(depth_map.keys()) | set(calculator_value_map.keys()))
+        for depth in combined_depths:
+            calculator_values = calculator_value_map.get(depth, {})
+            missing_calculators = [
+                calculator.feature_name
+                for calculator, _config in calculator_configs
+                if int(calculator.id) not in calculator_values
+            ]
+            if missing_calculators:
+                well_name = wf.well.name if wf.well and wf.well.name else f'well_id={wf.well_id}'
+                collect_errors.append(
+                    FeatureCalculatorError(
+                        code='missing_calculator_value_at_depth',
+                        message=(
+                            f"Нет значения calculator-признаков {', '.join(missing_calculators)} "
+                            f"на глубине {depth:g}; строки с неполным набором выбранных calculator-признаков запрещены."
+                        ),
+                        feature_name=', '.join(missing_calculators),
+                        well_id=int(wf.well_id),
+                        well_name=well_name,
+                    )
+                )
+
+        if collect_errors:
+            continue
+
+        for sample_index, depth in enumerate(combined_depths):
             line = [f"{int(wf.well_id)}_{depth:g}", sample_index]
-            values_by_canonical = depth_map[depth]
-            for param in params:
+            values_by_canonical = depth_map.get(depth, {})
+            for param in canonical_params:
                 line.append(values_by_canonical.get(param.canonical_id, None))
+            values_by_calculator = calculator_value_map.get(depth, {})
+            for calculator, _config in calculator_configs:
+                line.append(values_by_calculator.get(int(calculator.id)))
             rows.append(line)
+
+    if collect_errors:
+        _show_calculator_collect_errors(collect_errors)
+        _set_cluster_well_collect_button_state(False)
+        return
 
     _invalidate_cluster_well_dataset_data(dataset_id)
     session.add(WellLogClusterDatasetData(dataset_id=dataset_id, data=_serialize_cluster_dataset(rows)))
     session.commit()
     _set_cluster_well_collect_button_state(True)
+    row_count = max(0, len(rows) - 1)
+    canonical_count = len(canonical_feature_columns)
+    calculator_count = len(calculator_feature_columns)
+    total_feature_count = len(columns) - 1
     set_info(
-        f'COLLECT WELL LOG: собрано строк {max(0, len(rows)-1)} и признаков {len(columns)-1} '
-        f'(включая {WELL_LOG_CLUSTER_SAMPLE_INDEX_FEATURE_NAME}).',
+        f'COLLECT WELL LOG: собрано строк {row_count}, canonical признаков {canonical_count}, '
+        f'calculator признаков {calculator_count}, всего признаков {total_feature_count} '
+        f'включая {WELL_LOG_CLUSTER_SAMPLE_INDEX_FEATURE_NAME}.',
         'green'
     )
 

--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -900,19 +900,103 @@ def load_input_series_for_calculator(
     return series_list, errors
 
 
-def validate_feature_calculator_for_dataset(dataset_id: int, calculator_id: int) -> list[FeatureCalculatorError]:
-    """Stage-1 dataset applicability placeholder; real checks are implemented later."""
-    return [
-        FeatureCalculatorError(
-            code="not_implemented",
-            message=(
-                "Проверка применимости расчётного признака к Well Log dataset "
-                f"id={dataset_id} ещё не реализована."
-            ),
-            calculator_id=int(calculator_id),
-            severity="warning",
+def _attach_well_context(error: FeatureCalculatorError, well_row: Any) -> FeatureCalculatorError:
+    well_id = getattr(well_row, "well_id", None)
+    well = getattr(well_row, "well", None)
+    well_name = getattr(well, "name", None) if well is not None else None
+    return FeatureCalculatorError(
+        code=error.code,
+        message=error.message,
+        calculator_id=error.calculator_id,
+        feature_name=error.feature_name,
+        well_id=int(well_id) if well_id is not None else error.well_id,
+        well_name=str(well_name) if well_name else error.well_name,
+        canonical_name=error.canonical_name,
+        severity=error.severity,
+    )
+
+
+def validate_calculators_for_dataset(
+    dataset_id: int,
+    *,
+    calculator_ids: Sequence[int] | None = None,
+    db_session: Any = None,
+) -> list[FeatureCalculatorError]:
+    """Fully validate selected calculated features for every well/interval in a dataset.
+
+    The validation intentionally performs a real evaluation pass for each selected
+    calculator and each dataset well interval.  This preflight is used by COLLECT
+    so calculation errors are reported before any previous dataset ``data`` row is
+    deleted or replaced.
+    """
+    from models_db.model import session
+    from models_db.model_cluster import (
+        ClusterWellLogParameterFromCalculator,
+        FeatureCalculator,
+        WellForCluster,
+    )
+
+    if db_session is None:
+        db_session = session
+
+    well_rows = (
+        db_session.query(WellForCluster)
+        .filter(WellForCluster.dataset_id == int(dataset_id))
+        .order_by(WellForCluster.well_id)
+        .all()
+    )
+    if not well_rows:
+        return [
+            _error(
+                "empty_dataset_wells",
+                f"В Well Log dataset id={int(dataset_id)} нет скважин для проверки calculator-признаков.",
+            )
+        ]
+
+    query = (
+        db_session.query(FeatureCalculator)
+        .join(
+            ClusterWellLogParameterFromCalculator,
+            ClusterWellLogParameterFromCalculator.calculator_id == FeatureCalculator.id,
         )
-    ]
+        .filter(ClusterWellLogParameterFromCalculator.dataset_id == int(dataset_id))
+    )
+    if calculator_ids is not None:
+        normalized_ids = [int(calculator_id) for calculator_id in calculator_ids]
+        if not normalized_ids:
+            return []
+        query = query.filter(FeatureCalculator.id.in_(normalized_ids))
+    calculators = query.order_by(FeatureCalculator.feature_name, FeatureCalculator.id).all()
+    if not calculators:
+        return []
+
+    errors: list[FeatureCalculatorError] = []
+    for calculator in calculators:
+        config, parse_errors = parse_feature_calculator_config(calculator)
+        if parse_errors:
+            errors.extend(parse_errors)
+        if config is None:
+            continue
+        config_errors = validate_feature_calculator_config(config)
+        if config_errors:
+            errors.extend(config_errors)
+            continue
+        for well_row in well_rows:
+            result = evaluate_feature_calculator_for_well(
+                config,
+                well_id=int(well_row.well_id),
+                top_md=float(well_row.top_md),
+                bottom_md=float(well_row.bottom_md),
+                db_session=db_session,
+            )
+            if result.errors:
+                errors.extend(_attach_well_context(error, well_row) for error in result.errors)
+    return errors
+
+
+def validate_feature_calculator_for_dataset(dataset_id: int, calculator_id: int) -> list[FeatureCalculatorError]:
+    """Validate one calculated feature against all wells/intervals of a dataset."""
+    return validate_calculators_for_dataset(int(dataset_id), calculator_ids=[int(calculator_id)])
 
 
 def evaluate_feature_calculator_for_well(

--- a/tests/test_well_feature_calculator_dataset_validation.py
+++ b/tests/test_well_feature_calculator_dataset_validation.py
@@ -1,0 +1,162 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "cluster" / "well_feature_calculator.py"
+_SPEC = importlib.util.spec_from_file_location("well_feature_calculator_dataset", _MODULE_PATH)
+well_feature_calculator = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = well_feature_calculator
+_SPEC.loader.exec_module(well_feature_calculator)
+
+from well_feature_calculator_dataset import validate_calculators_for_dataset
+
+
+class Field:
+    def __init__(self, name):
+        self.name = name
+
+    def __eq__(self, other):
+        return ("eq", self.name, other)
+
+    def in_(self, values):
+        return ("in", self.name, values)
+
+
+class Query:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def join(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return list(self.rows)
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+
+class FakeSession:
+    def __init__(self, *, values):
+        self.canonical = types.SimpleNamespace(id=1, canonical_name="GR", canonical_name_norm="gr")
+        self.well = types.SimpleNamespace(id=7, name="Well-1")
+        self.well_for_cluster = types.SimpleNamespace(
+            dataset_id=3,
+            well_id=self.well.id,
+            top_md=100.0,
+            bottom_md=100.2,
+            well=self.well,
+        )
+        self.well_log = types.SimpleNamespace(
+            well_id=self.well.id,
+            curve_name="GR",
+            curve_data=json.dumps(values),
+            begin=100.0,
+            end=100.2,
+            step=0.1,
+        )
+        self.calculator = types.SimpleNamespace(
+            id=11,
+            feature_name="LOG_GR",
+            expression=None,
+            transform_type="log",
+            params_json=json.dumps(
+                {
+                    "version": 1,
+                    "mode": "operation",
+                    "operation": "log",
+                    "inputs": [{"canonical_id": 1, "canonical_name": "GR"}],
+                    "normalization_scope": "whole_well",
+                    "outlier_policy": "none",
+                }
+            ),
+        )
+
+    def query(self, *entities):
+        first = entities[0]
+        name = getattr(first, "__name__", None)
+        if name == "WellForCluster":
+            return Query([self.well_for_cluster])
+        if name == "FeatureCalculator":
+            return Query([self.calculator])
+        if name == "CanonicalWellLog":
+            return Query([self.canonical])
+        if name == "WellLog":
+            return Query([self.well_log])
+        # AliasWellLog.alias_name_norm projection.
+        if getattr(first, "name", None) == "alias_name_norm":
+            return Query([("gr",)])
+        return Query([])
+
+
+def install_fake_model_modules(fake_session, monkeypatch):
+    model = types.ModuleType("models_db.model")
+    model.session = fake_session
+
+    class WellLog:
+        well_id = Field("well_id")
+
+    model.WellLog = WellLog
+
+    model_cluster = types.ModuleType("models_db.model_cluster")
+
+    class WellForCluster:
+        dataset_id = Field("dataset_id")
+        well_id = Field("well_id")
+
+    class ClusterWellLogParameterFromCalculator:
+        dataset_id = Field("dataset_id")
+        calculator_id = Field("calculator_id")
+
+    class FeatureCalculator:
+        id = Field("id")
+        feature_name = Field("feature_name")
+
+    class CanonicalWellLog:
+        id = Field("id")
+        canonical_name_norm = Field("canonical_name_norm")
+
+    class AliasWellLog:
+        alias_name_norm = Field("alias_name_norm")
+        canonical_id = Field("canonical_id")
+
+    model_cluster.WellForCluster = WellForCluster
+    model_cluster.ClusterWellLogParameterFromCalculator = ClusterWellLogParameterFromCalculator
+    model_cluster.FeatureCalculator = FeatureCalculator
+    model_cluster.CanonicalWellLog = CanonicalWellLog
+    model_cluster.AliasWellLog = AliasWellLog
+
+    package = types.ModuleType("models_db")
+    monkeypatch.setitem(sys.modules, "models_db", package)
+    monkeypatch.setitem(sys.modules, "models_db.model", model)
+    monkeypatch.setitem(sys.modules, "models_db.model_cluster", model_cluster)
+
+
+def test_validate_calculators_for_dataset_accepts_valid_selected_calculator(monkeypatch):
+    fake_session = FakeSession(values=[1.0, 2.0, 3.0])
+    install_fake_model_modules(fake_session, monkeypatch)
+
+    errors = validate_calculators_for_dataset(3, db_session=fake_session)
+
+    assert errors == []
+
+
+def test_validate_calculators_for_dataset_reports_preflight_math_error(monkeypatch):
+    fake_session = FakeSession(values=[1.0, 0.0, 3.0])
+    install_fake_model_modules(fake_session, monkeypatch)
+
+    errors = validate_calculators_for_dataset(3, db_session=fake_session)
+
+    assert {error.code for error in errors} == {"invalid_math_domain"}
+    assert errors[0].feature_name == "LOG_GR"
+    assert errors[0].well_name == "Well-1"


### PR DESCRIPTION
### Motivation
- Add selected global calculated (calculator) Well Log features into the existing `COLLECT` flow so they participate in final dataset assembly. 
- Perform a full preflight validation of all selected calculators across every well/interval to surface calculation errors before replacing existing `data` rows. 
- Ensure stable column ordering and strict blocking semantics when calculator values are missing or produce invalid math results.

### Description
- Implemented dataset-level preflight validation: added `validate_calculators_for_dataset` and helper `_attach_well_context` in `cluster/well_feature_calculator.py` to parse, validate and trial-evaluate each selected `FeatureCalculator` for every well/interval. 
- Extended `collect_cluster_well_log_dataset_data()` in `cluster/well_dataset.py` to load `ClusterWellLogParameterFromCalculator` / `FeatureCalculator`, run the preflight, evaluate calculators per-well, and merge calculator values into the collected rows using a stable column order (`well_id_depth`, `sample_index_in_well`, canonical columns, calculator columns). 
- Enforced strict blocking rules so `COLLECT` aborts (without deleting previous `data`) when any calculator or point-level error occurs or when a calculator lacks a value for a depth row; added user-visible error formatting `_format_feature_calculator_error` and `_show_calculator_collect_errors`. 
- Added unit tests `tests/test_well_feature_calculator_dataset_validation.py` covering successful validation and a math-domain preflight failure for `log`, and adjusted collection to report counts of canonical/calculator features in the success message.

### Testing
- Ran targeted unit tests with `pytest -q tests/test_well_feature_calculator_dataset_validation.py tests/test_well_feature_calculator_formula.py tests/test_well_feature_calculator_unary.py`, all targeted tests passed (`32 passed`).
- Verified modules compile with `python -m py_compile cluster/well_dataset.py cluster/well_feature_calculator.py` which succeeded. 
- Ran full `pytest -q` but collection aborted due to missing environment dependencies (`sqlalchemy`, `numpy`) unrelated to the new changes, so unrelated tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eac3e3904832f89ca851b7d31cf46)