### PR TITLE
Preload cluster intervals in well log form

### DIFF
--- a/well_log.py
+++ b/well_log.py
@@ -355,11 +355,51 @@ def show_well_log():
         WellLogForm.resize(int(m_width/4), m_height - 200)
 
         ui_wl.label.setText(f'Каротажные кривые скважины {get_well_name()}')
+
+        def set_spinbox_value_expanding_range(spinbox, value):
+            value = float(value)
+            if value < spinbox.minimum():
+                spinbox.setMinimum(value)
+            if value > spinbox.maximum():
+                spinbox.setMaximum(value)
+            spinbox.setValue(value)
+
+        def load_selected_cluster_interval_to_spinboxes():
+            cluster_combo = getattr(ui, 'comboBox_cluster_well_set', None)
+            if cluster_combo is None:
+                return False
+
+            dataset_id = cluster_combo.currentData()
+            well_id = get_well_id()
+            if dataset_id is None or not well_id:
+                return False
+
+            row = (
+                session.query(WellForCluster)
+                .filter(WellForCluster.dataset_id == int(dataset_id), WellForCluster.well_id == int(well_id))
+                .first()
+            )
+            if row is None or row.top_md is None or row.bottom_md is None:
+                return False
+
+            top_md = float(row.top_md)
+            bottom_md = float(row.bottom_md)
+            if bottom_md < top_md:
+                top_md, bottom_md = bottom_md, top_md
+            interval = bottom_md - top_md
+            if interval <= 0:
+                return False
+
+            set_spinbox_value_expanding_range(ui_wl.doubleSpinBox_depth, top_md)
+            set_spinbox_value_expanding_range(ui_wl.doubleSpinBox_interval, interval)
+            return True
+
         boundaries = session.query(Boundary).filter_by(well_id=get_well_id()).all()
         for b in boundaries:
             if 'uf' in b.title or 'уф' in b.title or 'ss' in b.title:
                 ui_wl.doubleSpinBox_depth.setValue(b.depth)
                 break
+        load_selected_cluster_interval_to_spinboxes()
 
         def update_list_well_log():
             well_log = session.query(WellLog).filter(WellLog.well_id == get_well_id()).all()


### PR DESCRIPTION
### Motivation

- Make `form_well_log` immediately show the cluster interval saved for the current well so a user can visually see which interval is selected when the form opens.
- Ensure saved cluster intervals are not silently clamped by the spinbox range, so stored values are visible even when outside defaults.

### Description

- Added helper `set_spinbox_value_expanding_range(spinbox, value)` that expands a spinbox range when needed and sets the value. 
- Added `load_selected_cluster_interval_to_spinboxes()` which reads `WellForCluster` for the active `comboBox_cluster_well_set` and current well and computes `top_md` and `interval = bottom_md - top_md`.
- If a valid saved interval exists it sets `ui_wl.doubleSpinBox_depth` to `top_md` and `ui_wl.doubleSpinBox_interval` to `interval`, preserving the existing `uf/уф/ss` boundary fallback when no cluster interval is available.

### Testing

- Ran `python -m py_compile well_log.py` which succeeded. 
- Ran `python -m pytest tests/test_well_feature_calculator_dataset_validation.py` which passed all tests (`3 passed`).
- Ran `git diff --check` as an automatic verification with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21111ef940832fb552a211a2cb1204)