### PR TITLE
Implement ML Clutter synthetic generator

### DIFF
--- a/ml_air_clutter/config.py
+++ b/ml_air_clutter/config.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict, dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -9,6 +10,28 @@ class NormalizationConfig:
     eps: float = 1e-8
     clip_lower_percentile: float = 1.0
     clip_upper_percentile: float = 99.0
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SyntheticClutterConfig:
+    """Serializable configuration for analytical synthetic air-clutter generation."""
+
+    seed: Optional[int] = 42
+    target_snr_db: Optional[float] = 6.0
+    hyperbolas: bool = True
+    sloped_events: bool = True
+    ringing: bool = True
+    vertical_spikes: bool = True
+    noise_zones: bool = True
+    num_hyperbolas: int = 3
+    num_sloped_events: int = 2
+    num_ringing_events: int = 2
+    num_vertical_spikes: int = 4
+    num_noise_zones: int = 2
+    base_amplitude: float = 1.0
 
     def to_dict(self):
         return asdict(self)

--- a/ml_air_clutter/synthetic_clutter.py
+++ b/ml_air_clutter/synthetic_clutter.py
@@ -1,0 +1,167 @@
+"""Analytical synthetic air-clutter generator for ML Clutter experiments."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .config import SyntheticClutterConfig
+
+
+def generate_synthetic_clutter(clean_profile, config=None):
+    """Return ``noisy, clutter, mask, meta`` for a clean ``[traces, samples]`` profile."""
+
+    clean = np.asarray(clean_profile, dtype=float)
+    _validate_clean(clean)
+    config = config or SyntheticClutterConfig()
+    rng = np.random.default_rng(config.seed)
+    clutter = np.zeros_like(clean, dtype=float)
+    mask = np.zeros_like(clean, dtype=float)
+    meta = {"config": config.to_dict(), "objects": []}
+
+    if config.hyperbolas:
+        _add_hyperbolas(clutter, mask, meta, rng, config)
+    if config.sloped_events:
+        _add_sloped_events(clutter, mask, meta, rng, config)
+    if config.ringing:
+        _add_ringing(clutter, mask, meta, rng, config)
+    if config.vertical_spikes:
+        _add_vertical_spikes(clutter, mask, meta, rng, config)
+    if config.noise_zones:
+        _add_noise_zones(clutter, mask, meta, rng, config)
+
+    clutter, scale = _scale_to_target_snr(clean, clutter, config.target_snr_db)
+    noisy = clean + clutter
+    mask = (mask > 0).astype(float)
+    meta["target_snr_scale"] = scale
+    meta["actual_snr_db"] = compute_snr_db(clean, clutter)
+    return noisy, clutter, mask, meta
+
+
+def compute_snr_db(signal, noise, eps=1e-12):
+    signal_power = float(np.mean(np.asarray(signal, dtype=float) ** 2))
+    noise_power = float(np.mean(np.asarray(noise, dtype=float) ** 2))
+    return 10.0 * math.log10((signal_power + eps) / (noise_power + eps))
+
+
+def ricker_wavelet(offset, frequency):
+    x = np.asarray(offset, dtype=float) * float(frequency)
+    return (1.0 - 2.0 * np.pi**2 * x**2) * np.exp(-(np.pi**2) * x**2)
+
+
+def _validate_clean(clean):
+    if clean.ndim != 2:
+        raise ValueError(f"Clean profile must be a 2D array, got ndim={clean.ndim}.")
+    if not np.isfinite(clean).all():
+        raise ValueError("Clean profile contains non-finite amplitudes.")
+
+
+def _add_hyperbolas(clutter, mask, meta, rng, config):
+    traces, samples = clutter.shape
+    xs = np.arange(traces)
+    zs = np.arange(samples)
+    for _ in range(max(0, config.num_hyperbolas)):
+        x0 = float(rng.uniform(0, max(1, traces - 1)))
+        z0 = float(rng.uniform(8, max(9, samples * 0.35)))
+        curvature = float(rng.uniform(0.002, 0.03))
+        width_x = float(rng.uniform(max(4, traces * 0.05), max(5, traces * 0.35)))
+        amplitude = _signed_amplitude(rng, config.base_amplitude, 0.5, 1.4)
+        frequency = float(rng.uniform(0.035, 0.09))
+        phase = float(rng.uniform(-np.pi, np.pi))
+        decay = float(rng.uniform(0.7, 2.2))
+        z_curve = z0 + curvature * (xs - x0) ** 2
+        horizontal_weight = np.exp(-0.5 * ((xs - x0) / max(width_x, 1.0)) ** 2)
+        for ix, zc in enumerate(z_curve):
+            pulse = ricker_wavelet(zs - zc + phase / (2 * np.pi * frequency), frequency)
+            contribution = amplitude * horizontal_weight[ix] * pulse * np.exp(-abs(ix - x0) / max(width_x * decay, 1.0))
+            clutter[ix] += contribution
+            mask[ix] = np.maximum(mask[ix], (np.abs(zs - zc) <= max(4, 1.5 / frequency)) * horizontal_weight[ix])
+        meta["objects"].append({"type": "hyperbola", "x0": x0, "z0": z0, "curvature": curvature, "width_x": width_x, "amplitude": amplitude, "frequency": frequency, "phase": phase, "decay": decay})
+
+
+def _add_sloped_events(clutter, mask, meta, rng, config):
+    traces, samples = clutter.shape
+    xs = np.arange(traces)
+    zs = np.arange(samples)
+    for _ in range(max(0, config.num_sloped_events)):
+        x_start = int(rng.integers(0, max(1, traces)))
+        x_end = int(rng.integers(x_start + 1, traces + 1)) if x_start < traces - 1 else traces
+        z_start = float(rng.uniform(5, samples * 0.5))
+        slope = float(rng.uniform(-0.4, 0.4))
+        amplitude = _signed_amplitude(rng, config.base_amplitude, 0.25, 1.1)
+        thickness = float(rng.uniform(2.0, 8.0))
+        frequency = float(rng.uniform(0.025, 0.08))
+        for ix in range(x_start, x_end):
+            zc = z_start + slope * (ix - x_start)
+            if -thickness <= zc < samples + thickness:
+                pulse = ricker_wavelet(zs - zc, frequency)
+                clutter[ix] += amplitude * pulse
+                mask[ix] = np.maximum(mask[ix], (np.abs(zs - zc) <= thickness).astype(float))
+        meta["objects"].append({"type": "sloped_event", "x_start": x_start, "x_end": x_end, "z_start": z_start, "slope": slope, "amplitude": amplitude, "thickness": thickness, "frequency": frequency})
+
+
+def _add_ringing(clutter, mask, meta, rng, config):
+    traces, samples = clutter.shape
+    zs = np.arange(samples)
+    for _ in range(max(0, config.num_ringing_events)):
+        x0 = int(rng.integers(0, max(1, traces)))
+        x1 = int(rng.integers(x0 + 1, traces + 1)) if x0 < traces - 1 else traces
+        z0 = float(rng.uniform(0, samples * 0.25))
+        frequency = float(rng.uniform(0.045, 0.14))
+        decay = float(rng.uniform(25.0, 110.0))
+        phase = float(rng.uniform(-np.pi, np.pi))
+        amplitude = _signed_amplitude(rng, config.base_amplitude, 0.15, 0.9)
+        wave = amplitude * np.sin(2 * np.pi * frequency * np.maximum(zs - z0, 0) + phase) * np.exp(-np.maximum(zs - z0, 0) / decay)
+        wave[zs < z0] = 0.0
+        clutter[x0:x1] += wave
+        mask[x0:x1] = np.maximum(mask[x0:x1], (zs >= z0).astype(float) * np.exp(-np.maximum(zs - z0, 0) / decay))
+        meta["objects"].append({"type": "ringing", "x_start": x0, "x_end": x1, "z_start": z0, "frequency": frequency, "decay": decay, "phase": phase, "amplitude": amplitude})
+
+
+def _add_vertical_spikes(clutter, mask, meta, rng, config):
+    traces, samples = clutter.shape
+    zs = np.arange(samples)
+    for _ in range(max(0, config.num_vertical_spikes)):
+        x0 = int(rng.integers(0, max(1, traces)))
+        width = int(rng.integers(1, max(2, min(8, traces + 1))))
+        amplitude = _signed_amplitude(rng, config.base_amplitude, 0.2, 1.0)
+        profile = amplitude * (0.7 * rng.normal(size=samples) + 0.3 * np.sin(2 * np.pi * rng.uniform(0.01, 0.06) * zs))
+        profile *= np.exp(-zs / float(rng.uniform(samples * 0.8, samples * 2.0)))
+        lo, hi = max(0, x0 - width), min(traces, x0 + width + 1)
+        weights = np.hanning(max(3, hi - lo + 2))[1:-1]
+        for j, ix in enumerate(range(lo, hi)):
+            clutter[ix] += weights[j] * profile
+            mask[ix] = np.maximum(mask[ix], weights[j])
+        meta["objects"].append({"type": "vertical_spike", "x0": x0, "width": width, "amplitude": amplitude})
+
+
+def _add_noise_zones(clutter, mask, meta, rng, config):
+    traces, samples = clutter.shape
+    for _ in range(max(0, config.num_noise_zones)):
+        x0 = int(rng.integers(0, max(1, traces)))
+        width = int(rng.integers(max(2, traces // 20), max(3, max(4, traces // 3))))
+        z0 = int(rng.integers(0, max(1, samples // 2)))
+        height = int(rng.integers(max(8, samples // 20), max(9, samples // 3)))
+        amp = float(rng.uniform(0.05, 0.4) * config.base_amplitude)
+        x1, z1 = min(traces, x0 + width), min(samples, z0 + height)
+        patch = amp * rng.normal(size=(x1 - x0, z1 - z0))
+        clutter[x0:x1, z0:z1] += patch
+        mask[x0:x1, z0:z1] = 1.0
+        meta["objects"].append({"type": "noise_zone", "x_start": x0, "x_end": x1, "z_start": z0, "z_end": z1, "amplitude": amp})
+
+
+def _signed_amplitude(rng, base, low, high):
+    return float(base * rng.uniform(low, high) * rng.choice([-1.0, 1.0]))
+
+
+def _scale_to_target_snr(clean, clutter, target_snr_db):
+    if target_snr_db is None or not np.any(clutter):
+        return clutter, 1.0
+    signal_power = float(np.mean(clean ** 2))
+    clutter_power = float(np.mean(clutter ** 2))
+    if clutter_power <= 0:
+        return clutter, 1.0
+    target_noise_power = signal_power / (10.0 ** (float(target_snr_db) / 10.0))
+    scale = math.sqrt(target_noise_power / clutter_power)
+    return clutter * scale, float(scale)

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -3,8 +3,9 @@ import json
 import numpy as np
 from PyQt5 import QtWidgets
 
-from ml_air_clutter.config import NormalizationConfig
+from ml_air_clutter.config import NormalizationConfig, SyntheticClutterConfig
 from ml_air_clutter.preprocessing import Normalizer, build_preprocessing_report
+from ml_air_clutter.synthetic_clutter import generate_synthetic_clutter
 from models_db.model import Profile, CurrentProfile, session
 from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
 
@@ -34,8 +35,9 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.real_noisy_profile = None
         self.normalized_clean_profile = None
         self.normalization_result = None
-        self.experiment_config = {"normalization": None}
+        self.experiment_config = {"normalization": None, "synthetic_clutter": None}
         self.experiment_profiles = {}
+        self.synthetic_clutter_result = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -43,6 +45,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_load_real_noisy.clicked.connect(lambda: self.load_selected_profile("real_noisy"))
         self.ui.pushButton_apply_preprocessing.clicked.connect(self.normalize_clean_profile)
         self.ui.pushButton_inverse_preprocessing.clicked.connect(self.preview_inverse_normalization)
+        self.ui.pushButton_generate_synthetic_clutter.clicked.connect(self.generate_synthetic_clutter_preview)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self._show_stats(
             "Experiment profile list is empty. "
@@ -163,6 +166,38 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self._display_profile(result.data, f"ML Clutter normalized clean ({config.mode})")
         self._log(f"Clean profile normalized with mode '{config.mode}'")
 
+    def generate_synthetic_clutter_preview(self):
+        if self.clean_profile is None:
+            self._show_generator_stats("Load a clean profile before synthetic clutter generation.")
+            self._log("ML Clutter: clean profile is not loaded for synthetic clutter generation", "red")
+            return
+
+        source_profile = self.normalized_clean_profile if self.normalized_clean_profile is not None else self.clean_profile
+        config = self._current_synthetic_clutter_config()
+        try:
+            noisy, clutter, mask, meta = generate_synthetic_clutter(source_profile, config)
+        except ValueError as exc:
+            self._show_generator_stats(str(exc))
+            self._log(f"ML Clutter: synthetic clutter generation failed: {exc}", "red")
+            return
+
+        self.synthetic_clutter_result = {
+            "noisy": noisy,
+            "clutter": clutter,
+            "mask": mask,
+            "meta": meta,
+        }
+        self.experiment_config["synthetic_clutter"] = meta
+        report = self._format_generator_report(meta, clutter, mask, noisy)
+        self._show_generator_stats(report)
+        self._display_profile(source_profile, "ML Clutter synthetic source clean")
+        self._display_profile(clutter, "ML Clutter synthetic clutter")
+        self._display_profile(mask, "ML Clutter synthetic clutter mask")
+        self._display_profile(noisy, "ML Clutter synthetic noisy profile")
+        self._log(
+            f"Synthetic clutter generated: {len(meta['objects'])} objects, SNR={meta['actual_snr_db']:.3g} dB"
+        )
+
     def preview_inverse_normalization(self):
         if self.normalization_result is None:
             self._show_preprocessing_stats("Normalize a clean profile first; no inverse parameters are available.")
@@ -181,6 +216,37 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
     def _current_normalization_config(self):
         mode = self.ui.comboBox_normalization_mode.currentData() or "standard"
         return NormalizationConfig(mode=mode)
+
+    def _current_synthetic_clutter_config(self):
+        return SyntheticClutterConfig(
+            seed=int(self.ui.spinBox_gen_seed.value()),
+            target_snr_db=float(self.ui.doubleSpinBox_gen_target_snr.value()),
+            hyperbolas=self.ui.checkBox_gen_hyperbolas.isChecked(),
+            sloped_events=self.ui.checkBox_gen_sloped_events.isChecked(),
+            ringing=self.ui.checkBox_gen_ringing.isChecked(),
+            vertical_spikes=self.ui.checkBox_gen_vertical_spikes.isChecked(),
+            noise_zones=self.ui.checkBox_gen_noise_zones.isChecked(),
+        )
+
+    @staticmethod
+    def _format_generator_report(meta, clutter, mask, noisy):
+        object_counts = {}
+        for obj in meta["objects"]:
+            object_counts[obj["type"]] = object_counts.get(obj["type"], 0) + 1
+        lines = [
+            "Synthetic clutter generation report",
+            f"Config: {meta['config']}",
+            f"Generated objects: {len(meta['objects'])} ({object_counts})",
+            f"Target SNR scale: {meta['target_snr_scale']:.6g}",
+            f"Actual SNR: {meta['actual_snr_db']:.6g} dB",
+            f"Clutter min/max: {float(np.min(clutter)):.6g} / {float(np.max(clutter)):.6g}",
+            f"Clutter RMS: {float(np.sqrt(np.mean(clutter ** 2))):.6g}",
+            f"Mask coverage: {float(np.mean(mask > 0)) * 100.0:.3g}%",
+            f"Noisy min/max: {float(np.min(noisy)):.6g} / {float(np.max(noisy)):.6g}",
+            "Meta preview:",
+            json.dumps(meta, indent=2)[:6000],
+        ]
+        return "\n".join(lines)
 
     def _prepare_profile_for_role(self, data, name):
         validation = self.validate_profile(data)
@@ -294,6 +360,10 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     def _show_preprocessing_stats(self, text):
         self.ui.textEdit_preprocessing_stats.setPlainText(text)
+        self.ui.textEdit_results_log.append(text)
+
+    def _show_generator_stats(self, text):
+        self.ui.textEdit_generator_meta.setPlainText(text)
         self.ui.textEdit_results_log.append(text)
 
     def _log(self, text, color="green"):

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -20,10 +20,7 @@ class Ui_MLClutterExperiment(object):
             "tab_noise_patterns",
             "Add noisy radarograms and configure extraction of real air-clutter patterns.",
         )
-        self.tab_generator = self._add_placeholder_tab(
-            "tab_generator",
-            "Configure analytical, real-pattern, or mixed clutter generation.",
-        )
+        self.tab_generator = self._add_generator_tab()
         self.tab_dataset = self._add_placeholder_tab(
             "tab_dataset",
             "Generate synthetic noisy/clean training pairs and patch datasets.",
@@ -102,6 +99,59 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.addTab(tab, "")
         return tab
 
+
+    def _add_generator_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_generator")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText("Configure analytical synthetic air-clutter generation for the loaded clean profile.")
+        layout.addWidget(intro, 0, 0, 1, 3)
+        self.checkBox_gen_hyperbolas = QtWidgets.QCheckBox(tab)
+        self.checkBox_gen_hyperbolas.setObjectName("checkBox_gen_hyperbolas")
+        self.checkBox_gen_hyperbolas.setChecked(True)
+        layout.addWidget(self.checkBox_gen_hyperbolas, 1, 0)
+        self.checkBox_gen_sloped_events = QtWidgets.QCheckBox(tab)
+        self.checkBox_gen_sloped_events.setObjectName("checkBox_gen_sloped_events")
+        self.checkBox_gen_sloped_events.setChecked(True)
+        layout.addWidget(self.checkBox_gen_sloped_events, 1, 1)
+        self.checkBox_gen_ringing = QtWidgets.QCheckBox(tab)
+        self.checkBox_gen_ringing.setObjectName("checkBox_gen_ringing")
+        self.checkBox_gen_ringing.setChecked(True)
+        layout.addWidget(self.checkBox_gen_ringing, 1, 2)
+        self.checkBox_gen_vertical_spikes = QtWidgets.QCheckBox(tab)
+        self.checkBox_gen_vertical_spikes.setObjectName("checkBox_gen_vertical_spikes")
+        self.checkBox_gen_vertical_spikes.setChecked(True)
+        layout.addWidget(self.checkBox_gen_vertical_spikes, 2, 0)
+        self.checkBox_gen_noise_zones = QtWidgets.QCheckBox(tab)
+        self.checkBox_gen_noise_zones.setObjectName("checkBox_gen_noise_zones")
+        self.checkBox_gen_noise_zones.setChecked(True)
+        layout.addWidget(self.checkBox_gen_noise_zones, 2, 1)
+        self.spinBox_gen_seed = QtWidgets.QSpinBox(tab)
+        self.spinBox_gen_seed.setObjectName("spinBox_gen_seed")
+        self.spinBox_gen_seed.setRange(0, 2147483647)
+        self.spinBox_gen_seed.setValue(42)
+        layout.addWidget(QtWidgets.QLabel("Seed", tab), 3, 0)
+        layout.addWidget(self.spinBox_gen_seed, 3, 1)
+        self.doubleSpinBox_gen_target_snr = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_gen_target_snr.setObjectName("doubleSpinBox_gen_target_snr")
+        self.doubleSpinBox_gen_target_snr.setRange(-30.0, 60.0)
+        self.doubleSpinBox_gen_target_snr.setValue(6.0)
+        self.doubleSpinBox_gen_target_snr.setSuffix(" dB")
+        layout.addWidget(QtWidgets.QLabel("Target SNR", tab), 4, 0)
+        layout.addWidget(self.doubleSpinBox_gen_target_snr, 4, 1)
+        self.pushButton_generate_synthetic_clutter = QtWidgets.QPushButton(tab)
+        self.pushButton_generate_synthetic_clutter.setObjectName("pushButton_generate_synthetic_clutter")
+        layout.addWidget(self.pushButton_generate_synthetic_clutter, 5, 0, 1, 2)
+        self.textEdit_generator_meta = QtWidgets.QTextEdit(tab)
+        self.textEdit_generator_meta.setReadOnly(True)
+        self.textEdit_generator_meta.setObjectName("textEdit_generator_meta")
+        layout.addWidget(self.textEdit_generator_meta, 6, 0, 1, 3)
+        layout.setRowStretch(6, 1)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
     def _add_placeholder_tab(self, object_name, message):
         tab = QtWidgets.QWidget()
         tab.setObjectName(object_name)
@@ -138,6 +188,12 @@ class Ui_MLClutterExperiment(object):
         self.checkBox_enable_preprocessing.setText(_translate("MLClutterExperiment", "Enable preprocessing"))
         self.pushButton_apply_preprocessing.setText(_translate("MLClutterExperiment", "Normalize Clean Profile"))
         self.pushButton_inverse_preprocessing.setText(_translate("MLClutterExperiment", "Preview Inverse Transform"))
+        self.checkBox_gen_hyperbolas.setText(_translate("MLClutterExperiment", "Hyperbolas"))
+        self.checkBox_gen_sloped_events.setText(_translate("MLClutterExperiment", "Sloped events"))
+        self.checkBox_gen_ringing.setText(_translate("MLClutterExperiment", "Ringing"))
+        self.checkBox_gen_vertical_spikes.setText(_translate("MLClutterExperiment", "Vertical spikes"))
+        self.checkBox_gen_noise_zones.setText(_translate("MLClutterExperiment", "Wide noise zones"))
+        self.pushButton_generate_synthetic_clutter.setText(_translate("MLClutterExperiment", "Generate Synthetic Clutter"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))

--- a/tests/test_ml_air_clutter_synthetic_clutter.py
+++ b/tests/test_ml_air_clutter_synthetic_clutter.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ml_air_clutter.config import SyntheticClutterConfig
+from ml_air_clutter.synthetic_clutter import compute_snr_db, generate_synthetic_clutter
+
+
+def test_synthetic_clutter_returns_expected_shapes_and_meta():
+    clean = np.ones((32, 512), dtype=float)
+    config = SyntheticClutterConfig(seed=7, target_snr_db=3.0)
+
+    noisy, clutter, mask, meta = generate_synthetic_clutter(clean, config)
+
+    assert noisy.shape == clean.shape
+    assert clutter.shape == clean.shape
+    assert mask.shape == clean.shape
+    assert len(meta["objects"]) > 0
+    assert set(np.unique(mask)).issubset({0.0, 1.0})
+    np.testing.assert_allclose(noisy, clean + clutter)
+    assert abs(compute_snr_db(clean, clutter) - 3.0) < 1e-6
+
+
+def test_synthetic_clutter_is_reproducible_for_same_seed():
+    clean = np.linspace(-1.0, 1.0, 16 * 512).reshape(16, 512)
+    config = SyntheticClutterConfig(seed=123, num_hyperbolas=1, num_sloped_events=1, num_ringing_events=1)
+
+    first = generate_synthetic_clutter(clean, config)
+    second = generate_synthetic_clutter(clean, config)
+
+    for left, right in zip(first[:3], second[:3]):
+        np.testing.assert_allclose(left, right)
+    assert first[3] == second[3]
+
+
+def test_synthetic_clutter_can_disable_all_objects():
+    clean = np.ones((8, 512), dtype=float)
+    config = SyntheticClutterConfig(
+        hyperbolas=False,
+        sloped_events=False,
+        ringing=False,
+        vertical_spikes=False,
+        noise_zones=False,
+    )
+
+    noisy, clutter, mask, meta = generate_synthetic_clutter(clean, config)
+
+    np.testing.assert_allclose(noisy, clean)
+    np.testing.assert_allclose(clutter, 0.0)
+    np.testing.assert_allclose(mask, 0.0)
+    assert meta["objects"] == []


### PR DESCRIPTION
### Motivation
- Реализовать этап 4 плана: аналитический генератор синтетических воздушных помех для эксперимента `ML Clutter` с возможностью настраивать типы помех и целевой SNR. 
- Обеспечить быструю визуальную проверку результата генерации (clean, clutter, mask, noisy) из окна эксперимента. 
- Добавить базовые unit-тесты для контракта генератора и воспроизводимости по `seed`.

### Description
- Добавлен сериализуемый конфиг `SyntheticClutterConfig` в `ml_air_clutter/config.py` с настройками `seed`, `target_snr_db`, включением/отключением типов помех и числа объектов. 
- Реализован генератор `generate_synthetic_clutter` в новом файле `ml_air_clutter/synthetic_clutter.py`, реализующий гиперболы, наклонные события, ringing, вертикальные всплески, широкие шумовые зоны, бинарную маску, расчёт и масштабирование помех до целевого SNR и возврат `noisy, clutter, mask, meta`. 
- В UI добавлена вкладка `Generator` с чекбоксами типов помех, полями `Seed` и `Target SNR` и кнопкой `Generate Synthetic Clutter` в `qt/ml_clutter_experiment_form.py`. 
- Интеграция в окно управления: в `ml_clutter_experiment.py` добавлена обработка кнопки и метод `generate_synthetic_clutter_preview`, сохранение `meta` в `experiment_config`, отправка массивов для визуализации в `MainWindow` и вывод краткого отчёта.
- Добавлены unit-тесты `tests/test_ml_air_clutter_synthetic_clutter.py` проверяющие формы результатов, бинарность маски, воспроизводимость по `seed` и поведение при отключённых объектах.

### Testing
- Выполнена статическая проверка синтаксиса: `python -m py_compile ml_air_clutter/config.py ml_air_clutter/synthetic_clutter.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py tests/test_ml_air_clutter_synthetic_clutter.py` — успешно. 
- Локальные unit-тесты добавлены в `tests/test_ml_air_clutter_synthetic_clutter.py`, но запуск `pytest -q tests/test_ml_air_clutter_synthetic_clutter.py tests/test_ml_air_clutter_preprocessing.py` завершился ошибкой сборки из-за отсутствия системных зависимостей в окружении (`numpy`), поэтому тесты не были выполнены here. 
- Полный прогон `pytest -q` также заблокирован в текущем окружении из‑за отсутствия `numpy` и `sqlalchemy`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33f838e984832fb1698ae15b68efa2)