### PR TITLE
Добавить валидацию и загрузку профилей для ML Clutter

### DIFF
--- a/geovel.py
+++ b/geovel.py
@@ -129,6 +129,7 @@ def open_ml_clutter_experiment():
             profile_id_getter=get_profile_id,
             profile_name_getter=get_profile_name,
             info_callback=set_info,
+            visualization_callback=lambda data, title: (draw_image(data), set_info(title, 'blue')),
         )
     ml_clutter_experiment_window.show()
     ml_clutter_experiment_window.raise_()

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -8,17 +8,26 @@ from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
 
 
 class MLClutterExperimentWindow(QtWidgets.QDialog):
-    """Stage-1 control window for the experimental ML air-clutter workflow."""
+    """Control window for the experimental ML air-clutter workflow."""
 
     PROFILE_ID_ROLE = 256
+    MIN_NUM_TRACES = 1
 
-    def __init__(self, parent=None, profile_id_getter=None, profile_name_getter=None, info_callback=None):
+    def __init__(
+        self,
+        parent=None,
+        profile_id_getter=None,
+        profile_name_getter=None,
+        info_callback=None,
+        visualization_callback=None,
+    ):
         super().__init__(parent)
         self.ui = Ui_MLClutterExperiment()
         self.ui.setupUi(self)
         self.profile_id_getter = profile_id_getter
         self.profile_name_getter = profile_name_getter
         self.info_callback = info_callback
+        self.visualization_callback = visualization_callback
         self.clean_profile = None
         self.real_noisy_profile = None
         self.experiment_profiles = {}
@@ -44,12 +53,12 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             self._show_stats(f"Profile id{profile_id} was not found in the database.")
             self._log(f"ML Clutter: profile id{profile_id} was not found", "red")
             return
-        data = np.array(json.loads(profile.signal), dtype=float)
+        data = self._profile_signal_to_array(profile.signal)
         self.experiment_profiles[profile.id] = {"profile": profile, "data": data}
 
         existing_item = self._find_experiment_item(profile.id)
         if existing_item is None:
-            item = QtWidgets.QListWidgetItem(f"{profile.title} ({data.shape[0]} measurements) id{profile.id}")
+            item = QtWidgets.QListWidgetItem(f"{profile.title} ({data.shape[0]} traces) id{profile.id}")
             item.setData(self.PROFILE_ID_ROLE, profile.id)
             self.ui.listWidget_profiles.addItem(item)
             self.ui.listWidget_profiles.setCurrentItem(item)
@@ -65,11 +74,9 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             self._show_stats("CurrentProfile is empty. Draw or load a profile first.")
             self._log("ML Clutter: CurrentProfile is empty", "red")
             return
-        data = np.array(json.loads(current.signal), dtype=float)
-        self.clean_profile = data
+        data = self._profile_signal_to_array(current.signal)
         profile_name = self.profile_name_getter() if self.profile_name_getter else f"id{current.profile_id}"
-        self._show_stats(self._format_validation_report(profile_name, data, source="drawn CurrentProfile -> clean"))
-        self._log(f"Drawn CurrentProfile loaded as clean data for ML Clutter: {profile_name}")
+        self._load_profile_array(data, "clean", profile_name, "drawn CurrentProfile -> clean")
 
     def load_selected_profile(self, role):
         item = self.ui.listWidget_profiles.currentItem()
@@ -83,14 +90,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             return
         profile = profile_entry["profile"]
         data = profile_entry["data"]
-        if role == "clean":
-            self.clean_profile = data
-            source = "experiment profile -> clean"
-        else:
-            self.real_noisy_profile = data
-            source = "experiment profile -> real noisy"
-        self._show_stats(self._format_validation_report(profile.title, data, source=source))
-        self._log(f"Experiment profile '{profile.title}' loaded as {role.replace('_', ' ')}")
+        source = "experiment profile -> clean" if role == "clean" else "experiment profile -> real noisy"
+        self._load_profile_array(data, role, profile.title, source)
 
     def show_selected_profile_stats(self):
         item = self.ui.listWidget_profiles.currentItem()
