### PR TITLE
Align formula/calculator depths and make normalization robust to non-finite stats

### DIFF
--- a/cluster/well_dataset.py
+++ b/cluster/well_dataset.py
@@ -999,6 +999,7 @@ def _show_calculator_collect_errors(errors: list[Any], *, title: str = 'COLLECT 
 def collect_cluster_well_log_dataset_data() -> None:
     from .well_feature_calculator import (
         FeatureCalculatorError,
+        complete_calculator_depths,
         evaluate_feature_calculator_for_well,
         parse_feature_calculator_config,
         validate_calculators_for_dataset,
@@ -1111,28 +1112,25 @@ def collect_cluster_well_log_dataset_data() -> None:
             for depth, value in zip(result.depths, result.values):
                 calculator_value_map.setdefault(round(float(depth), 6), {})[int(calculator.id)] = value
 
-        combined_depths = sorted(set(depth_map.keys()) | set(calculator_value_map.keys()))
-        for depth in combined_depths:
-            calculator_values = calculator_value_map.get(depth, {})
-            missing_calculators = [
-                calculator.feature_name
-                for calculator, _config in calculator_configs
-                if int(calculator.id) not in calculator_values
-            ]
-            if missing_calculators:
+        if calculator_configs:
+            calculator_ids = [int(calculator.id) for calculator, _config in calculator_configs]
+            combined_depths = complete_calculator_depths(calculator_value_map, calculator_ids)
+            if not combined_depths:
                 well_name = wf.well.name if wf.well and wf.well.name else f'well_id={wf.well_id}'
                 collect_errors.append(
                     FeatureCalculatorError(
-                        code='missing_calculator_value_at_depth',
+                        code='no_common_calculator_depths',
                         message=(
-                            f"Нет значения calculator-признаков {', '.join(missing_calculators)} "
-                            f"на глубине {depth:g}; строки с неполным набором выбранных calculator-признаков запрещены."
+                            'Нет глубин, на которых рассчитаны все выбранные calculator-признаки; '
+                            'проверьте интервалы скважины и глубинные сетки calculator-признаков.'
                         ),
-                        feature_name=', '.join(missing_calculators),
+                        feature_name=', '.join(calculator.feature_name for calculator, _config in calculator_configs),
                         well_id=int(wf.well_id),
                         well_name=well_name,
                     )
                 )
+        else:
+            combined_depths = sorted(depth_map.keys())
 
         if collect_errors:
             continue

--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -29,6 +29,8 @@ FEATURE_CALCULATOR_STATUS_LABELS = {
     "invalid_sqrt_domain": "Invalid math domain",
     "not_enough_points": "Not enough points",
     "non_finite_result": "Non-finite result",
+    "no_common_calculator_depths": "No common calculator depths",
+    "no_common_formula_depths": "No common formula depths",
 }
 
 FEATURE_CALCULATOR_RECOMMENDATIONS = {
@@ -40,6 +42,8 @@ FEATURE_CALCULATOR_RECOMMENDATIONS = {
     "division_by_zero": "Измените формулу или входные кривые так, чтобы знаменатель не обращался в ноль на выбранном интервале.",
     "not_enough_points": "Расширьте интервал или выберите кривую, где достаточно точек для операции.",
     "non_finite_result": "Проверьте входные значения и параметры операции: результат не должен содержать NaN или inf.",
+    "no_common_calculator_depths": "Проверьте выбранные интервалы и глубинные сетки calculator-признаков: для COLLECT нужна хотя бы одна глубина, где рассчитаны все выбранные calculator-признаки.",
+    "no_common_formula_depths": "Проверьте выбранные интервалы и глубинные сетки входных кривых формулы: нужна хотя бы одна общая глубина без интерполяции.",
 }
 
 FEATURE_CALCULATOR_UNARY_OPERATIONS = {
@@ -485,16 +489,20 @@ def apply_rolling_median(values: Sequence[float | None], window: int = 3) -> tup
     return result, []
 
 
+def _finite_values(values: Sequence[float | None]) -> list[float]:
+    """Return finite values, silently ignoring gaps outside the calculation interval."""
+    return [float(value) for value in values if value is not None and math.isfinite(value)]
+
+
 def apply_zscore(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
-    source = list(values if stats_values is None else stats_values)
+    source = _finite_values(values if stats_values is None else stats_values)
     source_error = _blocking_if_any_missing(values, "non_finite_result", "zscore требует конечные значения расчётного интервала.")
-    stats_error = _blocking_if_any_missing(source, "non_finite_result", "zscore требует конечные значения области нормировки.")
-    if source_error or stats_error:
-        return [], [error for error in (source_error, stats_error) if error]
+    if source_error:
+        return [], [source_error]
     if len(source) < 2:
-        return [], [_error("not_enough_points", "Для zscore требуется минимум две точки.")]
-    mean = sum(float(value) for value in source) / len(source)
-    variance = sum((float(value) - mean) ** 2 for value in source) / len(source)
+        return [], [_error("not_enough_points", "Для zscore требуется минимум две конечные точки в области нормировки.")]
+    mean = sum(source) / len(source)
+    variance = sum((value - mean) ** 2 for value in source) / len(source)
     std = math.sqrt(variance)
     if std == 0:
         return [], [_error("zero_std", "Стандартное отклонение равно нулю; zscore невозможен.")]
@@ -502,16 +510,14 @@ def apply_zscore(values: Sequence[float | None], stats_values: Sequence[float | 
 
 
 def apply_robust(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
-    source = list(values if stats_values is None else stats_values)
+    source = _finite_values(values if stats_values is None else stats_values)
     source_error = _blocking_if_any_missing(values, "non_finite_result", "robust требует конечные значения расчётного интервала.")
-    stats_error = _blocking_if_any_missing(source, "non_finite_result", "robust требует конечные значения области нормировки.")
-    if source_error or stats_error:
-        return [], [error for error in (source_error, stats_error) if error]
+    if source_error:
+        return [], [source_error]
     if len(source) < 2:
-        return [], [_error("not_enough_points", "Для robust-нормировки требуется минимум две точки.")]
-    numeric_source = [float(value) for value in source]
-    median_value = statistics.median(numeric_source)
-    q1, q3 = _quartiles(numeric_source)
+        return [], [_error("not_enough_points", "Для robust-нормировки требуется минимум две конечные точки в области нормировки.")]
+    median_value = statistics.median(source)
+    q1, q3 = _quartiles(source)
     iqr = q3 - q1
     if iqr == 0:
         return [], [_error("zero_iqr", "IQR равен нулю; robust-нормировка невозможна.")]
@@ -519,13 +525,14 @@ def apply_robust(values: Sequence[float | None], stats_values: Sequence[float | 
 
 
 def apply_minmax(values: Sequence[float | None], stats_values: Sequence[float | None] | None = None) -> tuple[list[float | None], list[FeatureCalculatorError]]:
-    source = list(values if stats_values is None else stats_values)
+    source = _finite_values(values if stats_values is None else stats_values)
     source_error = _blocking_if_any_missing(values, "non_finite_result", "minmax требует конечные значения расчётного интервала.")
-    stats_error = _blocking_if_any_missing(source, "non_finite_result", "minmax требует конечные значения области нормировки.")
-    if source_error or stats_error:
-        return [], [error for error in (source_error, stats_error) if error]
-    min_value = min(float(value) for value in source)
-    max_value = max(float(value) for value in source)
+    if source_error:
+        return [], [source_error]
+    if len(source) < 2:
+        return [], [_error("not_enough_points", "Для minmax требуется минимум две конечные точки в области нормировки.")]
+    min_value = min(source)
+    max_value = max(source)
     value_range = max_value - min_value
     if value_range == 0:
         return [], [_error("zero_range", "Диапазон значений равен нулю; minmax невозможен.")]
@@ -765,6 +772,90 @@ def evaluate_formula_series(
     if non_finite_error:
         return [], [non_finite_error]
     return result_values, []
+
+
+
+def align_formula_series_on_common_depths(
+    series_list: Sequence[WellLogCurveSeries],
+    *,
+    precision: int = FEATURE_CALCULATOR_DEPTH_PRECISION,
+) -> tuple[list[WellLogCurveSeries], list[FeatureCalculatorError]]:
+    """Align formula inputs by common rounded depths without interpolation.
+
+    Clean canonical curves are collected by rounded depth, so formula features should
+    be calculated on the same common-depth principle instead of failing when input
+    curves have harmless extra edge points or different start/end depths.
+    """
+    if not series_list:
+        return [], [_error("missing_inputs", "Для расчёта формулы нужны входные canonical-кривые.")]
+
+    depth_maps: list[dict[float, tuple[float, float | None]]] = []
+    for series in series_list:
+        depth_map: dict[float, tuple[float, float | None]] = {}
+        for depth, value in zip(series.depths, series.values):
+            rounded_depth = round(float(depth), precision)
+            depth_map.setdefault(rounded_depth, (float(depth), value))
+        if not depth_map:
+            return [], [
+                _error(
+                    "no_common_formula_depths",
+                    f"У входной кривой '{series.canonical_name}' нет точек в расчётном интервале.",
+                    well_id=series.well_id,
+                    canonical_name=series.canonical_name,
+                )
+            ]
+        depth_maps.append(depth_map)
+
+    common_depths = sorted(set.intersection(*(set(depth_map) for depth_map in depth_maps)))
+    if not common_depths:
+        input_names = ", ".join(series.canonical_name for series in series_list)
+        return [], [
+            _error(
+                "no_common_formula_depths",
+                f"Нет общих глубин для входных кривых формулы: {input_names}. Формула рассчитывается только на совпадающих глубинах без интерполяции.",
+                well_id=series_list[0].well_id,
+            )
+        ]
+
+    aligned: list[WellLogCurveSeries] = []
+    for series, depth_map in zip(series_list, depth_maps):
+        aligned_values = [depth_map[depth][1] for depth in common_depths]
+        aligned.append(
+            WellLogCurveSeries(
+                well_id=series.well_id,
+                canonical_id=series.canonical_id,
+                canonical_name=series.canonical_name,
+                depths=[float(depth) for depth in common_depths],
+                values=aligned_values,
+                step=series.step,
+                begin=float(common_depths[0]),
+                end=float(common_depths[-1]),
+                source_curve_name=series.source_curve_name,
+                stats_depths=list(series.stats_depths),
+                stats_values=list(series.stats_values),
+            )
+        )
+    return aligned, []
+
+def complete_calculator_depths(
+    calculator_value_map: dict[float, dict[int, Any]],
+    calculator_ids: Sequence[int],
+) -> list[float]:
+    """Return depths where every selected calculator has a computed value.
+
+    COLLECT builds rows on a depth grid. Canonical curves may have extra edge
+    depths or slightly different grids, so calculator-backed features should not
+    be required on the union of all canonical depths.  A calculator row is
+    complete only where all selected calculator ids are present.
+    """
+    normalized_ids = [int(calculator_id) for calculator_id in calculator_ids]
+    if not normalized_ids:
+        return []
+    return sorted(
+        float(depth)
+        for depth, values_by_calculator in calculator_value_map.items()
+        if all(calculator_id in values_by_calculator for calculator_id in normalized_ids)
+    )
 
 
 def _rounded_depths(depths: Sequence[float], precision: int = FEATURE_CALCULATOR_DEPTH_PRECISION) -> list[float]:
@@ -1196,13 +1287,15 @@ def evaluate_feature_calculator_for_well(
         )
         if load_errors:
             return FeatureCalculatorEvaluationResult(errors=load_errors)
-        grid_errors = validate_depth_grid_compatibility(series_list, config=config)
-        if grid_errors:
-            return FeatureCalculatorEvaluationResult(errors=grid_errors)
-        values, formula_errors = evaluate_formula_series(str(config.expression), series_list)
+        aligned_series, alignment_errors = align_formula_series_on_common_depths(series_list)
+        if alignment_errors:
+            return FeatureCalculatorEvaluationResult(
+                errors=[_copy_error_context(error, config=config, well_id=int(well_id)) for error in alignment_errors]
+            )
+        values, formula_errors = evaluate_formula_series(str(config.expression), aligned_series)
         return FeatureCalculatorEvaluationResult(
             values=values,
-            depths=series_list[0].depths if not formula_errors and series_list else [],
+            depths=aligned_series[0].depths if not formula_errors and aligned_series else [],
             errors=[_copy_error_context(error, config=config, well_id=int(well_id)) for error in formula_errors],
         )
 

--- a/tests/test_well_feature_calculator_formula.py
+++ b/tests/test_well_feature_calculator_formula.py
@@ -139,3 +139,38 @@ def test_formula_evaluation_uses_loaded_series_and_strict_grid(monkeypatch):
     assert result.ok
     assert_close_list(result.values, [4.0, 6.0])
     assert_close_list(result.depths, [100.0, 100.1])
+
+
+def test_complete_calculator_depths_uses_calculator_intersection_not_canonical_union():
+    complete = well_feature_calculator.complete_calculator_depths(
+        {
+            100.0: {1: 10.0},
+            100.1: {1: 11.0, 2: 21.0},
+            100.2: {1: 12.0, 2: 22.0},
+            100.3: {2: 23.0},
+        },
+        [1, 2],
+    )
+
+    assert complete == [100.1, 100.2]
+
+
+def test_formula_evaluation_aligns_on_common_depths(monkeypatch):
+    config = FeatureCalculatorConfig(
+        mode="formula",
+        expression="A + B",
+        inputs=[FeatureCalculatorInput(canonical_name="A"), FeatureCalculatorInput(canonical_name="B")],
+    )
+
+    def fake_loader(config, well_id, top_md, bottom_md, *, db_session=None):
+        return [
+            series("A", [1.0, 2.0, 3.0], depths=[100.0, 100.1, 100.2]),
+            series("B", [10.0, 20.0, 30.0], depths=[100.1, 100.2, 100.3]),
+        ], []
+
+    monkeypatch.setattr(well_feature_calculator, "load_input_series_for_calculator", fake_loader)
+    result = evaluate_feature_calculator_for_well(config, well_id=7, top_md=100.0, bottom_md=100.3)
+
+    assert result.ok
+    assert_close_list(result.depths, [100.1, 100.2])
+    assert_close_list(result.values, [12.0, 23.0])

--- a/tests/test_well_feature_calculator_unary.py
+++ b/tests/test_well_feature_calculator_unary.py
@@ -115,11 +115,25 @@ def test_zscore_can_use_separate_whole_well_stats():
     assert_close_list(values, [0.0, math.sqrt(1.5)])
 
 
+def test_zscore_ignores_non_finite_values_outside_interval_stats():
+    values, errors = apply_zscore([2.0, 3.0], stats_values=[None, 1.0, 2.0, float("nan"), 3.0])
+
+    assert errors == []
+    assert_close_list(values, [0.0, math.sqrt(1.5)])
+
+
 def test_robust_median_iqr_normalization():
     values, errors = apply_robust([1.0, 2.0, 3.0, 4.0])
 
     assert errors == []
     assert_close_list(values, [-1.0, -1.0 / 3.0, 1.0 / 3.0, 1.0])
+
+
+def test_robust_ignores_non_finite_values_outside_interval_stats():
+    values, errors = apply_robust([2.0, 3.0], stats_values=[None, 1.0, 2.0, float("inf"), 3.0, 4.0])
+
+    assert errors == []
+    assert_close_list(values, [-1.0 / 3.0, 1.0 / 3.0])
 
 
 def test_minmax_normalization():


### PR DESCRIPTION
### Motivation
- Prevent failing feature calculations when input curves or calculator outputs have harmless extra edge depths or non-finite values outside the normalization interval.
- Ensure COLLECT builds rows only on depths where all selected calculator-backed features exist to avoid incomplete rows.

### Description
- Add `align_formula_series_on_common_depths` to compute formula inputs aligned on common rounded depths without interpolation and return a clear `no_common_formula_depths` error when none exist.
- Add `complete_calculator_depths` and use it in the collector to form `combined_depths` from the intersection of calculator results and emit a `no_common_calculator_depths` error when empty, updating the collector error text accordingly.
- Make unary normalizations (`zscore`, `robust`, `minmax`) ignore non-finite/stat gaps outside the calculation interval by introducing `_finite_values`, tighten point-count checks, and return clearer error codes/messages for insufficient/degenerate stats.
- Add new status labels and recommendations for the new error codes and update `evaluate_feature_calculator_for_well` to use the aligned series and aligned depths for formula mode.

### Testing
- Ran unit tests covering formula alignment and calculator depth intersection including `tests/test_well_feature_calculator_formula.py` and they passed.
- Ran unit tests covering unary normalizations including `tests/test_well_feature_calculator_unary.py` and they passed.
- Ran the full test suite (`pytest`) and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb755addc832fb304dcb22bd6aaf2)