### PR TITLE
Add ML Clutter Experiment dialog and integrate into main UI

### DIFF
--- a/geovel.py
+++ b/geovel.py
@@ -30,6 +30,7 @@ from noise import *
 from slice import *
 from calc_object_models import *
 from cluster import *
+from ml_clutter_experiment import MLClutterExperimentWindow
 
 MainWindow.show()
 
@@ -118,6 +119,23 @@ ui.pushButton_medfilt.clicked.connect(calc_medfilt)
 ui.pushButton_wiener.clicked.connect(calc_wiener)
 ui.pushButton_savgol.clicked.connect(calc_savgol)
 ui.pushButton_filtfilt.clicked.connect(calc_filtfilt)
+
+
+def open_ml_clutter_experiment():
+    global ml_clutter_experiment_window
+    if 'ml_clutter_experiment_window' not in globals() or ml_clutter_experiment_window is None:
+        ml_clutter_experiment_window = MLClutterExperimentWindow(
+            MainWindow,
+            profile_id_getter=get_profile_id,
+            profile_name_getter=get_profile_name,
+            info_callback=set_info,
+        )
+    ml_clutter_experiment_window.show()
+    ml_clutter_experiment_window.raise_()
+    ml_clutter_experiment_window.activateWindow()
+
+
+ui.pushButton_ml_clutter.clicked.connect(open_ml_clutter_experiment)
 ui.pushButton_wavelet_filter.clicked.connect(calc_wavelet_filter)
 ui.pushButton_calc_all_param.clicked.connect(calc_all_params)
 ui.toolButton_recalc_relief.clicked.connect(recalc_relief)

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -1,0 +1,106 @@
+import json
+
+import numpy as np
+from PyQt5 import QtWidgets
+
+from models_db.model import Profile, CurrentProfile, session
+from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
+
+
+class MLClutterExperimentWindow(QtWidgets.QDialog):
+    """Stage-1 control window for the experimental ML air-clutter workflow."""
+
+    def __init__(self, parent=None, profile_id_getter=None, profile_name_getter=None, info_callback=None):
+        super().__init__(parent)
+        self.ui = Ui_MLClutterExperiment()
+        self.ui.setupUi(self)
+        self.profile_id_getter = profile_id_getter
+        self.profile_name_getter = profile_name_getter
+        self.info_callback = info_callback
+        self.clean_profile = None
+        self.real_noisy_profile = None
+
+        self.ui.pushButton_refresh_profiles.clicked.connect(self.refresh_profiles)
+        self.ui.pushButton_use_current_profile.clicked.connect(self.use_current_profile)
+        self.ui.pushButton_load_clean.clicked.connect(lambda: self.load_selected_profile("clean"))
+        self.ui.pushButton_load_real_noisy.clicked.connect(lambda: self.load_selected_profile("real_noisy"))
+        self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
+        self.refresh_profiles()
+
+    def refresh_profiles(self):
+        self.ui.listWidget_profiles.clear()
+        for profile in session.query(Profile).order_by(Profile.id).all():
+            count_measure = self._safe_profile_trace_count(profile)
+            item = QtWidgets.QListWidgetItem(f"{profile.title} ({count_measure} measurements) id{profile.id}")
+            item.setData(256, profile.id)
+            self.ui.listWidget_profiles.addItem(item)
+        self._log("Profile list refreshed")
+
+    def use_current_profile(self):
+        current = session.query(CurrentProfile).first()
+        if current is None:
+            self._show_stats("Current profile is empty. Draw or load a profile first.")
+            self._log("Current profile is empty", "red")
+            return
+        data = np.array(json.loads(current.signal), dtype=float)
+        self.clean_profile = data
+        profile_name = self.profile_name_getter() if self.profile_name_getter else f"id{current.profile_id}"
+        self._show_stats(self._format_validation_report(profile_name, data, source="CurrentProfile -> clean"))
+        self._log(f"Current profile loaded as clean data for ML Clutter: {profile_name}")
+
+    def load_selected_profile(self, role):
+        item = self.ui.listWidget_profiles.currentItem()
+        if item is None:
+            self._show_stats("Select a profile in the list first.")
+            return
+        profile = session.query(Profile).filter_by(id=item.data(256)).first()
+        if profile is None:
+            self._show_stats("Selected profile was not found in the database.")
+            return
+        data = np.array(json.loads(profile.signal), dtype=float)
+        if role == "clean":
+            self.clean_profile = data
+            source = "database profile -> clean"
+        else:
+            self.real_noisy_profile = data
+            source = "database profile -> real noisy"
+        self._show_stats(self._format_validation_report(profile.title, data, source=source))
+        self._log(f"Profile '{profile.title}' loaded as {role.replace('_', ' ')}")
+
+    def show_selected_profile_stats(self):
+        item = self.ui.listWidget_profiles.currentItem()
+        if item is None:
+            return
+        profile = session.query(Profile).filter_by(id=item.data(256)).first()
+        if profile is None:
+            return
+        data = np.array(json.loads(profile.signal), dtype=float)
+        self._show_stats(self._format_validation_report(profile.title, data, source="database profile"))
+
+    @staticmethod
+    def _safe_profile_trace_count(profile):
+        try:
+            return len(json.loads(profile.signal))
+        except (TypeError, json.JSONDecodeError):
+            return 0
+
+    @staticmethod
+    def _format_validation_report(name, data, source):
+        lines = [f"Name: {name}", f"Source: {source}", f"Shape: {data.shape}"]
+        lines.append(f"2D array: {'OK' if data.ndim == 2 else 'ERROR'}")
+        lines.append(f"Expected [num_traces, 512]: {'OK' if data.ndim == 2 and data.shape[1] == 512 else 'WARNING'}")
+        lines.append(f"Finite amplitudes: {'OK' if np.isfinite(data).all() else 'ERROR'}")
+        if data.size:
+            lines.append(f"Min / Max: {np.nanmin(data):.6g} / {np.nanmax(data):.6g}")
+            lines.append(f"Mean / Std: {np.nanmean(data):.6g} / {np.nanstd(data):.6g}")
+        lines.append("Axis convention: rows are traces, columns are samples/time/depth.")
+        return "\n".join(lines)
+
+    def _show_stats(self, text):
+        self.ui.textEdit_profile_stats.setPlainText(text)
+        self.ui.textEdit_results_log.append(text)
+
+    def _log(self, text, color="green"):
+        self.ui.textEdit_results_log.append(text)
+        if self.info_callback:
+            self.info_callback(text, color)

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+from PyQt5 import QtCore, QtWidgets
+
+
+class Ui_MLClutterExperiment(object):
+    def setupUi(self, MLClutterExperiment):
+        MLClutterExperiment.setObjectName("MLClutterExperiment")
+        MLClutterExperiment.resize(980, 720)
+        self.verticalLayout = QtWidgets.QVBoxLayout(MLClutterExperiment)
+        self.verticalLayout.setObjectName("verticalLayout")
+        self.headerLabel = QtWidgets.QLabel(MLClutterExperiment)
+        self.headerLabel.setObjectName("headerLabel")
+        self.verticalLayout.addWidget(self.headerLabel)
+        self.tabWidget = QtWidgets.QTabWidget(MLClutterExperiment)
+        self.tabWidget.setObjectName("tabWidget")
+
+        self.tab_profiles = self._add_profiles_tab()
+        self.tab_noise_patterns = self._add_placeholder_tab(
+            "tab_noise_patterns",
+            "Add noisy radarograms and configure extraction of real air-clutter patterns.",
+        )
+        self.tab_generator = self._add_placeholder_tab(
+            "tab_generator",
+            "Configure analytical, real-pattern, or mixed clutter generation.",
+        )
+        self.tab_dataset = self._add_placeholder_tab(
+            "tab_dataset",
+            "Generate synthetic noisy/clean training pairs and patch datasets.",
+        )
+        self.tab_model = self._add_placeholder_tab(
+            "tab_model",
+            "Choose baseline CNN, DnCNN, or U-Net model settings.",
+        )
+        self.tab_training = self._add_placeholder_tab(
+            "tab_training",
+            "Run training, validation, checkpoints, and training metrics.",
+        )
+        self.tab_inference = self._add_placeholder_tab(
+            "tab_inference",
+            "Apply trained clutter-removal models to synthetic or real profiles.",
+        )
+        self.tab_results = self._add_results_tab()
+
+        self.verticalLayout.addWidget(self.tabWidget)
+        self.retranslateUi(MLClutterExperiment)
+        self.tabWidget.setCurrentIndex(0)
+        QtCore.QMetaObject.connectSlotsByName(MLClutterExperiment)
+
+    def _add_profiles_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_profiles")
+        layout = QtWidgets.QGridLayout(tab)
+        layout.setObjectName("gridLayout_profiles")
+        self.listWidget_profiles = QtWidgets.QListWidget(tab)
+        self.listWidget_profiles.setObjectName("listWidget_profiles")
+        layout.addWidget(self.listWidget_profiles, 1, 0, 6, 1)
+        self.pushButton_refresh_profiles = QtWidgets.QPushButton(tab)
+        self.pushButton_refresh_profiles.setObjectName("pushButton_refresh_profiles")
+        layout.addWidget(self.pushButton_refresh_profiles, 1, 1)
+        self.pushButton_use_current_profile = QtWidgets.QPushButton(tab)
+        self.pushButton_use_current_profile.setObjectName("pushButton_use_current_profile")
+        layout.addWidget(self.pushButton_use_current_profile, 2, 1)
+        self.pushButton_load_clean = QtWidgets.QPushButton(tab)
+        self.pushButton_load_clean.setObjectName("pushButton_load_clean")
+        layout.addWidget(self.pushButton_load_clean, 3, 1)
+        self.pushButton_load_real_noisy = QtWidgets.QPushButton(tab)
+        self.pushButton_load_real_noisy.setObjectName("pushButton_load_real_noisy")
+        layout.addWidget(self.pushButton_load_real_noisy, 4, 1)
+        self.groupBox_profile_stats = QtWidgets.QGroupBox(tab)
+        self.groupBox_profile_stats.setObjectName("groupBox_profile_stats")
+        stats_layout = QtWidgets.QVBoxLayout(self.groupBox_profile_stats)
+        self.textEdit_profile_stats = QtWidgets.QTextEdit(self.groupBox_profile_stats)
+        self.textEdit_profile_stats.setReadOnly(True)
+        self.textEdit_profile_stats.setObjectName("textEdit_profile_stats")
+        stats_layout.addWidget(self.textEdit_profile_stats)
+        layout.addWidget(self.groupBox_profile_stats, 7, 0, 1, 2)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
+    def _add_placeholder_tab(self, object_name, message):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName(object_name)
+        layout = QtWidgets.QVBoxLayout(tab)
+        label = QtWidgets.QLabel(tab)
+        label.setWordWrap(True)
+        label.setText(message)
+        layout.addWidget(label)
+        layout.addStretch()
+        self.tabWidget.addTab(tab, "")
+        return tab
+
+    def _add_results_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_results")
+        layout = QtWidgets.QVBoxLayout(tab)
+        self.textEdit_results_log = QtWidgets.QTextEdit(tab)
+        self.textEdit_results_log.setReadOnly(True)
+        self.textEdit_results_log.setObjectName("textEdit_results_log")
+        layout.addWidget(self.textEdit_results_log)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
+    def retranslateUi(self, MLClutterExperiment):
+        _translate = QtCore.QCoreApplication.translate
+        MLClutterExperiment.setWindowTitle(_translate("MLClutterExperiment", "ML Clutter Experiment"))
+        self.headerLabel.setText(_translate("MLClutterExperiment", "Experimental ML Clutter block: data, generator, dataset, model, training, inference and results."))
+        self.pushButton_refresh_profiles.setText(_translate("MLClutterExperiment", "Refresh"))
+        self.pushButton_use_current_profile.setText(_translate("MLClutterExperiment", "Use Current Profile"))
+        self.pushButton_load_clean.setText(_translate("MLClutterExperiment", "Load as Clean"))
+        self.pushButton_load_real_noisy.setText(_translate("MLClutterExperiment", "Load as Real Noisy"))
+        self.groupBox_profile_stats.setTitle(_translate("MLClutterExperiment", "Profile statistics and validation"))
+        tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
+        for index, name in enumerate(tab_names):
+            self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))


### PR DESCRIPTION
### Motivation

- Provide an integrated experimental workbench for ML-based air-clutter workflows to inspect and prepare profile data for dataset/model development.
- Allow quick selection of database profiles or the current drawn profile and validate basic shape/statistics before further processing.

### Description

- Add a new dialog `MLClutterExperimentWindow` implemented in `ml_clutter_experiment.py` that lists `Profile` entries, loads a `CurrentProfile`, and displays validation/stats about selected signals. 
- Add a Qt form `qt/ml_clutter_experiment_form.py` which implements the UI tabs (Profiles, Noise Patterns, Generator, Dataset, Model, Training, Inference, Results) and widgets used by the dialog. 
- Integrate the dialog into the main application by importing `MLClutterExperimentWindow` in `geovel.py`, adding the `open_ml_clutter_experiment` helper, and connecting it to `ui.pushButton_ml_clutter`. 
- Use existing DB models (`models_db.model.Profile`, `CurrentProfile`, `session`), JSON decoding and `numpy` for signal validation and summary metrics.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33e91c8574832f9f4d93a8df79e8cb)