### PR TITLE
Cache completed cluster calculations for GPR and Well Log

### DIFF
--- a/alembic/versions/d3e4f5a6b7c8_add_cluster_calculation_cache.py
+++ b/alembic/versions/d3e4f5a6b7c8_add_cluster_calculation_cache.py
@@ -1,0 +1,49 @@
+"""add persistent cluster calculation cache
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd3e4f5a6b7c8'
+down_revision: Union[str, None] = 'c2d3e4f5a6b7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _create_cache_table(table_name: str, owner_column: str, owner_table: str) -> None:
+    op.create_table(
+        table_name,
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column(owner_column, sa.Integer(), nullable=False),
+        sa.Column('cache_key', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('data_hash', sa.String(), nullable=False),
+        sa.Column('config_json', sa.Text(), nullable=False),
+        sa.Column('result_payload', sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint([owner_column], [f'{owner_table}.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(f'ix_{table_name}_{owner_column}', table_name, [owner_column], unique=False)
+    op.create_index(f'ix_{table_name}_cache_key', table_name, ['cache_key'], unique=True)
+
+
+def upgrade() -> None:
+    _create_cache_table('cluster_calculation_cache', 'object_set_id', 'object_set')
+    _create_cache_table('well_log_cluster_calculation_cache', 'dataset_id', 'well_log_cluster_dataset')
+
+
+def downgrade() -> None:
+    for table_name, owner_column in (
+        ('well_log_cluster_calculation_cache', 'dataset_id'),
+        ('cluster_calculation_cache', 'object_set_id'),
+    ):
+        op.drop_index(f'ix_{table_name}_cache_key', table_name=table_name)
+        op.drop_index(f'ix_{table_name}_{owner_column}', table_name=table_name)
+        op.drop_table(table_name)

--- a/cluster/__init__.py
+++ b/cluster/__init__.py
@@ -14,6 +14,7 @@ _MODULE_NAMES = (
     "auto_candidates",
     "auto_runner",
     "auto_cache",
+    "result_cache",
     "profile_cache",
     "objects",
     "core",

--- a/cluster/actions.py
+++ b/cluster/actions.py
@@ -2,12 +2,53 @@ from __future__ import annotations
 
 from .common import *
 
-def calculate_well_log_cluster(run_context: ClusterRunContext) -> WellLogClusterVisualizationData | None:
+def calculate_well_log_cluster(
+        run_context: ClusterRunContext,
+        config: dict[str, Any] | None = None
+) -> WellLogClusterVisualizationData | None:
     """
     Выполняет ручной CALC для Well Log через общий pipeline clean → scale → PCA → cluster → metrics.
     """
     data = run_context["raw_rows"]
-    config = _read_manual_cluster_ui_config()
+    config = config or _read_manual_cluster_ui_config()
+    cache_key = build_cluster_calculation_cache_key(
+        source_type="well_log",
+        dataset_id=int(run_context["dataset_id"]),
+        data_hash=str(run_context.get("data_hash", "")),
+        config=config,
+    )
+    cached_result = load_cluster_calculation_cache(
+        source_type="well_log",
+        dataset_id=int(run_context["dataset_id"]),
+        cache_key=cache_key,
+    )
+    labels_for_output = get_cached_cluster_labels(cached_result, result_type="well_log")
+    if labels_for_output is not None:
+        visualization_data = cached_result.get("visualization_data")
+        data_pca = cached_result.get("data_for_diagnostics", [])
+        if isinstance(visualization_data, dict):
+            well_log_cluster_result_cache[int(run_context["dataset_id"])] = visualization_data
+            report_text = str(cached_result.get("report_text") or "")
+            if report_text:
+                set_info(report_text, "blue")
+            try:
+                show_cluster_diagnostics(
+                    data_for_clustering=data_pca,
+                    labels=labels_for_output,
+                    method_name=str(cached_result.get("method") or config["method"]),
+                )
+                set_info("CALC Well Log: обновлены диагностические графики качества кластеризации.", "blue")
+            except Exception as exc:
+                set_info(f"CALC Well Log: не удалось построить диагностические графики: {exc}", "brown")
+            show_well_log_cluster_visualization(visualization_data)
+            set_info("CALC Well Log: результат загружен из базы данных без повторного расчета.", "green")
+            set_info(
+                f"CALC Well Log: расчет завершен, labels={len(labels_for_output)}, "
+                f"clusters={visualization_data.get('summary', {}).get('cluster_count', 0)}.",
+                "green"
+            )
+            return visualization_data
+
     clear_data, kept_row_indices = clean_features(data=data, **config["clean"])
     if not clear_data:
         set_info("CALC Well Log: после очистки не осталось строк для кластеризации.", "brown")
@@ -125,6 +166,21 @@ def calculate_well_log_cluster(run_context: ClusterRunContext) -> WellLogCluster
         smoothing_changes=smoothing_changes,
     )
     well_log_cluster_result_cache[int(run_context["dataset_id"])] = visualization_data
+    save_cluster_calculation_cache(
+        source_type="well_log",
+        dataset_id=int(run_context["dataset_id"]),
+        cache_key=cache_key,
+        data_hash=str(run_context.get("data_hash", "")),
+        config=config,
+        result_payload={
+            "result_type": "well_log",
+            "visualization_data": visualization_data,
+            "labels": labels_for_output,
+            "data_for_diagnostics": np.asarray(data_pca).tolist(),
+            "method": config["method"],
+            "report_text": report_text,
+        },
+    )
 
     try:
         show_cluster_diagnostics(
@@ -149,9 +205,11 @@ def calculate_cluster():
     if run_context is None:
         return
 
+    manual_config = _read_manual_cluster_ui_config()
+
     if run_context["source_type"] == "well_log":
         try:
-            calculate_well_log_cluster(run_context)
+            calculate_well_log_cluster(run_context, manual_config)
         except Exception as exc:
             set_info(f"CALC Well Log: ошибка расчета: {exc}", "red")
             try:
@@ -231,17 +289,52 @@ def calculate_cluster():
     else:
         clust_method_analys = "kmeans"
 
-    label_list, clust_info = cluster_data(
-        data=data_pca,
-        method=clust_method_analys,
-        kmeans_n_clusters=kmeans_n,
-        kmeans_n_init=kmeans_n_init,
-        hdbscan_min_cluster_size=hdbsc_min_size,
-        hdbscan_min_samples=hdbsc_min_sample,
-        hdbscan_metric=hdbsc_type,
-        gmm_n_components=gmm_n,
-        gmm_covariance_type=gmm_type
+    cache_key = build_cluster_calculation_cache_key(
+        source_type="gpr",
+        dataset_id=clust_object_id,
+        data_hash=str(run_context.get("data_hash", "")),
+        config=manual_config,
     )
+    cached_result = load_cluster_calculation_cache(
+        source_type="gpr",
+        dataset_id=clust_object_id,
+        cache_key=cache_key,
+    )
+    label_list = get_cached_cluster_labels(
+        cached_result,
+        result_type="gpr",
+        expected_count=len(data_pca),
+    )
+    if label_list is not None:
+        clust_info = dict(cached_result.get("cluster_info") or {})
+        set_info("CALC: результат кластеризации загружен из базы данных без повторного расчета.", "green")
+    else:
+        label_list = []
+
+    if not label_list:
+        label_list, clust_info = cluster_data(
+            data=data_pca,
+            method=clust_method_analys,
+            kmeans_n_clusters=kmeans_n,
+            kmeans_n_init=kmeans_n_init,
+            hdbscan_min_cluster_size=hdbsc_min_size,
+            hdbscan_min_samples=hdbsc_min_sample,
+            hdbscan_metric=hdbsc_type,
+            gmm_n_components=gmm_n,
+            gmm_covariance_type=gmm_type
+        )
+        save_cluster_calculation_cache(
+            source_type="gpr",
+            dataset_id=clust_object_id,
+            cache_key=cache_key,
+            data_hash=str(run_context.get("data_hash", "")),
+            config=manual_config,
+            result_payload={
+                "result_type": "gpr",
+                "labels": [int(value) for value in label_list],
+                "cluster_info": clust_info,
+            },
+        )
 
     labels_for_output = list(label_list)
     profile_trace_rows: dict[int, dict[int, int]] = {}

--- a/cluster/result_cache.py
+++ b/cluster/result_cache.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from .common import *
+
+
+CLUSTER_CALC_CACHE_SCHEMA_VERSION = 1
+CLUSTER_CALC_CACHE_GZIP_PREFIX = "gzjson:"
+
+
+def build_cluster_calculation_cache_key(
+        *,
+        source_type: str,
+        dataset_id: int,
+        data_hash: str,
+        config: dict[str, Any]
+) -> str:
+    """Builds a stable key for a completed CALC result."""
+    payload = {
+        "schema_version": CLUSTER_CALC_CACHE_SCHEMA_VERSION,
+        "source_type": str(source_type or "").strip().lower(),
+        "dataset_id": int(dataset_id),
+        "data_hash": str(data_hash or ""),
+        "config": config or {},
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def encode_cluster_calculation_payload(payload: dict[str, Any]) -> str:
+    """Serializes and compresses a CALC result for a Text database column."""
+    raw = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), default=str).encode("utf-8")
+    return CLUSTER_CALC_CACHE_GZIP_PREFIX + base64.b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def decode_cluster_calculation_payload(value: str) -> dict[str, Any] | None:
+    """Deserializes a CALC cache payload, including uncompressed legacy JSON."""
+    if not value:
+        return None
+    try:
+        if value.startswith(CLUSTER_CALC_CACHE_GZIP_PREFIX):
+            compressed = base64.b64decode(value[len(CLUSTER_CALC_CACHE_GZIP_PREFIX):].encode("ascii"))
+            decoded = gzip.decompress(compressed).decode("utf-8")
+        else:
+            decoded = value
+        payload = json.loads(decoded)
+        return payload if isinstance(payload, dict) else None
+    except Exception:
+        return None
+
+
+def get_cached_cluster_labels(
+        payload: dict[str, Any] | None,
+        *,
+        result_type: str,
+        expected_count: int | None = None
+) -> list[int] | None:
+    """Validates the cache kind and returns normalized labels for a cache hit."""
+    if not payload or payload.get("result_type") != result_type:
+        return None
+    try:
+        labels = [int(value) for value in payload.get("labels", [])]
+    except (TypeError, ValueError):
+        return None
+    if not labels:
+        return None
+    if expected_count is not None and len(labels) != int(expected_count):
+        return None
+    return labels
+
+
+def _cluster_calculation_cache_model(source_type: str):
+    if str(source_type or "").strip().lower() == "well_log":
+        return WellLogClusterCalculationCache
+    return ClusterCalculationCache
+
+
+def _ensure_cluster_calculation_cache_table(source_type: str) -> None:
+    _cluster_calculation_cache_model(source_type).__table__.create(bind=engine, checkfirst=True)
+
+
+def load_cluster_calculation_cache(
+        *,
+        source_type: str,
+        dataset_id: int,
+        cache_key: str
+) -> dict[str, Any] | None:
+    """Loads a completed CALC result from the persistent cache."""
+    try:
+        _ensure_cluster_calculation_cache_table(source_type)
+        cache_model = _cluster_calculation_cache_model(source_type)
+        id_field = "dataset_id" if cache_model is WellLogClusterCalculationCache else "object_set_id"
+        row = session.query(cache_model).filter_by(
+            cache_key=str(cache_key),
+            **{id_field: int(dataset_id)},
+        ).first()
+        if row is None:
+            return None
+        return decode_cluster_calculation_payload(row.result_payload)
+    except Exception as exc:
+        set_info(f"CALC: ошибка чтения сохраненного результата: {exc}", "brown")
+        return None
+
+
+def save_cluster_calculation_cache(
+        *,
+        source_type: str,
+        dataset_id: int,
+        cache_key: str,
+        data_hash: str,
+        config: dict[str, Any],
+        result_payload: dict[str, Any]
+) -> None:
+    """Creates or updates a persistent completed-CALC cache record."""
+    try:
+        _ensure_cluster_calculation_cache_table(source_type)
+        cache_model = _cluster_calculation_cache_model(source_type)
+        id_field = "dataset_id" if cache_model is WellLogClusterCalculationCache else "object_set_id"
+        id_filter = {id_field: int(dataset_id)}
+        row = session.query(cache_model).filter_by(cache_key=str(cache_key), **id_filter).first()
+        if row is None:
+            row = cache_model(cache_key=str(cache_key), **id_filter)
+            session.add(row)
+        row.created_at = dt.datetime.utcnow()
+        row.data_hash = str(data_hash or "")
+        row.config_json = json.dumps(config or {}, ensure_ascii=False, sort_keys=True, default=str)
+        row.result_payload = encode_cluster_calculation_payload(result_payload or {})
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        set_info(f"CALC: ошибка сохранения результата: {exc}", "brown")

--- a/models_db/model_cluster.py
+++ b/models_db/model_cluster.py
@@ -25,6 +25,7 @@ class ObjectSet(Base):
     analysis = relationship('AnalysisCluster', back_populates='object_set')
     auto_tuning_cache = relationship('ClusterAutoTuningCache', back_populates='object_set', cascade='all, delete-orphan')
     auto_tuning_runs = relationship('ClusterAutoTuningRunState', back_populates='object_set', cascade='all, delete-orphan')
+    calculation_cache = relationship('ClusterCalculationCache', back_populates='object_set', cascade='all, delete-orphan')
 
 
 class ClusterAutoTuningCache(Base):
@@ -49,6 +50,22 @@ class WellLogClusterAutoTuningCache(Base):
     top_results = Column(Text, nullable=False)
 
     well_cluster_set = relationship('WellLogClusterDataset', back_populates='auto_tuning_cache')
+
+
+class ClusterCalculationCache(Base):
+    __tablename__ = 'cluster_calculation_cache'
+
+    id = Column(Integer, primary_key=True)
+    object_set_id = Column(Integer, ForeignKey('object_set.id'), nullable=False, index=True)
+    cache_key = Column(String, nullable=False, unique=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    data_hash = Column(String, nullable=False)
+    config_json = Column(Text, nullable=False)
+    result_payload = Column(Text, nullable=False)
+
+    object_set = relationship('ObjectSet', back_populates='calculation_cache')
+
+
 
 
 class ClusterAutoTuningRunState(Base):
@@ -85,6 +102,23 @@ class WellLogClusterDataset(Base):
     cluster_well_log_param_from_calculator = relationship('ClusterWellLogParameterFromCalculator', back_populates='well_cluster_set', cascade='all, delete-orphan')
     data = relationship('WellLogClusterDatasetData', back_populates='well_cluster_set', cascade='all, delete-orphan')
     auto_tuning_cache = relationship('WellLogClusterAutoTuningCache', back_populates='well_cluster_set', cascade='all, delete-orphan')
+    calculation_cache = relationship('WellLogClusterCalculationCache', back_populates='well_cluster_set', cascade='all, delete-orphan')
+
+
+class WellLogClusterCalculationCache(Base):
+    __tablename__ = 'well_log_cluster_calculation_cache'
+
+    id = Column(Integer, primary_key=True)
+    dataset_id = Column(Integer, ForeignKey('well_log_cluster_dataset.id'), nullable=False, index=True)
+    cache_key = Column(String, nullable=False, unique=True, index=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    data_hash = Column(String, nullable=False)
+    config_json = Column(Text, nullable=False)
+    result_payload = Column(Text, nullable=False)
+
+    well_cluster_set = relationship('WellLogClusterDataset', back_populates='calculation_cache')
+
+
 
 
 class WellForCluster(Base):

--- a/tests/test_cluster_calculation_cache.py
+++ b/tests/test_cluster_calculation_cache.py
@@ -1,0 +1,117 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def load_result_cache_module():
+    common = types.ModuleType("cluster.common")
+    common.__dict__.update(
+        {
+            "Any": object,
+            "json": json,
+            "hashlib": __import__("hashlib"),
+            "base64": __import__("base64"),
+            "gzip": __import__("gzip"),
+        }
+    )
+    package = types.ModuleType("cluster")
+    package.__path__ = [str(Path("cluster").resolve())]
+    sys.modules["cluster"] = package
+    sys.modules["cluster.common"] = common
+
+    spec = importlib.util.spec_from_file_location(
+        "cluster.result_cache",
+        Path("cluster/result_cache.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cluster.result_cache"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_calculation_cache_key_is_stable_for_equivalent_config_order():
+    module = load_result_cache_module()
+
+    first = module.build_cluster_calculation_cache_key(
+        source_type="gpr",
+        dataset_id=7,
+        data_hash="data-v1",
+        config={"method": "kmeans", "params": {"n_init": 10, "clusters": 4}},
+    )
+    second = module.build_cluster_calculation_cache_key(
+        source_type="GPR",
+        dataset_id=7,
+        data_hash="data-v1",
+        config={"params": {"clusters": 4, "n_init": 10}, "method": "kmeans"},
+    )
+
+    assert first == second
+
+
+def test_calculation_cache_key_changes_with_data_or_settings():
+    module = load_result_cache_module()
+    base = module.build_cluster_calculation_cache_key(
+        source_type="well_log",
+        dataset_id=3,
+        data_hash="data-v1",
+        config={"method": "kmeans", "clusters": 3},
+    )
+
+    changed_data = module.build_cluster_calculation_cache_key(
+        source_type="well_log",
+        dataset_id=3,
+        data_hash="data-v2",
+        config={"method": "kmeans", "clusters": 3},
+    )
+    changed_settings = module.build_cluster_calculation_cache_key(
+        source_type="well_log",
+        dataset_id=3,
+        data_hash="data-v1",
+        config={"method": "kmeans", "clusters": 4},
+    )
+
+    assert base != changed_data
+    assert base != changed_settings
+
+
+def test_calculation_payload_round_trip_and_invalid_value():
+    module = load_result_cache_module()
+    payload = {
+        "result_type": "well_log",
+        "labels": [0, 1, -1],
+        "visualization_data": {"dataset_title": "Каротаж №1"},
+    }
+
+    encoded = module.encode_cluster_calculation_payload(payload)
+
+    assert encoded.startswith(module.CLUSTER_CALC_CACHE_GZIP_PREFIX)
+    assert module.decode_cluster_calculation_payload(encoded) == payload
+    assert module.decode_cluster_calculation_payload("not-json") is None
+
+
+def test_cached_labels_accept_hits_for_gpr_and_well_log():
+    module = load_result_cache_module()
+
+    assert module.get_cached_cluster_labels(
+        {"result_type": "gpr", "labels": [0, 1, 1]},
+        result_type="gpr",
+        expected_count=3,
+    ) == [0, 1, 1]
+    assert module.get_cached_cluster_labels(
+        {"result_type": "well_log", "labels": [2, -1]},
+        result_type="well_log",
+    ) == [2, -1]
+
+
+def test_cached_labels_reject_wrong_source_stale_size_and_invalid_payload():
+    module = load_result_cache_module()
+    payload = {"result_type": "gpr", "labels": [0, 1]}
+
+    assert module.get_cached_cluster_labels(payload, result_type="well_log") is None
+    assert module.get_cached_cluster_labels(payload, result_type="gpr", expected_count=3) is None
+    assert module.get_cached_cluster_labels(
+        {"result_type": "gpr", "labels": ["bad"]},
+        result_type="gpr",
+    ) is None


### PR DESCRIPTION
### Motivation
- Ускорить повторные CALC-вычисления: при повторном запуске с теми же данными и настройками возвращать сохранённый результат из БД вместо повторного дорогостоящего расчёта. 
- Поддержать оба источника данных: георадар (GPR/ObjectSet) и каротаж (Well Log) с одинаковой семантикой инвалидации при изменении данных или настроек.

### Description
- Добавлен модуль `cluster/result_cache.py` с функциями `build_cluster_calculation_cache_key`, `encode_cluster_calculation_payload`, `decode_cluster_calculation_payload`, `load_cluster_calculation_cache`, `save_cluster_calculation_cache` и `get_cached_cluster_labels` для формирования ключей, сериализации/сжатия payload и чтения/записи кэша в БД.
- Расширены ORM-модели в `models_db/model_cluster.py` новыми таблицами `cluster_calculation_cache` и `well_log_cluster_calculation_cache` и соответствующими relationship-связями для `ObjectSet` и `WellLogClusterDataset`.
- Добавлена Alembic-миграция `alembic/versions/d3e4f5a6b7c8_add_cluster_calculation_cache.py`, создающая таблицы и индексы по владельцу и `cache_key`.
- Изменён `cluster/actions.py` так, чтобы при `CALC` сначала пытаться загрузить результат из persistent-cache (по ключу, учитывающему `source_type`, набор, `data_hash` и полную конфигурацию) и при наличии корректного payload восстанавливать визуализацию/diagnostics для `well_log` и метки/`cluster_info` для `gpr`; при cache-miss результат сохраняется в БД (payload gzip+base64 JSON).
- Добавлен импорт нового модуля в `cluster/__init__.py` и unit-тесты `tests/test_cluster_calculation_cache.py`, покрывающие стабильность/инвалидацию ключа, round-trip сериализацию и валидацию cached labels для GPR и Well Log.

### Testing
- Запущены автоматические тесты: `pytest -q tests` — 58 passed (включая новый тестовый файл). 
- Локальные модульные проверки: `pytest -q tests/test_cluster_calculation_cache.py` — 5 passed. 
- Пройдено статическое/байткод- и синтаксическое тестирование: `python -m py_compile` на изменённых файлах и `git diff --check` — без ошибок. 
- Примечание: полная автоколлекция репозитория в текущем окружении невозможна из-за отсутствия необязательных runtime-зависимостей (`SQLAlchemy`, `NumPy`), однако добавленные тесты и существующий `tests/` каталог успешно проходят.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27a0ed8c30832f9d8cb2ed0f1062f9)