@@ -103,6 +104,74 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         data = profile_entry["data"]
         self._show_stats(self._format_validation_report(profile.title, data, source="experiment profile"))
 
+    def _load_profile_array(self, data, role, name, source):
+        prepared, validation = self._prepare_profile_for_role(data, name)
+        self._show_stats(self._format_validation_report(name, prepared, source=source, validation=validation))
+        if not validation["valid"]:
+            self._log(f"ML Clutter: profile '{name}' rejected as {role.replace('_', ' ')}: {validation['reason']}", "red")
+            return
+        if role == "clean":
+            self.clean_profile = prepared
+        else:
+            self.real_noisy_profile = prepared
+        self._display_profile(prepared, f"ML Clutter {role.replace('_', ' ')}: {name}")
+        self._log(f"Profile '{name}' loaded as {role.replace('_', ' ')} and displayed in MainWindow")
+
+    def _prepare_profile_for_role(self, data, name):
+        validation = self.validate_profile(data)
+        if validation["needs_transpose"]:
+            answer = QtWidgets.QMessageBox.question(
+                self,
+                "Transpose profile?",
+                (
+                    f"Profile '{name}' has shape {data.shape}. It looks like [512, num_traces].\n"
+                    "Transpose it to [num_traces, 512]?"
+                ),
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.Yes,
+            )
+            if answer == QtWidgets.QMessageBox.Yes:
+                data = data.T
+                validation = self.validate_profile(data)
+                validation["transposed"] = True
+        return data, validation
+
+    @classmethod
+    def validate_profile(cls, data):
+        result = {"valid": False, "reason": "", "needs_transpose": False, "transposed": False}
+        if data.ndim != 2:
+            result["reason"] = f"Profile must be a 2D array, got ndim={data.ndim}."
+            return result
+        if data.shape[1] != 512:
+            if data.shape[0] == 512:
+                result["needs_transpose"] = True
+                result["reason"] = "Profile has [512, num_traces] shape and must be transposed."
+            else:
+                result["reason"] = f"Profile must have 512 samples per trace, got shape={data.shape}."
+            return result
+        if data.shape[0] < cls.MIN_NUM_TRACES:
+            result["reason"] = f"Profile must contain at least {cls.MIN_NUM_TRACES} traces, got {data.shape[0]}."
+            return result
+        if np.isnan(data).any():
+            result["reason"] = "Profile contains NaN values."
+            return result
+        if np.isinf(data).any():
+            result["reason"] = "Profile contains infinite values."
+            return result
+        if not np.isfinite(data).all():
+            result["reason"] = "Profile contains non-finite amplitudes."
+            return result
+        result["valid"] = True
+        result["reason"] = "OK"
+        return result
+
+    def _display_profile(self, data, title):
+        if self.visualization_callback:
+            self.visualization_callback(data.tolist(), title)
+
+    @staticmethod
+    def _profile_signal_to_array(signal):
+        return np.array(json.loads(signal), dtype=float)
 
     def _find_experiment_item(self, profile_id):
         for row in range(self.ui.listWidget_profiles.count()):
@@ -111,17 +180,48 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
                 return item
         return None
 
-    @staticmethod
-    def _format_validation_report(name, data, source):
+    @classmethod
+    def _format_validation_report(cls, name, data, source, validation=None):
+        validation = validation or cls.validate_profile(data)
+        stats = cls.profile_statistics(data)
         lines = [f"Name: {name}", f"Source: {source}", f"Shape: {data.shape}"]
