### PR TITLE
Add coverage/diagnostics and preview to Well Log feature constructor

### DIFF
--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -19,6 +19,29 @@ FEATURE_CALCULATOR_DEPTH_PRECISION = 6
 FEATURE_CALCULATOR_STEP_TOLERANCE = 1e-9
 FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS = {"log", "abs", "sqrt"}
 
+
+
+FEATURE_CALCULATOR_STATUS_LABELS = {
+    "missing_curve": "Missing curve",
+    "depth_grid_mismatch": "Depth grid mismatch",
+    "invalid_math_domain": "Invalid math domain",
+    "invalid_log_domain": "Invalid math domain",
+    "invalid_sqrt_domain": "Invalid math domain",
+    "not_enough_points": "Not enough points",
+    "non_finite_result": "Non-finite result",
+}
+
+FEATURE_CALCULATOR_RECOMMENDATIONS = {
+    "missing_curve": "Проверьте, что нужная canonical-кривая или её alias загружены во всех скважинах текущего dataset.",
+    "depth_grid_mismatch": "Проверьте, что входные кривые загружены с одинаковым шагом и одинаковой глубинной сеткой. Интерполяция в текущей версии калькулятора не выполняется.",
+    "invalid_math_domain": "Проверьте область определения операции: log требует X > 0, sqrt требует X >= 0.",
+    "invalid_log_domain": "Проверьте область определения log: все значения должны быть больше нуля.",
+    "invalid_sqrt_domain": "Проверьте область определения sqrt: все значения должны быть неотрицательными.",
+    "division_by_zero": "Измените формулу или входные кривые так, чтобы знаменатель не обращался в ноль на выбранном интервале.",
+    "not_enough_points": "Расширьте интервал или выберите кривую, где достаточно точек для операции.",
+    "non_finite_result": "Проверьте входные значения и параметры операции: результат не должен содержать NaN или inf.",
+}
+
 FEATURE_CALCULATOR_UNARY_OPERATIONS = {
     "log",
     "abs",
@@ -115,6 +138,52 @@ class WellLogCurveSeries:
     source_curve_name: str
     stats_depths: list[float] = field(default_factory=list)
     stats_values: list[float | None] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class FeatureCalculatorCoverageRow:
+    """Dataset coverage diagnostics for one well and one calculator feature."""
+
+    well_id: int
+    well_name: str | None
+    top_md: float
+    bottom_md: float
+    status: str
+    points: int = 0
+    errors: list[FeatureCalculatorError] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and self.status == "OK"
+
+
+@dataclass(slots=True)
+class FeatureCalculatorCoverageSummary:
+    """Aggregated applicability summary for a calculator feature in one dataset."""
+
+    dataset_id: int
+    calculator_id: int | None
+    feature_name: str | None
+    wells_total: int
+    wells_ok: int
+    error_count: int
+    min_points: int | None
+    max_points: int | None
+    input_curves: list[str]
+    mode: str
+    normalization_scope: str
+
+    @property
+    def can_be_added(self) -> bool:
+        return self.wells_total > 0 and self.error_count == 0 and self.wells_ok == self.wells_total
+
+
+@dataclass(slots=True)
+class FeatureCalculatorCoverageReport:
+    """Full dataset-level diagnostics report for one calculator feature."""
+
+    summary: FeatureCalculatorCoverageSummary
+    rows: list[FeatureCalculatorCoverageRow] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -928,6 +997,96 @@ def _attach_well_context(error: FeatureCalculatorError, well_row: Any) -> Featur
         canonical_name=error.canonical_name,
         severity=error.severity,
     )
