### PR TITLE
Add formula-level normalization functions and vectorized formula evaluation

### DIFF
--- a/cluster/well_feature_calculator.py
+++ b/cluster/well_feature_calculator.py
@@ -17,7 +17,7 @@ FEATURE_CALCULATOR_DEFAULT_NORMALIZATION_SCOPE = "whole_well"
 FEATURE_CALCULATOR_NORMALIZATION_SCOPES = {"whole_well", "interval"}
 FEATURE_CALCULATOR_DEPTH_PRECISION = 6
 FEATURE_CALCULATOR_STEP_TOLERANCE = 1e-9
-FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS = {"log", "abs", "sqrt"}
+FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS = {"log", "abs", "sqrt", "norm", "zscore", "robust", "minmax"}
 
 
 
@@ -636,13 +636,13 @@ class _SafeFormulaValidator(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> None:
         if not isinstance(node.func, ast.Name):
-            self._add_validation_error("Вызовы атрибутов и выражений запрещены; доступны только log, abs, sqrt.")
+            self._add_validation_error("Вызовы атрибутов и выражений запрещены; доступны только log, abs, sqrt, norm, zscore, robust, minmax.")
         elif node.func.id not in FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS:
-            self._add_validation_error(f"Функция '{node.func.id}' не разрешена; доступны только log, abs, sqrt.")
+            self._add_validation_error(f"Функция '{node.func.id}' не разрешена; доступны только log, abs, sqrt, norm, zscore, robust, minmax.")
         if node.keywords:
             self._add_validation_error("Именованные аргументы функций в формулах не поддерживаются.")
         if len(node.args) != 1:
-            self._add_validation_error("Функции log/abs/sqrt принимают ровно один аргумент.")
+            self._add_validation_error("Функции log/abs/sqrt/norm/zscore/robust/minmax принимают ровно один аргумент.")
         for arg in node.args:
             self.visit(arg)
 
@@ -665,8 +665,12 @@ def extract_formula_input_names(expression: str) -> tuple[list[str], list[Featur
     except SyntaxError as exc:
         return [], [_error("formula_parse_error", f"Синтаксическая ошибка формулы: {exc.msg}.")]
     names: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Name) and node.id not in FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS and node.id not in names:
+    name_nodes = sorted(
+        (node for node in ast.walk(tree) if isinstance(node, ast.Name)),
+        key=lambda node: (getattr(node, "lineno", 0), getattr(node, "col_offset", 0)),
+    )
+    for node in name_nodes:
+        if node.id not in FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS and node.id not in names:
             names.append(node.id)
     return names, []
 
@@ -745,11 +749,115 @@ def evaluate_safe_formula_point(
         return None, _error(exc.code, exc.message)
 
 
+def _depth_context_error(error: FeatureCalculatorError, depths: Sequence[float], index: int) -> FeatureCalculatorError:
+    if 0 <= index < len(depths):
+        error.message = f"{error.message} Глубина: {float(depths[index]):g}."
+    return error
+
+
+def _apply_formula_function(
+    function_name: str,
+    values: Sequence[float | None],
+    depths: Sequence[float],
+) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    result_values: list[float | None] = []
+    for index, value in enumerate(values):
+        if value is None or not math.isfinite(float(value)):
+            return [], [_depth_context_error(_error("missing_value_at_depth", "На текущей глубине отсутствует конечное значение входной формулы."), depths, index)]
+        argument = float(value)
+        if function_name == "log":
+            if argument <= 0:
+                return [], [_depth_context_error(_error("invalid_log_domain", "log(x) определён только для x > 0."), depths, index)]
+            result = math.log(argument)
+        elif function_name == "sqrt":
+            if argument < 0:
+                return [], [_depth_context_error(_error("invalid_sqrt_domain", "sqrt(x) определён только для x >= 0."), depths, index)]
+            result = math.sqrt(argument)
+        elif function_name == "abs":
+            result = abs(argument)
+        else:
+            return [], [_error("formula_validation_error", f"Функция '{function_name}' не разрешена.")]
+        if not math.isfinite(result):
+            return [], [_depth_context_error(_error("non_finite_result", "Результат формулы содержит NaN/inf; расчёт признака заблокирован."), depths, index)]
+        result_values.append(result)
+    return result_values, []
+
+
+def _evaluate_formula_series_node(
+    node: ast.AST,
+    values_by_name: dict[str, list[float | None]],
+    depths: Sequence[float],
+    stats_by_name: dict[str, list[float | None]] | None = None,
+) -> tuple[list[float | None], list[FeatureCalculatorError]]:
+    if isinstance(node, ast.Expression):
+        return _evaluate_formula_series_node(node.body, values_by_name, depths, stats_by_name)
+    if isinstance(node, ast.Constant):
+        value = float(node.value)
+        return [value for _depth in depths], []
+    if isinstance(node, ast.Name):
+        if node.id not in values_by_name:
+            return [], [_error("missing_value_at_depth", f"Нет значения входной кривой '{node.id}' на текущей глубине.")]
+        return list(values_by_name[node.id]), []
+    if isinstance(node, ast.UnaryOp):
+        operand_values, operand_errors = _evaluate_formula_series_node(node.operand, values_by_name, depths, stats_by_name)
+        if operand_errors:
+            return [], operand_errors
+        operator_func = _FORMULA_UNARY_OPERATORS[type(node.op)]
+        result_values: list[float | None] = []
+        for index, value in enumerate(operand_values):
+            if value is None or not math.isfinite(float(value)):
+                return [], [_depth_context_error(_error("missing_value_at_depth", "На текущей глубине отсутствует конечное значение входной формулы."), depths, index)]
+            result_values.append(operator_func(float(value)))
+        return result_values, []
+    if isinstance(node, ast.BinOp):
+        left_values, left_errors = _evaluate_formula_series_node(node.left, values_by_name, depths, stats_by_name)
+        if left_errors:
+            return [], left_errors
+        right_values, right_errors = _evaluate_formula_series_node(node.right, values_by_name, depths, stats_by_name)
+        if right_errors:
+            return [], right_errors
+        result_values: list[float | None] = []
+        for index, (left, right) in enumerate(zip(left_values, right_values)):
+            if left is None or not math.isfinite(float(left)) or right is None or not math.isfinite(float(right)):
+                return [], [_depth_context_error(_error("missing_value_at_depth", "На текущей глубине отсутствует конечное значение входной формулы."), depths, index)]
+            if isinstance(node.op, ast.Div):
+                if float(right) == 0:
+                    return [], [_depth_context_error(_error("division_by_zero", "Деление на ноль в формуле расчётного признака."), depths, index)]
+                value = float(left) / float(right)
+            else:
+                value = _FORMULA_BINARY_OPERATORS[type(node.op)](float(left), float(right))
+            if not math.isfinite(value):
+                return [], [_depth_context_error(_error("non_finite_result", "Результат формулы содержит NaN/inf; расчёт признака заблокирован."), depths, index)]
+            result_values.append(value)
+        return result_values, []
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        argument_values, argument_errors = _evaluate_formula_series_node(node.args[0], values_by_name, depths, stats_by_name)
+        if argument_errors:
+            return [], argument_errors
+        function_name = node.func.id
+        if function_name in {"log", "sqrt", "abs"}:
+            result_values, errors = _apply_formula_function(function_name, argument_values, depths)
+        elif function_name in {"norm", "zscore", "robust", "minmax"}:
+            stats_values = None
+            if isinstance(node.args[0], ast.Name) and stats_by_name is not None:
+                stats_values = stats_by_name.get(node.args[0].id)
+            if function_name in {"norm", "zscore"}:
+                result_values, errors = apply_zscore(argument_values, stats_values=stats_values)
+            elif function_name == "robust":
+                result_values, errors = apply_robust(argument_values, stats_values=stats_values)
+            else:
+                result_values, errors = apply_minmax(argument_values, stats_values=stats_values)
+        else:
+            return [], [_error("formula_validation_error", f"Функция '{function_name}' не разрешена.")]
+        return result_values, errors
+    return [], [_error("formula_validation_error", f"Недопустимый элемент формулы: {type(node).__name__}.")]
+
+
 def evaluate_formula_series(
     expression: str,
     series_list: Sequence[WellLogCurveSeries],
 ) -> tuple[list[float | None], list[FeatureCalculatorError]]:
-    """Evaluate formula for aligned input series; any point error blocks the whole feature."""
+    """Evaluate formula for aligned input series; any point or normalization error blocks the whole feature."""
     if not series_list:
         return [], [_error("missing_inputs", "Для расчёта формулы нужны входные canonical-кривые.")]
     names = [series.canonical_name for series in series_list]
@@ -759,20 +867,16 @@ def evaluate_formula_series(
     if errors or formula is None:
         return [], errors
 
-    result_values: list[float | None] = []
-    for index in range(len(series_list[0].depths)):
-        values_by_name = {series.canonical_name: series.values[index] for series in series_list}
-        value, point_error = evaluate_safe_formula_point(formula, values_by_name)
-        if point_error:
-            depth = series_list[0].depths[index]
-            point_error.message = f"{point_error.message} Глубина: {depth:g}."
-            return [], [point_error]
-        result_values.append(value)
+    depths = series_list[0].depths
+    values_by_name = {series.canonical_name: list(series.values) for series in series_list}
+    stats_by_name = {series.canonical_name: list(series.stats_values or series.values) for series in series_list}
+    result_values, evaluation_errors = _evaluate_formula_series_node(formula.tree, values_by_name, depths, stats_by_name)
+    if evaluation_errors:
+        return [], evaluation_errors
     non_finite_error = _non_finite_result_error(result_values)
     if non_finite_error:
         return [], [non_finite_error]
     return result_values, []
-
 
 
 def align_formula_series_on_common_depths(

--- a/qt/well_log_feature_constructor_form.py
+++ b/qt/well_log_feature_constructor_form.py
@@ -160,7 +160,7 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
         formula_buttons_layout = QtWidgets.QGridLayout(self.widget_formula_tokens)
         formula_buttons_layout.setContentsMargins(0, 0, 0, 0)
         self._formula_token_buttons: list[QtWidgets.QPushButton] = []
-        for index, token in enumerate(["+", "-", "*", "/", "(", ")", "log", "abs", "sqrt"]):
+        for index, token in enumerate(["+", "-", "*", "/", "(", ")", "log", "abs", "sqrt", "norm", "zscore", "minmax", "robust"]):
             button = QtWidgets.QPushButton(token, self.widget_formula_tokens)
             button.setObjectName(f"pushButton_well_log_constructor_formula_token_{token.replace('/', 'div')}")
             button.clicked.connect(lambda _checked=False, value=token: self._insert_formula_token(value))
@@ -381,7 +381,7 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
             self.tree_dataset_context: "Контекст текущего набора: скважины, канонические кривые и расчётные признаки, уже привязанные к набору.",
             self.lineEdit_feature_name: "Имя глобального признака. Оно не должно совпадать с канонической кривой, другим расчётным признаком или системным столбцом данных.",
             self.comboBox_mode: "Выберите операцию для одной канонической кривой или формулу для нескольких канонических кривых.",
-            self.textEdit_formula_expression: "Режим формулы поддерживает имена канонических кривых, числа, + - * /, скобки и функции log/abs/sqrt. eval, импорты и обращение к атрибутам запрещены.",
+            self.textEdit_formula_expression: "Режим формулы поддерживает имена канонических кривых, числа, + - * /, скобки и функции log/abs/sqrt/norm/zscore/minmax/robust. norm является z-score нормировкой. eval, импорты и обращение к атрибутам запрещены.",
             self.listWidget_formula_curves: "Имена канонических кривых, доступные в формулах. Дважды щёлкните по кривой, чтобы вставить её в выражение.",
             self.comboBox_input_curve: "Каноническая кривая, которая используется как вход для расчётного признака в режиме операции.",
             self.comboBox_operation: "Операция расчёта. Интерполяция не используется: входные кривые должны сохранять исходную сетку измеренных глубин.",
@@ -669,7 +669,7 @@ class WellLogFeatureConstructorDialog(QtWidgets.QDialog):
 
     def _insert_formula_token(self, token: str) -> None:
         cursor = self.textEdit_formula_expression.textCursor()
-        if token in {"log", "abs", "sqrt"}:
+        if token in {"log", "abs", "sqrt", "norm", "zscore", "minmax", "robust"}:
             cursor.insertText(f"{token}()")
             cursor.movePosition(QtGui.QTextCursor.Left)
         elif token in {"+", "-", "*", "/"}:

--- a/tests/test_well_feature_calculator_formula.py
+++ b/tests/test_well_feature_calculator_formula.py
@@ -49,10 +49,11 @@ def assert_close_list(actual, expected, *, abs_tol=1e-9):
 
 
 def test_extract_formula_input_names_ignores_allowed_functions():
-    names, errors = extract_formula_input_names("log(GR) + sqrt(RHOB) - abs(GR)")
+    names, errors = extract_formula_input_names("log(GR) + sqrt(RHOB) - abs(GR) + norm(NPHI)")
 
     assert errors == []
-    assert names == ["GR", "RHOB"]
+    assert names == ["GR", "RHOB", "NPHI"]
+
 
 def test_formula_adds_two_curves():
     values, errors = evaluate_formula_series("A + B", [series("A", [1.0, 2.0]), series("B", [3.0, 4.0])])
@@ -69,6 +70,24 @@ def test_formula_normalized_difference():
 
     assert errors == []
     assert_close_list(values, [0.5, 0.5])
+
+
+def test_formula_normalizes_curve_before_arithmetic():
+    values, errors = evaluate_formula_series(
+        "norm(A) + norm(B)",
+        [series("A", [10.0, 20.0, 30.0]), series("B", [100.0, 200.0, 300.0])],
+    )
+
+    assert errors == []
+    expected = [-2.449489742783178, 0.0, 2.449489742783178]
+    assert_close_list(values, expected)
+
+
+def test_formula_supports_minmax_normalization_function():
+    values, errors = evaluate_formula_series("minmax(A) / 2", [series("A", [10.0, 20.0, 30.0])])
+
+    assert errors == []
+    assert_close_list(values, [0.0, 0.25, 0.5])
 
 
 def test_formula_blocks_division_by_zero():


### PR DESCRIPTION
### Motivation
- Users need normalization functions available inside formula-mode expressions (so e.g. `norm(A) + norm(B)` or `minmax(A) / 2` work) and normalization should be applied to the whole curve before arithmetic, analogous to existing unary operations like `log`/`abs`.
- Formula evaluation must provide point-level diagnostics with depth context for normalization errors and integrate per-series statistics for normalization scopes such as `whole_well` or `interval`.

### Description
- Added allowed formula functions `norm`, `zscore`, `robust`, and `minmax` to `FEATURE_CALCULATOR_ALLOWED_FORMULA_FUNCTIONS` and updated validator messages to include them in `cluster/well_feature_calculator.py`.
- Rewrote formula evaluation to perform a vector-aware AST traversal via `_evaluate_formula_series_node` so function calls can produce per-depth vectors and normalization is executed before binary arithmetic.
- Implemented helpers `_apply_formula_function`, `_depth_context_error` and support for passing `stats_by_name` so normalization functions consume per-series statistics (`stats_values`) when applicable.
- Updated UI to add formula token buttons and tooltips for the new functions in `qt/well_log_feature_constructor_form.py` so users can insert `norm`, `zscore`, `robust`, `minmax` from the formula editor.
- Extended tests in `tests/test_well_feature_calculator_formula.py` to cover allowed-name extraction with `norm`, z-score normalization before arithmetic, and `minmax` usage.

### Testing
- Ran the full test suite with `python -m pytest tests` and the suite passed: all tests succeeded.
- Ran focused tests `pytest tests/test_well_feature_calculator_formula.py tests/test_well_feature_calculator_unary.py` to validate new formula cases and normalization logic and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd06b0914832f8bf4bc8ec5e4588e)