### PR TITLE
Fix Well Log calculator COLLECT depth grid handling

### DIFF
--- a/cluster/well_dataset.py
+++ b/cluster/well_dataset.py
@@ -999,6 +999,7 @@ def _show_calculator_collect_errors(errors: list[Any], *, title: str = 'COLLECT 
 def collect_cluster_well_log_dataset_data() -> None:
     from .well_feature_calculator import (
         FeatureCalculatorError,
+        complete_calculator_depths,
         evaluate_feature_calculator_for_well,
         parse_feature_calculator_config,
         validate_calculators_for_dataset,
@@ -1111,28 +1112,25 @@ def collect_cluster_well_log_dataset_data() -> None:
             for depth, value in zip(result.depths, result.values):
                 calculator_value_map.setdefault(round(float(depth), 6), {})[int(calculator.id)] = value
 
-        combined_depths = sorted(set(depth_map.keys()) | set(calculator_value_map.keys()))
-        for depth in combined_depths:
-            calculator_values = calculator_value_map.get(depth, {})
-            missing_calculators = [
-                calculator.feature_name
-                for calculator, _config in calculator_configs
-                if int(calculator.id) not in calculator_values
-            ]
-            if missing_calculators:
+        if calculator_configs:
+            calculator_ids = [int(calculator.id) for calculator, _config in calculator_configs]
+            combined_depths = complete_calculator_depths(calculator_value_map, calculator_ids)
+            if not combined_depths:
                 well_name = wf.well.name if wf.well and wf.well.name else f'well_id={wf.well_id}'
                 collect_errors.append(
                     FeatureCalculatorError(
-                        code='missing_calculator_value_at_depth',
+                        code='no_common_calculator_depths',
                         message=(
-                            f"Нет значения calculator-признаков {', '.join(missing_calculators)} "
-                            f"на глубине {depth:g}; строки с неполным набором выбранных calculator-признаков запрещены."
+                            'Нет глубин, на которых рассчитаны все выбранные calculator-признаки; '
+                            'проверьте интервалы скважины и глубинные сетки calculator-признаков.'
                         ),
-                        feature_name=', '.join(missing_calculators),
+                        feature_name=', '.join(calculator.feature_name for calculator, _config in calculator_configs),
                         well_id=int(wf.well_id),
                         well_name=well_name,
                     )
                 )
+        else:
+            combined_depths = sorted(depth_map.keys())
 
         if collect_errors:
             continue

--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -29,6 +29,7 @@ FEATURE_CALCULATOR_STATUS_LABELS = {
     "invalid_sqrt_domain": "Invalid math domain",
     "not_enough_points": "Not enough points",
     "non_finite_result": "Non-finite result",
+    "no_common_calculator_depths": "No common calculator depths",
 }
 
 FEATURE_CALCULATOR_RECOMMENDATIONS = {
@@ -40,6 +41,7 @@ FEATURE_CALCULATOR_RECOMMENDATIONS = {
     "division_by_zero": "Измените формулу или входные кривые так, чтобы знаменатель не обращался в ноль на выбранном интервале.",
     "not_enough_points": "Расширьте интервал или выберите кривую, где достаточно точек для операции.",
     "non_finite_result": "Проверьте входные значения и параметры операции: результат не должен содержать NaN или inf.",
+    "no_common_calculator_depths": "Проверьте выбранные интервалы и глубинные сетки calculator-признаков: для COLLECT нужна хотя бы одна глубина, где рассчитаны все выбранные calculator-признаки.",
 }
 
 FEATURE_CALCULATOR_UNARY_OPERATIONS = {
@@ -765,6 +767,27 @@ def evaluate_formula_series(
     if non_finite_error:
         return [], [non_finite_error]
     return result_values, []
+
+
+def complete_calculator_depths(
+    calculator_value_map: dict[float, dict[int, Any]],
+    calculator_ids: Sequence[int],
+) -> list[float]:
+    """Return depths where every selected calculator has a computed value.
+
+    COLLECT builds rows on a depth grid. Canonical curves may have extra edge
+    depths or slightly different grids, so calculator-backed features should not
+    be required on the union of all canonical depths.  A calculator row is
+    complete only where all selected calculator ids are present.
+    """
+    normalized_ids = [int(calculator_id) for calculator_id in calculator_ids]
+    if not normalized_ids:
+        return []
+    return sorted(
+        float(depth)
+        for depth, values_by_calculator in calculator_value_map.items()
+        if all(calculator_id in values_by_calculator for calculator_id in normalized_ids)
+    )
 
 
 def _rounded_depths(depths: Sequence[float], precision: int = FEATURE_CALCULATOR_DEPTH_PRECISION) -> list[float]:

--- a/tests/test_well_feature_calculator_formula.py
+++ b/tests/test_well_feature_calculator_formula.py
@@ -139,3 +139,17 @@ def test_formula_evaluation_uses_loaded_series_and_strict_grid(monkeypatch):
     assert result.ok
     assert_close_list(result.values, [4.0, 6.0])
     assert_close_list(result.depths, [100.0, 100.1])
+
+
+def test_complete_calculator_depths_uses_calculator_intersection_not_canonical_union():
+    complete = well_feature_calculator.complete_calculator_depths(
+        {
+            100.0: {1: 10.0},
+            100.1: {1: 11.0, 2: 21.0},
+            100.2: {1: 12.0, 2: 22.0},
+            100.3: {2: 23.0},
+        },
+        [1, 2],
+    )
+
+    assert complete == [100.1, 100.2]


### PR DESCRIPTION
### Motivation
- COLLECT erroneously treated the union of canonical curve depths as the required grid for calculator-backed features, causing false "missing value" errors when calculators were only computed on a subset of depths.
- The intent is to build rows only on depths where all selected calculator features have values so COLLECT does not fail due to unrelated edge depths from canonical curves.

### Description
- Added `complete_calculator_depths(calculator_value_map, calculator_ids)` in `cluster/well_feature_calculator.py` to return only depths where every selected calculator has a computed value.  
- Updated `collect_cluster_well_log_dataset_data` in `cluster/well_dataset.py` to use `complete_calculator_depths` when calculator features are present and to fall back to canonical depths when no calculators are selected.  
- Introduced a new error/status code `no_common_calculator_depths` with user-facing label and recommendation to explain the case when there are no depths common to all selected calculators.  
- Added a regression test `test_complete_calculator_depths_uses_calculator_intersection_not_canonical_union` in `tests/test_well_feature_calculator_formula.py` covering the intersection behaviour.

### Testing
- Ran `pytest -q tests/test_well_feature_calculator_unary.py tests/test_well_feature_calculator_formula.py` and all tests passed (32 passed).  
- Ran full `pytest -q` but test collection failed due to missing environment dependencies (`sqlalchemy` and `numpy`), which are unrelated to the change and prevented a complete test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb755addc832fb304dcb22bd6aaf2)