+
+
+def feature_calculator_status_for_errors(errors: Sequence[FeatureCalculatorError]) -> str:
+    """Return a concise user-facing coverage status for calculator errors."""
+    if not errors:
+        return "OK"
+    code = errors[0].code
+    return FEATURE_CALCULATOR_STATUS_LABELS.get(code, str(code).replace("_", " ").title())
+
+
+def feature_calculator_recommendation(error: FeatureCalculatorError | None) -> str:
+    """Return a short operator recommendation for a detailed diagnostic error."""
+    if error is None:
+        return "Расчётный признак успешно рассчитывается для выбранной скважины."
+    return FEATURE_CALCULATOR_RECOMMENDATIONS.get(
+        error.code,
+        "Проверьте параметры признака, входные canonical-кривые и выбранный интервал скважины.",
+    )
+
+
+def _config_input_names(config: FeatureCalculatorConfig) -> list[str]:
+    names: list[str] = []
+    for input_curve in config.inputs:
+        label = input_curve.canonical_name or (f"canonical_id={input_curve.canonical_id}" if input_curve.canonical_id is not None else "unknown")
+        names.append(str(label))
+    return names
+
+
+def build_feature_calculator_coverage_report(
+    dataset_id: int,
+    config: FeatureCalculatorConfig,
+    *,
+    db_session: Any = None,
+) -> FeatureCalculatorCoverageReport:
+    """Evaluate one calculator feature against every dataset well and summarize coverage.
+
+    This helper is intentionally read-only: it performs the same strict backend
+    evaluation as COLLECT preflight but returns per-well rows suitable for the
+    constructor UI coverage report and preview diagnostics.
+    """
+    from models_db.model import session
+    from models_db.model_cluster import WellForCluster
+
+    if db_session is None:
+        db_session = session
+
+    well_rows = (
+        db_session.query(WellForCluster)
+        .filter(WellForCluster.dataset_id == int(dataset_id))
+        .order_by(WellForCluster.well_id)
+        .all()
+    )
+    rows: list[FeatureCalculatorCoverageRow] = []
+    for well_row in well_rows:
+        result = evaluate_feature_calculator_for_well(
+            config,
+            well_id=int(well_row.well_id),
+            top_md=float(well_row.top_md),
+            bottom_md=float(well_row.bottom_md),
+            db_session=db_session,
+        )
+        attached_errors = [_attach_well_context(error, well_row) for error in result.errors]
+        rows.append(
+            FeatureCalculatorCoverageRow(
+                well_id=int(well_row.well_id),
+                well_name=getattr(getattr(well_row, "well", None), "name", None),
+                top_md=float(well_row.top_md),
+                bottom_md=float(well_row.bottom_md),
+                status=feature_calculator_status_for_errors(attached_errors),
+                points=len(result.depths) if result.ok else 0,
+                errors=attached_errors,
+            )
+        )
+
+    ok_points = [row.points for row in rows if row.ok]
+    error_count = sum(len(row.errors) for row in rows)
+    summary = FeatureCalculatorCoverageSummary(
+        dataset_id=int(dataset_id),
+        calculator_id=config.calculator_id,
+        feature_name=config.feature_name,
+        wells_total=len(rows),
+        wells_ok=sum(1 for row in rows if row.ok),
+        error_count=error_count,
+        min_points=min(ok_points) if ok_points else None,
+        max_points=max(ok_points) if ok_points else None,
+        input_curves=_config_input_names(config),
+        mode=config.mode,
+        normalization_scope=config.normalization_scope,
+    )
+    return FeatureCalculatorCoverageReport(summary=summary, rows=rows)
 
 
 def validate_calculators_for_dataset(

--- a/qt/well_log_feature_constructor_form.py
+++ b/qt/well_log_feature_constructor_form.py
@@ -4,6 +4,8 @@ import json
 from typing import Any, Callable
 
 from PyQt5 import QtCore, QtGui, QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 
 from cluster.well_feature_calculator import (
     FEATURE_CALCULATOR_DEFAULT_OUTLIER_POLICY,
@@ -11,7 +13,10 @@ from cluster.well_feature_calculator import (
     FEATURE_CALCULATOR_INVALID_MATH_POLICY,
     FEATURE_CALCULATOR_NORMALIZATION_SCOPES,
     FEATURE_CALCULATOR_UNARY_OPERATIONS,
+    build_feature_calculator_coverage_report,
+    evaluate_feature_calculator_for_well,
     extract_formula_input_names,
+    feature_calculator_recommendation,
     parse_feature_calculator_config,
     parse_safe_formula,
     validate_feature_calculator_config,
@@ -70,10 +75,11 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
         self.collect_state_callback = collect_state_callback
         self.info_callback = info_callback
         self._selected_feature_id: int | None = None
+        self._coverage_rows: list[Any] = []
 
         self.setObjectName("WellLogFeatureConstructorDialog")
         self.setWindowTitle("Well Log Feature Constructor")
-        self.resize(1100, 720)
+        self.resize(1280, 860)
         self._setup_ui()
         self._fill_dataset_context()
         self._fill_input_curves()
@@ -204,6 +210,10 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
         self.pushButton_save.setObjectName("pushButton_well_log_constructor_save")
         self.pushButton_save.clicked.connect(self._save_feature_clicked)
         validation_buttons_layout.addWidget(self.pushButton_save)
+        self.pushButton_preview = QtWidgets.QPushButton("Preview", create_group)
+        self.pushButton_preview.setObjectName("pushButton_well_log_constructor_preview")
+        self.pushButton_preview.clicked.connect(self._preview_current_definition)
+        validation_buttons_layout.addWidget(self.pushButton_preview)
         create_layout.addRow(validation_buttons_layout)
 
         self.textEdit_validation = QtWidgets.QTextEdit(create_group)
@@ -246,6 +256,46 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
         actions_layout.addWidget(self.pushButton_remove_from_dataset)
         definition_layout.addLayout(actions_layout)
         right_layout.addWidget(definition_group, stretch=1)
+
+        diagnostics_group = QtWidgets.QGroupBox("Coverage, diagnostics and preview", right_widget)
+        diagnostics_layout = QtWidgets.QVBoxLayout(diagnostics_group)
+        self.label_coverage_summary = QtWidgets.QLabel(diagnostics_group)
+        self.label_coverage_summary.setObjectName("label_well_log_constructor_coverage_summary")
+        self.label_coverage_summary.setWordWrap(True)
+        diagnostics_layout.addWidget(self.label_coverage_summary)
+
+        self.table_coverage = QtWidgets.QTableWidget(diagnostics_group)
+        self.table_coverage.setObjectName("tableWidget_well_log_constructor_coverage")
+        self.table_coverage.setColumnCount(4)
+        self.table_coverage.setHorizontalHeaderLabels(["Well", "Status", "Points", "Errors"])
+        self.table_coverage.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
+        self.table_coverage.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.table_coverage.itemSelectionChanged.connect(self._coverage_selection_changed)
+        diagnostics_layout.addWidget(self.table_coverage, stretch=1)
+
+        self.textEdit_error_detail = QtWidgets.QTextEdit(diagnostics_group)
+        self.textEdit_error_detail.setObjectName("textEdit_well_log_constructor_error_detail")
+        self.textEdit_error_detail.setReadOnly(True)
+        self.textEdit_error_detail.setMaximumHeight(115)
+        diagnostics_layout.addWidget(self.textEdit_error_detail)
+
+        preview_controls = QtWidgets.QHBoxLayout()
+        preview_controls.addWidget(QtWidgets.QLabel("Preview well", diagnostics_group))
+        self.comboBox_preview_well = QtWidgets.QComboBox(diagnostics_group)
+        self.comboBox_preview_well.setObjectName("comboBox_well_log_constructor_preview_well")
+        self.comboBox_preview_well.currentIndexChanged.connect(self._preview_selected_feature)
+        preview_controls.addWidget(self.comboBox_preview_well, stretch=1)
+        self.pushButton_preview_selected = QtWidgets.QPushButton("Preview selected", diagnostics_group)
+        self.pushButton_preview_selected.setObjectName("pushButton_well_log_constructor_preview_selected")
+        self.pushButton_preview_selected.clicked.connect(self._preview_selected_feature)
+        preview_controls.addWidget(self.pushButton_preview_selected)
+        diagnostics_layout.addLayout(preview_controls)
+
+        self.preview_figure = Figure(figsize=(4.8, 3.2))
+        self.preview_canvas = FigureCanvas(self.preview_figure)
+        self.preview_canvas.setObjectName("canvas_well_log_constructor_preview")
+        diagnostics_layout.addWidget(self.preview_canvas, stretch=1)
+        right_layout.addWidget(diagnostics_group, stretch=3)
 
         splitter.addWidget(left_widget)
         splitter.addWidget(right_widget)
@@ -291,6 +341,18 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
             QtWidgets.QTreeWidgetItem(calculators_item, [str(feature.get("feature_name")), str(feature.get("calculator_id"))])
         self.tree_dataset_context.addTopLevelItem(calculators_item)
         self.tree_dataset_context.expandAll()
+        if hasattr(self, "comboBox_preview_well"):
+            current_well_id = self.comboBox_preview_well.currentData()
+            self.comboBox_preview_well.blockSignals(True)
+            self.comboBox_preview_well.clear()
+            for well in self.wells:
+                label = f"{well.get('name', well.get('id'))} [{well.get('top_md', '')} - {well.get('bottom_md', '')}]"
+                self.comboBox_preview_well.addItem(str(label), int(well.get("id")))
+            if current_well_id is not None:
+                index = self.comboBox_preview_well.findData(current_well_id)
+                if index >= 0:
+                    self.comboBox_preview_well.setCurrentIndex(index)
+            self.comboBox_preview_well.blockSignals(False)
 
     def _fill_input_curves(self) -> None:
         self.comboBox_input_curve.clear()
@@ -627,6 +689,11 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
         if not selected:
             self._selected_feature_id = None
             self.textEdit_definition.clear()
+            self._coverage_rows = []
+            if hasattr(self, "table_coverage"):
+                self.table_coverage.setRowCount(0)
+                self.label_coverage_summary.setText(self._coverage_summary_text(None))
+                self.textEdit_error_detail.clear()
             return
         row = selected[0].row()
         id_item = self.table_global_features.item(row, 0)
@@ -681,6 +748,167 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
             lines.append("Errors:")
             lines.extend(f"- [{error.code}] {error.message}" for error in parse_errors)
         self.textEdit_definition.setPlainText("\n".join(lines))
+        self._refresh_selected_feature_diagnostics(feature, config, parse_errors)
+
+    def _status_error_count_text(self, errors: list[Any]) -> str:
+        if not errors:
+            return ""
+        return "; ".join(f"[{getattr(error, 'code', 'error')}] {getattr(error, 'message', str(error))}" for error in errors[:2])
+
+    def _coverage_summary_text(self, report: Any | None) -> str:
+        if report is None:
+            return "Select a saved feature to calculate coverage report. Preview can also be built for the unsaved form definition."
+        summary = report.summary
+        points = "—" if summary.min_points is None else f"{summary.min_points} / {summary.max_points}"
+        inputs = ", ".join(summary.input_curves) or "—"
+        can_add = "YES" if summary.can_be_added else "NO"
+        return (
+            f"Wells: {summary.wells_total}; OK: {summary.wells_ok}; Errors: {summary.error_count}; "
+            f"Min/Max points: {points}; Inputs: {inputs}; Mode: {summary.mode}; "
+            f"Normalization: {summary.normalization_scope}; Can be added to dataset: {can_add}"
+        )
+
+    def _refresh_selected_feature_diagnostics(self, feature: FeatureCalculator, config: Any | None, parse_errors: list[Any]) -> None:
+        self._coverage_rows = []
+        self.table_coverage.setRowCount(0)
+        self.textEdit_error_detail.clear()
+        if parse_errors or config is None:
+            self.label_coverage_summary.setText("Coverage unavailable: selected feature definition has parse errors.")
+            self.pushButton_add_to_dataset.setEnabled(False)
+            return
+        report = build_feature_calculator_coverage_report(self.dataset_id, config)
+        self._coverage_rows = report.rows
+        self.label_coverage_summary.setText(self._coverage_summary_text(report))
+        self.pushButton_add_to_dataset.setEnabled(report.summary.can_be_added)
+        self.table_coverage.setRowCount(len(report.rows))
+        for row_index, row in enumerate(report.rows):
+            values = [
+                row.well_name or f"well_id={row.well_id}",
+                row.status,
+                row.points,
+                self._status_error_count_text(row.errors),
+            ]
+            for column, value in enumerate(values):
+                item = QtWidgets.QTableWidgetItem(str(value))
+                item.setData(QtCore.Qt.UserRole, row_index)
+                if row.errors:
+                    item.setForeground(QtGui.QBrush(QtGui.QColor("#b00020")))
+                elif column == 1:
+                    item.setForeground(QtGui.QBrush(QtGui.QColor("#0a7f22")))
+                self.table_coverage.setItem(row_index, column, item)
+        self.table_coverage.resizeColumnsToContents()
+        if report.rows:
+            self.table_coverage.selectRow(0)
+        self._preview_selected_feature()
+
+    def _coverage_selection_changed(self) -> None:
+        selected = self.table_coverage.selectedItems()
+        if not selected:
+            self.textEdit_error_detail.clear()
+            return
+        row_index = selected[0].data(QtCore.Qt.UserRole)
+        try:
+            row = self._coverage_rows[int(row_index)]
+        except (TypeError, ValueError, IndexError):
+            self.textEdit_error_detail.clear()
+            return
+        lines = [
+            f"Well: {row.well_name or '—'} (id={row.well_id})",
+            f"Depth interval: {row.top_md:g} - {row.bottom_md:g}",
+            f"Status: {row.status}",
+            f"Points: {row.points}",
+        ]
+        if row.errors:
+            error = row.errors[0]
+            lines.extend([
+                f"Feature: {getattr(error, 'feature_name', None) or 'calculator'}",
+                f"Input curve: {getattr(error, 'canonical_name', None) or '—'}",
+                f"Error code: {getattr(error, 'code', 'error')}",
+                f"Message: {getattr(error, 'message', str(error))}",
+                f"Recommendation: {feature_calculator_recommendation(error)}",
+            ])
+        else:
+            lines.append(f"Recommendation: {feature_calculator_recommendation(None)}")
+        self.textEdit_error_detail.setPlainText("\n".join(lines))
+
+    def _well_context_by_id(self, well_id: int | None) -> dict[str, Any] | None:
+        if well_id is None:
+            return None
+        for well in self.wells:
+            if int(well.get("id")) == int(well_id):
+                return well
+        return None
+
+    def _preview_config(self, config: Any, *, title: str) -> None:
+        well_id = self.comboBox_preview_well.currentData()
+        well = self._well_context_by_id(well_id)
+        self.preview_figure.clear()
+        ax = self.preview_figure.add_subplot(111)
+        if well is None:
+            ax.text(0.5, 0.5, "Select well for preview", ha="center", va="center")
+            self.preview_canvas.draw_idle()
+            return
+        result = evaluate_feature_calculator_for_well(
+            config,
+            well_id=int(well["id"]),
+            top_md=float(well.get("top_md")),
+            bottom_md=float(well.get("bottom_md")),
+        )
+        if result.errors:
+            error = result.errors[0]
+            ax.text(0.5, 0.5, f"Preview error:\n[{error.code}] {error.message}", ha="center", va="center", wrap=True)
+            ax.set_axis_off()
+            self.textEdit_error_detail.setPlainText(
+                f"Preview error for {well.get('name', well.get('id'))}:\n"
+                f"Feature: {config.feature_name or title}\n"
+                f"Operation/formula: {config.operation or config.expression}\n"
+                f"Depth interval: {float(well.get('top_md')):g} - {float(well.get('bottom_md')):g}\n"
+                f"Error code: {error.code}\n"
+                f"Message: {error.message}\n"
+                f"Recommendation: {feature_calculator_recommendation(error)}"
+            )
+        else:
+            points = [(value, depth) for value, depth in zip(result.values, result.depths) if value is not None]
+            if points:
+                x_values, y_depths = zip(*points)
+                ax.plot(x_values, y_depths, linewidth=1.1, marker=".", markersize=3, color="#1f77b4")
+                ax.invert_yaxis()
+                ax.grid(True, alpha=0.25)
+                ax.set_xlabel(config.feature_name or title)
+                ax.set_ylabel("Depth MD")
+                ax.set_title(f"{title}: {well.get('name', well.get('id'))}")
+            else:
+                ax.text(0.5, 0.5, "Preview returned no points", ha="center", va="center")
+        self.preview_figure.tight_layout()
+        self.preview_canvas.draw_idle()
+
+    def _preview_selected_feature(self, *_args: Any) -> None:
+        feature = self._selected_feature()
+        if feature is None or not hasattr(self, "preview_canvas"):
+            return
+        config, parse_errors = parse_feature_calculator_config(feature)
+        if parse_errors or config is None:
+            self.preview_figure.clear()
+            ax = self.preview_figure.add_subplot(111)
+            ax.text(0.5, 0.5, "Selected feature has parse errors", ha="center", va="center")
+            ax.set_axis_off()
+            self.preview_canvas.draw_idle()
+            return
+        self._preview_config(config, title=str(feature.feature_name))
+
+    def _preview_current_definition(self) -> None:
+        config_dict, errors = self._build_current_config()
+        if errors or config_dict is None:
+            self.textEdit_validation.setPlainText("\n".join(errors))
+            QtWidgets.QMessageBox.warning(self, "Preview calculated feature", "Исправьте ошибки формы перед preview.")
+            return
+        feature_name = self.lineEdit_feature_name.text().strip() or "Preview feature"
+        config, parse_errors = parse_feature_calculator_config({"feature_name": feature_name, "params_json": config_dict})
+        if parse_errors or config is None:
+            self.textEdit_validation.setPlainText("\n".join(error.message for error in parse_errors))
+            return
+        self.textEdit_validation.setPlainText("Preview calculated without saving feature definition.")
+        self._preview_config(config, title=feature_name)
 
     def _format_errors(self, errors: list[Any], limit: int = 10) -> str:
         lines = []

--- a/tests/test_well_feature_calculator_dataset_validation.py
+++ b/tests/test_well_feature_calculator_dataset_validation.py
@@ -160,3 +160,37 @@ def test_validate_calculators_for_dataset_reports_preflight_math_error(monkeypat
     assert {error.code for error in errors} == {"invalid_math_domain"}
     assert errors[0].feature_name == "LOG_GR"
     assert errors[0].well_name == "Well-1"
+
+
+def test_build_feature_calculator_coverage_report_summarizes_ok_and_blocks_errors(monkeypatch):
+    fake_session = FakeSession(values=[1.0, 2.0, 3.0])
+    install_fake_model_modules(fake_session, monkeypatch)
+    config, errors = well_feature_calculator.parse_feature_calculator_config(fake_session.calculator)
+
+    assert errors == []
+    report = well_feature_calculator.build_feature_calculator_coverage_report(3, config, db_session=fake_session)
+
+    assert report.summary.wells_total == 1
+    assert report.summary.wells_ok == 1
+    assert report.summary.error_count == 0
+    assert report.summary.min_points == 3
+    assert report.summary.max_points == 3
+    assert report.summary.input_curves == ["GR"]
+    assert report.summary.can_be_added is True
+    assert report.rows[0].status == "OK"
+    assert report.rows[0].points == 3
+
+    failing_session = FakeSession(values=[1.0, 0.0, 3.0])
+    install_fake_model_modules(failing_session, monkeypatch)
+    failing_config, errors = well_feature_calculator.parse_feature_calculator_config(failing_session.calculator)
+
+    assert errors == []
+    failing_report = well_feature_calculator.build_feature_calculator_coverage_report(3, failing_config, db_session=failing_session)
+
+    assert failing_report.summary.wells_total == 1
+    assert failing_report.summary.wells_ok == 0
+    assert failing_report.summary.error_count == 1
+    assert failing_report.summary.can_be_added is False
+    assert failing_report.rows[0].status == "Invalid math domain"
+    assert failing_report.rows[0].points == 0
+    assert failing_report.rows[0].errors[0].well_name == "Well-1"


### PR DESCRIPTION
### Motivation
- Provide users with actionable diagnostics why a calculator feature can or cannot be applied to a dataset and let them preview results on a single well before adding the feature to the dataset.
- Reuse the strict backend validation used by `COLLECT` to build a read-only coverage report for the constructor UI so `ADD TO DATASET` can be safely gated.
- Improve developer UX by returning structured, user-friendly error codes and recommendations for common failure modes.

### Description
- Backend: added coverage/report dataclasses and helpers in `cluster/well_feature_calculator.py` including `FeatureCalculatorCoverageRow`, `FeatureCalculatorCoverageSummary`, `FeatureCalculatorCoverageReport`, `feature_calculator_status_for_errors`, `feature_calculator_recommendation`, `_config_input_names` and `build_feature_calculator_coverage_report(dataset_id, config, db_session=None)` which evaluate a calculator for every well/interval and aggregate per-well diagnostics and a summary; also added status labels and human recommendations constants.
- Backend: integrated coverage helper with existing evaluation flow and reuses existing `evaluate_feature_calculator_for_well`/validation logic (strict, no interpolation) to ensure results match `COLLECT` preflight behavior.
- UI: extended `qt/well_log_feature_constructor_form.py` to add a `Preview` button, a new diagnostics block (coverage table `Well | Status | Points | Errors`, dataset-level summary label), detailed per-error pane, preview well selector and a Matplotlib canvas for preview plotting; added logic to build/refresh the coverage report for a selected saved feature and to preview both saved and unsaved feature definitions.
- Tests: added `test_build_feature_calculator_coverage_report_summarizes_ok_and_blocks_errors` to `tests/test_well_feature_calculator_dataset_validation.py` to assert coverage summary behavior for OK and failing math-domain cases.

### Testing
- Compiled modified modules with `python -m py_compile cluster/well_feature_calculator.py qt/well_log_feature_constructor_form.py` which succeeded.
- Ran focused unit tests: `pytest -q tests/test_well_feature_calculator_unary.py tests/test_well_feature_calculator_formula.py tests/test_well_feature_calculator_dataset_validation.py` and all relevant tests passed (`34 passed` for the test suite used here), including the new coverage test.
- Ran full `pytest -q` which fails during collection in this environment due to missing external packages (`sqlalchemy`, `numpy`) unrelated to the changed files; this does not affect the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb841db5c832fb4dd139afd946136)