-        lines.append(f"2D array: {'OK' if data.ndim == 2 else 'ERROR'}")
-        lines.append(f"Expected [num_traces, 512]: {'OK' if data.ndim == 2 and data.shape[1] == 512 else 'WARNING'}")
-        lines.append(f"Finite amplitudes: {'OK' if np.isfinite(data).all() else 'ERROR'}")
-        if data.size:
-            lines.append(f"Min / Max: {np.nanmin(data):.6g} / {np.nanmax(data):.6g}")
-            lines.append(f"Mean / Std: {np.nanmean(data):.6g} / {np.nanstd(data):.6g}")
-        lines.append("Axis convention: rows are traces, columns are samples/time/depth.")
+        lines.append(f"Validation: {'OK' if validation['valid'] else 'ERROR'}")
+        lines.append(f"Reason: {validation['reason']}")
+        if validation.get("needs_transpose"):
+            lines.append("Suggestion: transpose profile from [512, num_traces] to [num_traces, 512].")
+        if validation.get("transposed"):
+            lines.append("Action: profile was transposed to [num_traces, 512].")
+        lines.extend([
+            f"Traces: {stats['num_traces']}",
+            f"Samples per trace: {stats['samples_per_trace']}",
+            f"Min / Max: {stats['min']:.6g} / {stats['max']:.6g}",
+            f"Mean / Std: {stats['mean']:.6g} / {stats['std']:.6g}",
+            f"Median: {stats['median']:.6g}",
+            f"Percentile 1 / 99: {stats['p01']:.6g} / {stats['p99']:.6g}",
+            f"Has NaN: {'yes' if stats['has_nan'] else 'no'}",
+            f"Has inf: {'yes' if stats['has_inf'] else 'no'}",
+            "Axis convention: rows are traces, columns are samples/time/depth.",
+        ])
         return "\n".join(lines)
+
+    @staticmethod
+    def profile_statistics(data):
+        finite = data[np.isfinite(data)]
+        if finite.size == 0:
+            finite = np.array([np.nan])
+        return {
+            "num_traces": data.shape[0] if data.ndim >= 1 else 0,
+            "samples_per_trace": data.shape[1] if data.ndim == 2 else 0,
+            "min": float(np.nanmin(finite)),
+            "max": float(np.nanmax(finite)),
+            "mean": float(np.nanmean(finite)),
+            "std": float(np.nanstd(finite)),
+            "median": float(np.nanmedian(finite)),
+            "p01": float(np.nanpercentile(finite, 1)),
+            "p99": float(np.nanpercentile(finite, 99)),
+            "has_nan": bool(np.isnan(data).any()),
+            "has_inf": bool(np.isinf(data).any()),
+        }
 
     def _show_stats(self, text):
         self.ui.textEdit_profile_stats.setPlainText(text)


### PR DESCRIPTION
### Motivation
- Реализовать этап 2 из плана ML Clutter: позволить выбирать профиль из приложения, загружать его как `clean` или `real noisy`, валидировать форму и сразу отображать в главном окне. 

### Description
- Добавлен поток загрузки и валидации профиля в `ml_clutter_experiment.py`: `add_current_selected_profile`, `use_drawn_current_profile`, `load_selected_profile` теперь используют единый обработчик `_load_profile_array` с проверкой и подсказкой о транспозиции. 
- Реализованы правила валидации `validate_profile` (2D, 512 сэмплов на трассу, минимум трасс, отсутствие NaN/inf) и подготовка-перетаскивание `_prepare_profile_for_role` с диалогом транспонирования. 
- Добавлены расчёт и форматирование статистики профиля (`profile_statistics`, `_format_validation_report`) и отправка принятого профиля на визуализацию через callback `visualization_callback`. 
- Обновлён `geovel.py` чтобы передавать `visualization_callback=lambda data, title: (draw_image(data), set_info(title, 'blue'))` в конструктор окна эксперимента. 

### Testing
- Скомпилированы изменённые модули для проверки синтаксиса: `python -m py_compile ml_clutter_experiment.py geovel.py` и `python -m compileall ml_clutter_experiment.py geovel.py`, оба запуски прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f1b64788832fa12702bc5131ef72)