### PR TITLE
Improve isolated AUTO candidate worker startup, timeout handling and IPC

### DIFF
--- a/cluster/auto_candidates.py
+++ b/cluster/auto_candidates.py
@@ -1053,12 +1053,69 @@ def build_fine_search_space(
     )
 
 
-def _cluster_candidate_worker(payload: dict, out_queue) -> None:
+def _cluster_candidate_worker(payload: dict, out_conn) -> None:
     try:
         result = run_cluster_candidate(**payload)
-        out_queue.put({"ok": True, "result": result})
+        out_conn.send({"ok": True, "result": result})
     except Exception as exc:
-        out_queue.put({"ok": False, "error": f"subprocess exception: {exc}"})
+        out_conn.send({"ok": False, "error": f"subprocess exception: {exc}"})
+    finally:
+        try:
+            out_conn.close()
+        except Exception:
+            pass
+
+
+def _get_candidate_worker_start_methods() -> list[str]:
+    """
+    Возвращает безопасный порядок запуска isolated-worker для AUTO-кандидата.
+
+    В GUI-приложении нельзя использовать spawn/forkserver: свежий интерпретатор
+    повторно импортирует стартовый модуль приложения и может открыть второе окно.
+    Поэтому isolated AUTO-кандидат запускается только через fork и только при
+    явно включенном UI-timeout кандидата.
+    """
+    available_methods = set(mp.get_all_start_methods())
+    return ["fork"] if "fork" in available_methods else []
+
+
+def _select_candidate_worker_start_method() -> Optional[str]:
+    """
+    Возвращает предпочтительный start_method для обратной совместимости тестов/кода.
+    """
+    methods = _get_candidate_worker_start_methods()
+    return methods[0] if methods else None
+
+
+def _resolve_candidate_hard_timeout(hard_timeout_sec: Optional[float]) -> Optional[float]:
+    """
+    Возвращает явный UI-timeout worker'а. Если UI-лимит отключен, isolated
+    subprocess не запускается: кандидат считается в текущем процессе, чтобы AUTO
+    не зависал на fork до первого же расчета и не открывал дополнительные окна.
+    """
+    if hard_timeout_sec is None:
+        return None
+    try:
+        timeout_float = float(hard_timeout_sec)
+    except (TypeError, ValueError):
+        return None
+    if timeout_float <= 0:
+        return None
+    return max(1.0, timeout_float)
+
+
+def _build_isolated_candidate_payload(kwargs: dict) -> dict:
+    """
+    Готовит payload для subprocess. Runtime-cache в isolated режиме не возвращает
+    изменения в parent-процесс, поэтому его безопаснее не передавать повторному
+    worker'у: так мы не сериализуем/не наследуем большие numpy-массивы и старое
+    состояние предыдущего расчета.
+    """
+    payload = dict(kwargs)
+    for cache_key in ("transform_cache", "preprocess_cache", "preprocess_rank_cache", "metrics_cache"):
+        if cache_key in payload:
+            payload[cache_key] = None
+    return payload
 
 
 def run_cluster_candidate_isolated(
@@ -1066,32 +1123,79 @@ def run_cluster_candidate_isolated(
         hard_timeout_sec: Optional[float] = AUTO_CANDIDATE_HARD_TIMEOUT_SEC,
         **kwargs
 ) -> CandidateResult:
-    start_methods = mp.get_all_start_methods()
-    if "fork" not in start_methods:
+    effective_timeout_sec = _resolve_candidate_hard_timeout(hard_timeout_sec)
+    if effective_timeout_sec is None:
+        # Без явного UI-timeout считаем в текущем процессе. Это исключает fork/forkserver
+        # на обычном AUTO-запуске: расчет идет в основном окне и не провоцирует
+        # deadlock на первом кандидате из-за унаследованного состояния потоков.
+        return run_cluster_candidate(**kwargs)
+
+    start_methods = _get_candidate_worker_start_methods()
+    if not start_methods:
         # Windows fallback: избегаем spawn, чтобы дочерний процесс не инициализировал GUI.
         return run_cluster_candidate(**kwargs)
-    ctx = mp.get_context("fork")
-    q = ctx.Queue(maxsize=1)
-    proc = ctx.Process(target=_cluster_candidate_worker, args=(kwargs, q), daemon=True)
-    proc.start()
-    if hard_timeout_sec is None:
-        proc.join()
-    else:
-        proc.join(timeout=max(1.0, float(hard_timeout_sec)))
+
     candidate_id = str(kwargs.get("candidate_id") or "")
     candidate = kwargs.get("candidate")
-    if proc.is_alive():
-        proc.kill()
-        proc.join(timeout=1.0)
-        return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="invalid", error_text=f"hard-timeout>{hard_timeout_sec:.1f}s (isolated worker killed)")
-    if proc.exitcode not in (0, None):
-        return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=f"isolated worker exitcode={proc.exitcode}")
-    try:
-        msg = q.get_nowait()
-    except Exception:
-        return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text="isolated worker: empty result")
-    if not msg.get("ok"):
-        return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=str(msg.get("error") or "isolated worker unknown error"))
-    return msg.get("result")
+    payload = _build_isolated_candidate_payload(kwargs)
+    start_errors: list[str] = []
+
+    for method_idx, start_method in enumerate(start_methods):
+        is_last_method = method_idx == len(start_methods) - 1
+        parent_conn = None
+        child_conn = None
+        proc = None
+        try:
+            ctx = mp.get_context(start_method)
+            parent_conn, child_conn = ctx.Pipe(duplex=False)
+            proc = ctx.Process(target=_cluster_candidate_worker, args=(payload, child_conn), daemon=True)
+            proc.start()
+            child_conn.close()
+            child_conn = None
+        except Exception as exc:
+            start_errors.append(f"{start_method}: {exc}")
+            for conn in (child_conn, parent_conn):
+                try:
+                    if conn is not None:
+                        conn.close()
+                except Exception:
+                    pass
+            continue
+
+        if effective_timeout_sec is None:
+            proc.join()
+        else:
+            proc.join(timeout=effective_timeout_sec)
+
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=1.0)
+            parent_conn.close()
+            timeout_label = f"{effective_timeout_sec:.1f}" if effective_timeout_sec is not None else "unknown"
+            return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="invalid", error_text=f"hard-timeout>{timeout_label}s (isolated worker killed, start_method={start_method})")
+        if proc.exitcode not in (0, None):
+            parent_conn.close()
+            error_text = f"isolated worker exitcode={proc.exitcode} (start_method={start_method})"
+            if not is_last_method:
+                start_errors.append(error_text)
+                continue
+            return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=error_text)
+        try:
+            msg = parent_conn.recv() if parent_conn.poll(1.0) else None
+        except Exception:
+            msg = None
+        finally:
+            parent_conn.close()
+        if not msg:
+            error_text = f"isolated worker: empty result (start_method={start_method})"
+            if not is_last_method:
+                start_errors.append(error_text)
+                continue
+            return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=error_text)
+        if not msg.get("ok"):
+            return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=str(msg.get("error") or "isolated worker unknown error"))
+        return msg.get("result")
+
+    return make_candidate_result(candidate_id=candidate_id, candidate_config=candidate, status="error", error_text=f"isolated worker start failed ({'; '.join(start_errors)})")
 
 

--- a/tests/test_cluster_auto_max_clusters.py
+++ b/tests/test_cluster_auto_max_clusters.py
@@ -179,3 +179,54 @@ def test_build_fine_search_space_clamps_kmeans_and_gmm_to_max_clusters(auto_cand
         params = candidate["method_params"]
         assert params.get("kmeans_n_clusters", 0) <= 4
         assert params.get("gmm_n_components", 0) <= 4
+
+
+def test_candidate_worker_uses_only_fork_to_avoid_second_gui_window(auto_candidates, monkeypatch):
+    class MpStub:
+        @staticmethod
+        def get_all_start_methods():
+            return ["fork", "forkserver", "spawn"]
+
+    monkeypatch.setattr(auto_candidates, "mp", MpStub, raising=False)
+
+    assert auto_candidates._get_candidate_worker_start_methods() == ["fork"]
+    assert auto_candidates._select_candidate_worker_start_method() == "fork"
+
+
+def test_isolated_candidate_payload_drops_runtime_caches(auto_candidates):
+    payload = auto_candidates._build_isolated_candidate_payload({
+        "candidate_id": "C001",
+        "transform_cache": {"old": "value"},
+        "preprocess_cache": {"old": "value"},
+        "preprocess_rank_cache": {"old": "value"},
+        "metrics_cache": {"old": "value"},
+        "base_data": [[1.0]],
+    })
+
+    assert payload["transform_cache"] is None
+    assert payload["preprocess_cache"] is None
+    assert payload["preprocess_rank_cache"] is None
+    assert payload["metrics_cache"] is None
+    assert payload["base_data"] == [[1.0]]
+
+
+def test_candidate_without_ui_timeout_runs_inline(auto_candidates, monkeypatch):
+    called = {}
+
+    def run_cluster_candidate(**kwargs):
+        called["kwargs"] = kwargs
+        return {"status": "ok", "candidate_id": kwargs.get("candidate_id")}
+
+    class MpStub:
+        @staticmethod
+        def get_all_start_methods():
+            raise AssertionError("multiprocessing must not be used without explicit UI timeout")
+
+    monkeypatch.setattr(auto_candidates, "run_cluster_candidate", run_cluster_candidate, raising=False)
+    monkeypatch.setattr(auto_candidates, "mp", MpStub, raising=False)
+
+    result = auto_candidates.run_cluster_candidate_isolated(candidate_id="C001", hard_timeout_sec=None)
+
+    assert result == {"status": "ok", "candidate_id": "C001"}
+    assert called["kwargs"]["candidate_id"] == "C001"
+    assert auto_candidates._resolve_candidate_hard_timeout(None) is None


### PR DESCRIPTION
### Motivation

- Prevent GUI re-initialization and accidental second windows by avoiding `spawn`/`forkserver` for isolated AUTO workers and prefer `fork` when available. 
- Avoid inheriting large runtime caches into subprocesses and allow running candidates inline when no UI hard-timeout is specified to prevent deadlocks. 
- Make IPC and timeout handling with isolated workers more robust and provide clearer error reporting.

### Description

- Replace the worker Queue-based IPC with a `Pipe` connection and update `_cluster_candidate_worker` to send results via `out_conn.send` and always close the connection. 
- Add helper functions `
_get_candidate_worker_start_methods`, `_select_candidate_worker_start_method`, `_resolve_candidate_hard_timeout`, and `_build_isolated_candidate_payload` to choose safe start methods, resolve the effective timeout, and strip runtime caches from subprocess payloads. 
- Rework `run_cluster_candidate_isolated` to run inline when no hard UI timeout is provided, to iterate available start methods (prefer `fork`), spawn isolated processes with `mp.get_context(start_method)`, handle join/timeouts, kill/cleanup on hung workers, collect IPC results from the parent `Pipe`, and return detailed error statuses when startup or execution fails. 
- Add tests exercising the new behavior and payload sanitization in `tests/test_cluster_auto_max_clusters.py`.

### Testing

- Ran `tests/test_cluster_auto_max_clusters.py::test_candidate_worker_uses_only_fork_to_avoid_second_gui_window` which verifies start-method selection and it passed. 
- Ran `tests/test_cluster_auto_max_clusters.py::test_isolated_candidate_payload_drops_runtime_caches` which verifies runtime caches are removed from the isolated payload and it passed. 
- Ran `tests/test_cluster_auto_max_clusters.py::test_candidate_without_ui_timeout_runs_inline` which verifies inline execution when `hard_timeout_sec=None` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211b96be28832f81a77f2eba8cd08d)