### PR TITLE
Add real-noise pattern extraction and persistent PatternLibrary for ML Clutter

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -1,11 +1,18 @@
 """Experimental ML air-clutter removal helpers."""
 
 from .config import NormalizationConfig
+from .noise_patterns import PatternExtractionConfig, extract_energy_patterns, extract_pattern_from_bbox
+from .pattern_library import NoisePattern, PatternLibrary
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
 
 __all__ = [
     "NormalizationConfig",
+    "NoisePattern",
+    "PatternExtractionConfig",
+    "PatternLibrary",
     "NormalizationResult",
     "Normalizer",
     "build_preprocessing_report",
+    "extract_energy_patterns",
+    "extract_pattern_from_bbox",
 ]

--- a/ml_air_clutter/noise_patterns.py
+++ b/ml_air_clutter/noise_patterns.py
@@ -1,0 +1,136 @@
+from dataclasses import asdict, dataclass
+from typing import Optional, Sequence, Tuple
+
+import numpy as np
+
+from .preprocessing import Normalizer
+from .config import NormalizationConfig
+
+DEFAULT_PATTERN_TAGS = ("pole", "powerline", "metal_fence", "building", "ringing", "vertical_spike", "unknown")
+
+
+@dataclass(frozen=True)
+class PatternExtractionConfig:
+    """Configuration for extracting real air-clutter patches from noisy radarograms."""
+
+    patch_width: int = 64
+    patch_height: int = 128
+    stride_x: int = 32
+    stride_z: int = 64
+    energy_percentile: float = 95.0
+    min_mask_coverage: float = 0.05
+    max_patterns: Optional[int] = 32
+    normalization_mode: str = "standard"
+
+    def to_dict(self):
+        return asdict(self)
+
+
+def validate_bbox(bbox: Sequence[int], shape: Tuple[int, int]):
+    if len(bbox) != 4:
+        raise ValueError("Pattern bbox must contain [x_start, x_end, z_start, z_end].")
+    x_start, x_end, z_start, z_end = [int(value) for value in bbox]
+    num_traces, num_samples = shape
+    if x_start < 0 or z_start < 0 or x_end > num_traces or z_end > num_samples:
+        raise ValueError(f"Pattern bbox {bbox} is outside profile shape {shape}.")
+    if x_end <= x_start or z_end <= z_start:
+        raise ValueError(f"Pattern bbox {bbox} must have positive width and height.")
+    return x_start, x_end, z_start, z_end
+
+
+def extract_pattern_from_bbox(profile, bbox, mask=None, config=None):
+    """Extract and normalize one real-noise pattern from a manually selected bbox."""
+
+    array = np.asarray(profile, dtype=float)
+    _validate_profile_array(array)
+    x_start, x_end, z_start, z_end = validate_bbox(bbox, array.shape)
+    patch = array[x_start:x_end, z_start:z_end].copy()
+    if mask is None:
+        patch_mask = np.ones_like(patch, dtype=float)
+    else:
+        mask_array = np.asarray(mask, dtype=float)
+        if mask_array.shape != array.shape:
+            raise ValueError(f"Mask shape {mask_array.shape} must match profile shape {array.shape}.")
+        patch_mask = (mask_array[x_start:x_end, z_start:z_end] > 0).astype(float)
+    return normalize_pattern_patch(patch, patch_mask, config or PatternExtractionConfig())
+
+
+def extract_energy_patterns(profile, config=None):
+    """Semi-automatic extraction of high-energy patch patterns using moving-window RMS."""
+
+    config = config or PatternExtractionConfig()
+    array = np.asarray(profile, dtype=float)
+    _validate_profile_array(array)
+    _validate_config(config, array.shape)
+    energy = np.abs(array)
+    threshold = float(np.percentile(energy, config.energy_percentile))
+    candidate_mask = (energy >= threshold).astype(float)
+    candidates = []
+    for x_start in range(0, array.shape[0] - config.patch_width + 1, config.stride_x):
+        for z_start in range(0, array.shape[1] - config.patch_height + 1, config.stride_z):
+            x_end = x_start + config.patch_width
+            z_end = z_start + config.patch_height
+            mask_patch = candidate_mask[x_start:x_end, z_start:z_end]
+            coverage = float(np.mean(mask_patch > 0))
+            if coverage < config.min_mask_coverage:
+                continue
+            patch = array[x_start:x_end, z_start:z_end].copy()
+            normalized = normalize_pattern_patch(patch, mask_patch, config)
+            normalized["bbox"] = [x_start, x_end, z_start, z_end]
+            normalized["energy_score"] = float(np.sqrt(np.mean(patch ** 2)))
+            normalized["mask_coverage"] = coverage
+            candidates.append(normalized)
+    candidates.sort(key=lambda item: item["energy_score"], reverse=True)
+    if config.max_patterns is not None:
+        candidates = candidates[: int(config.max_patterns)]
+    return candidates
+
+
+def normalize_pattern_patch(patch, mask, config):
+    patch = np.asarray(patch, dtype=float)
+    mask = np.asarray(mask, dtype=float)
+    if patch.ndim != 2:
+        raise ValueError("Pattern patch must be a 2D array.")
+    if mask.shape != patch.shape:
+        raise ValueError(f"Pattern mask shape {mask.shape} must match patch shape {patch.shape}.")
+    result = Normalizer.fit_transform(patch, NormalizationConfig(mode=config.normalization_mode))
+    stats = pattern_statistics(result.data, mask)
+    return {
+        "array": result.data,
+        "mask": (mask > 0).astype(float),
+        "normalization": {"config": result.config.to_dict(), "params": result.params},
+        "stats": stats,
+    }
+
+
+def pattern_statistics(array, mask=None):
+    arr = np.asarray(array, dtype=float)
+    stats = {
+        "shape": list(arr.shape),
+        "min": float(np.min(arr)),
+        "max": float(np.max(arr)),
+        "mean": float(np.mean(arr)),
+        "std": float(np.std(arr)),
+        "rms": float(np.sqrt(np.mean(arr ** 2))),
+    }
+    if mask is not None:
+        stats["mask_coverage"] = float(np.mean(np.asarray(mask) > 0))
+    return stats
+
+
+def _validate_profile_array(array):
+    if array.ndim != 2:
+        raise ValueError(f"Noisy radarogram must be a 2D array, got ndim={array.ndim}.")
+    if not np.isfinite(array).all():
+        raise ValueError("Noisy radarogram contains non-finite amplitudes.")
+
+
+def _validate_config(config, shape):
+    if config.patch_width <= 0 or config.patch_height <= 0:
+        raise ValueError("Patch width and height must be positive.")
+    if config.stride_x <= 0 or config.stride_z <= 0:
+        raise ValueError("Extraction strides must be positive.")
+    if config.patch_width > shape[0] or config.patch_height > shape[1]:
+        raise ValueError(f"Patch size {(config.patch_width, config.patch_height)} exceeds profile shape {shape}.")
+    if not 0.0 <= config.energy_percentile <= 100.0:
+        raise ValueError("Energy percentile must be in [0, 100].")

--- a/ml_air_clutter/pattern_library.py
+++ b/ml_air_clutter/pattern_library.py
@@ -1,0 +1,129 @@
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+from .noise_patterns import DEFAULT_PATTERN_TAGS, pattern_statistics
+
+
+@dataclass
+class NoisePattern:
+    pattern_id: str
+    source_profile: str
+    array: np.ndarray
+    mask: np.ndarray
+    bbox: list
+    normalization: dict
+    stats: dict
+    tags: list = field(default_factory=lambda: ["unknown"])
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    comment: str = ""
+
+    @classmethod
+    def create(cls, source_profile, array, mask, bbox, normalization=None, tags=None, comment="", pattern_id=None):
+        pattern_tags = list(tags or ["unknown"])
+        invalid_tags = sorted(set(pattern_tags) - set(DEFAULT_PATTERN_TAGS))
+        if invalid_tags:
+            raise ValueError(f"Unsupported pattern tags: {invalid_tags}")
+        arr = np.asarray(array, dtype=float)
+        m = (np.asarray(mask, dtype=float) > 0).astype(float)
+        if arr.ndim != 2:
+            raise ValueError("Pattern array must be 2D.")
+        if m.shape != arr.shape:
+            raise ValueError(f"Pattern mask shape {m.shape} must match array shape {arr.shape}.")
+        if not np.isfinite(arr).all():
+            raise ValueError("Pattern array contains non-finite values.")
+        return cls(
+            pattern_id=pattern_id or str(uuid.uuid4()),
+            source_profile=str(source_profile),
+            array=arr,
+            mask=m,
+            bbox=[int(v) for v in bbox],
+            normalization=normalization or {},
+            stats=pattern_statistics(arr, m),
+            tags=pattern_tags,
+            comment=comment,
+        )
+
+    def to_metadata(self, array_file, mask_file):
+        return {
+            "pattern_id": self.pattern_id,
+            "source_profile": self.source_profile,
+            "array_file": array_file,
+            "mask_file": mask_file,
+            "bbox": self.bbox,
+            "normalization": self.normalization,
+            "stats": self.stats,
+            "tags": self.tags,
+            "created_at": self.created_at,
+            "comment": self.comment,
+        }
+
+
+class PatternLibrary:
+    """In-memory catalog of real air-clutter patterns with JSON/NPY persistence."""
+
+    def __init__(self, patterns=None):
+        self.patterns = list(patterns or [])
+
+    def add_pattern(self, pattern):
+        if self.get(pattern.pattern_id) is not None:
+            raise ValueError(f"Pattern id already exists: {pattern.pattern_id}")
+        self.patterns.append(pattern)
+        return pattern
+
+    def get(self, pattern_id):
+        for pattern in self.patterns:
+            if pattern.pattern_id == pattern_id:
+                return pattern
+        return None
+
+    def summary(self):
+        tags = {}
+        for pattern in self.patterns:
+            for tag in pattern.tags:
+                tags[tag] = tags.get(tag, 0) + 1
+        return {"num_patterns": len(self.patterns), "tags": tags}
+
+    def save(self, directory):
+        root = Path(directory)
+        arrays_dir = root / "arrays"
+        arrays_dir.mkdir(parents=True, exist_ok=True)
+        index = {"version": 1, "saved_at": datetime.now(timezone.utc).isoformat(), "patterns": []}
+        for pattern in self.patterns:
+            array_file = f"arrays/{pattern.pattern_id}_array.npy"
+            mask_file = f"arrays/{pattern.pattern_id}_mask.npy"
+            np.save(root / array_file, pattern.array)
+            np.save(root / mask_file, pattern.mask)
+            index["patterns"].append(pattern.to_metadata(array_file, mask_file))
+        with (root / "pattern_library_index.json").open("w", encoding="utf-8") as handle:
+            json.dump(index, handle, ensure_ascii=False, indent=2)
+        return root / "pattern_library_index.json"
+
+    @classmethod
+    def load(cls, directory):
+        root = Path(directory)
+        index_path = root / "pattern_library_index.json"
+        with index_path.open("r", encoding="utf-8") as handle:
+            index = json.load(handle)
+        patterns = []
+        for meta in index.get("patterns", []):
+            array = np.load(root / meta["array_file"])
+            mask = np.load(root / meta["mask_file"])
+            pattern = NoisePattern.create(
+                source_profile=meta["source_profile"],
+                array=array,
+                mask=mask,
+                bbox=meta["bbox"],
+                normalization=meta.get("normalization", {}),
+                tags=meta.get("tags", ["unknown"]),
+                comment=meta.get("comment", ""),
+                pattern_id=meta["pattern_id"],
+            )
+            pattern.created_at = meta.get("created_at", pattern.created_at)
+            pattern.stats = meta.get("stats", pattern.stats)
+            patterns.append(pattern)
+        return cls(patterns)

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -1,9 +1,12 @@
 import json
+from pathlib import Path
 
 import numpy as np
 from PyQt5 import QtWidgets
 
 from ml_air_clutter.config import NormalizationConfig, SyntheticClutterConfig
+from ml_air_clutter.noise_patterns import PatternExtractionConfig, extract_energy_patterns, extract_pattern_from_bbox
+from ml_air_clutter.pattern_library import NoisePattern, PatternLibrary
 from ml_air_clutter.preprocessing import Normalizer, build_preprocessing_report
 from ml_air_clutter.synthetic_clutter import generate_synthetic_clutter
 from models_db.model import Profile, CurrentProfile, session
@@ -33,9 +36,11 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.visualization_callback = visualization_callback
         self.clean_profile = None
         self.real_noisy_profile = None
+        self.real_noisy_profiles = []
+        self.pattern_library = PatternLibrary()
         self.normalized_clean_profile = None
         self.normalization_result = None
-        self.experiment_config = {"normalization": None, "synthetic_clutter": None}
+        self.experiment_config = {"normalization": None, "synthetic_clutter": None, "pattern_library": None}
         self.experiment_profiles = {}
         self.synthetic_clutter_result = None
 
@@ -46,6 +51,12 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_apply_preprocessing.clicked.connect(self.normalize_clean_profile)
         self.ui.pushButton_inverse_preprocessing.clicked.connect(self.preview_inverse_normalization)
         self.ui.pushButton_generate_synthetic_clutter.clicked.connect(self.generate_synthetic_clutter_preview)
+        self.ui.pushButton_add_noisy_to_library.clicked.connect(self.add_loaded_real_noisy_to_pattern_sources)
+        self.ui.pushButton_extract_manual_pattern.clicked.connect(self.extract_manual_pattern)
+        self.ui.pushButton_extract_energy_patterns.clicked.connect(self.extract_energy_patterns)
+        self.ui.pushButton_preview_pattern.clicked.connect(self.preview_selected_pattern)
+        self.ui.pushButton_save_pattern_library.clicked.connect(self.save_pattern_library)
+        self.ui.pushButton_load_pattern_library.clicked.connect(self.load_pattern_library)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self._show_stats(
             "Experiment profile list is empty. "
@@ -126,8 +137,109 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             self.normalization_result = None
         else:
             self.real_noisy_profile = prepared
+            self._register_real_noisy_profile(name, prepared, source)
         self._display_profile(prepared, f"ML Clutter {role.replace('_', ' ')}: {name}")
         self._log(f"Profile '{name}' loaded as {role.replace('_', ' ')} and displayed in MainWindow")
+
+    def add_loaded_real_noisy_to_pattern_sources(self):
+        if self.real_noisy_profile is None:
+            self._show_pattern_stats("Load a real noisy profile before adding it to the pattern source list.")
+            self._log("ML Clutter: no real noisy profile loaded for pattern extraction", "red")
+            return
+        name = f"real_noisy_{len(self.real_noisy_profiles) + 1}"
+        self._register_real_noisy_profile(name, self.real_noisy_profile, "loaded real noisy profile")
+
+    def extract_manual_pattern(self):
+        source = self._selected_noisy_source()
+        if source is None:
+            self._show_pattern_stats("Add and select a real noisy radarogram source first.")
+            return
+        bbox = [
+            self.ui.spinBox_pattern_x_start.value(),
+            self.ui.spinBox_pattern_x_end.value(),
+            self.ui.spinBox_pattern_z_start.value(),
+            self.ui.spinBox_pattern_z_end.value(),
+        ]
+        try:
+            extracted = extract_pattern_from_bbox(source["data"], bbox)
+            pattern = NoisePattern.create(
+                source_profile=source["name"],
+                array=extracted["array"],
+                mask=extracted["mask"],
+                bbox=bbox,
+                normalization=extracted["normalization"],
+                tags=[self.ui.comboBox_pattern_tag.currentData() or "unknown"],
+                comment="manual bbox extraction",
+            )
+            self.pattern_library.add_pattern(pattern)
+        except ValueError as exc:
+            self._show_pattern_stats(str(exc))
+            self._log(f"ML Clutter: manual pattern extraction failed: {exc}", "red")
+            return
+        self._refresh_pattern_library_ui()
+        self._display_profile(pattern.array, f"ML Clutter extracted pattern {pattern.pattern_id}")
+        self._log(f"Manual real-noise pattern extracted from '{source['name']}': {pattern.pattern_id}")
+
+    def extract_energy_patterns(self):
+        source = self._selected_noisy_source()
+        if source is None:
+            self._show_pattern_stats("Add and select a real noisy radarogram source first.")
+            return
+        config = PatternExtractionConfig()
+        try:
+            extracted_patterns = extract_energy_patterns(source["data"], config)
+            for extracted in extracted_patterns:
+                self.pattern_library.add_pattern(NoisePattern.create(
+                    source_profile=source["name"],
+                    array=extracted["array"],
+                    mask=extracted["mask"],
+                    bbox=extracted["bbox"],
+                    normalization=extracted["normalization"],
+                    tags=["unknown"],
+                    comment=f"auto energy extraction; score={extracted['energy_score']:.6g}",
+                ))
+        except ValueError as exc:
+            self._show_pattern_stats(str(exc))
+            self._log(f"ML Clutter: energy pattern extraction failed: {exc}", "red")
+            return
+        self._refresh_pattern_library_ui()
+        self._log(f"Auto-extracted {len(extracted_patterns)} high-energy real-noise patterns from '{source['name']}'")
+
+    def preview_selected_pattern(self):
+        pattern = self._selected_pattern()
+        if pattern is None:
+            self._show_pattern_stats("Select a pattern from the library before preview.")
+            return
+        self._display_profile(pattern.array, f"ML Clutter pattern {pattern.pattern_id}")
+        self._display_profile(pattern.mask, f"ML Clutter pattern mask {pattern.pattern_id}")
+        self._show_pattern_stats(self._format_pattern_report(pattern))
+
+    def save_pattern_library(self):
+        if not self.pattern_library.patterns:
+            self._show_pattern_stats("Pattern library is empty; extract at least one pattern before saving.")
+            return
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Save pattern library directory")
+        if not directory:
+            return
+        index_path = self.pattern_library.save(directory)
+        self.experiment_config["pattern_library"] = {"path": str(index_path), "summary": self.pattern_library.summary()}
+        self._show_pattern_stats(f"Pattern library saved to {index_path}\n{json.dumps(self.pattern_library.summary(), indent=2)}")
+        self._log(f"Pattern library saved: {index_path}")
+
+    def load_pattern_library(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Load pattern library directory")
+        if not directory:
+            return
+        try:
+            self.pattern_library = PatternLibrary.load(directory)
+        except (OSError, ValueError, KeyError) as exc:
+            self._show_pattern_stats(f"Failed to load pattern library: {exc}")
+            self._log(f"ML Clutter: failed to load pattern library: {exc}", "red")
+            return
+        self._refresh_pattern_library_ui()
+        self.experiment_config["pattern_library"] = {"path": str(Path(directory) / "pattern_library_index.json"), "summary": self.pattern_library.summary()}
+        self._log(f"Pattern library loaded from {directory}")
+
 
     def normalize_clean_profile(self):
         if self.clean_profile is None:
@@ -296,6 +408,57 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         result["reason"] = "OK"
         return result
 
+    def _register_real_noisy_profile(self, name, data, source):
+        entry = {"name": name, "data": np.asarray(data, dtype=float), "source": source}
+        self.real_noisy_profiles.append(entry)
+        item = QtWidgets.QListWidgetItem(f"{name} ({entry['data'].shape[0]} traces)")
+        item.setData(self.PROFILE_ID_ROLE, len(self.real_noisy_profiles) - 1)
+        self.ui.listWidget_noisy_profiles.addItem(item)
+        self.ui.listWidget_noisy_profiles.setCurrentItem(item)
+        self.ui.spinBox_pattern_x_end.setMaximum(entry["data"].shape[0])
+        self.ui.spinBox_pattern_x_end.setValue(min(entry["data"].shape[0], max(1, self.ui.spinBox_pattern_x_end.value())))
+        self.ui.spinBox_pattern_z_end.setValue(min(entry["data"].shape[1], max(1, self.ui.spinBox_pattern_z_end.value())))
+        self._show_pattern_stats(
+            f"Real noisy source registered: {name}\nShape: {entry['data'].shape}\nSource: {source}"
+        )
+
+    def _selected_noisy_source(self):
+        item = self.ui.listWidget_noisy_profiles.currentItem()
+        if item is None:
+            return None
+        index = item.data(self.PROFILE_ID_ROLE)
+        if index is None or index < 0 or index >= len(self.real_noisy_profiles):
+            return None
+        return self.real_noisy_profiles[index]
+
+    def _selected_pattern(self):
+        item = self.ui.listWidget_pattern_library.currentItem()
+        if item is None:
+            return None
+        return self.pattern_library.get(item.data(self.PROFILE_ID_ROLE))
+
+    def _refresh_pattern_library_ui(self):
+        self.ui.listWidget_pattern_library.clear()
+        for pattern in self.pattern_library.patterns:
+            item = QtWidgets.QListWidgetItem(f"{pattern.pattern_id[:8]} {pattern.array.shape} tags={','.join(pattern.tags)}")
+            item.setData(self.PROFILE_ID_ROLE, pattern.pattern_id)
+            self.ui.listWidget_pattern_library.addItem(item)
+        self._show_pattern_stats(json.dumps(self.pattern_library.summary(), indent=2))
+
+    @staticmethod
+    def _format_pattern_report(pattern):
+        return "\n".join([
+            "Noise pattern report",
+            f"Pattern id: {pattern.pattern_id}",
+            f"Source profile: {pattern.source_profile}",
+            f"BBox: {pattern.bbox}",
+            f"Tags: {', '.join(pattern.tags)}",
+            f"Created at: {pattern.created_at}",
+            f"Comment: {pattern.comment}",
+            f"Stats: {json.dumps(pattern.stats, indent=2)}",
+        ])
+
+
     def _display_profile(self, data, title):
         if self.visualization_callback:
             self.visualization_callback(data.tolist(), title)
@@ -364,6 +527,10 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     def _show_generator_stats(self, text):
         self.ui.textEdit_generator_meta.setPlainText(text)
+        self.ui.textEdit_results_log.append(text)
+
+    def _show_pattern_stats(self, text):
+        self.ui.textEdit_pattern_library.setPlainText(text)
         self.ui.textEdit_results_log.append(text)
 
     def _log(self, text, color="green"):

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -16,10 +16,7 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.setObjectName("tabWidget")
 
         self.tab_profiles = self._add_profiles_tab()
-        self.tab_noise_patterns = self._add_placeholder_tab(
-            "tab_noise_patterns",
-            "Add noisy radarograms and configure extraction of real air-clutter patterns.",
-        )
+        self.tab_noise_patterns = self._add_noise_patterns_tab()
         self.tab_generator = self._add_generator_tab()
         self.tab_dataset = self._add_placeholder_tab(
             "tab_dataset",
@@ -96,6 +93,73 @@ class Ui_MLClutterExperiment(object):
         self.textEdit_preprocessing_stats.setObjectName("textEdit_preprocessing_stats")
         preprocessing_layout.addWidget(self.textEdit_preprocessing_stats, 3, 0, 1, 2)
         layout.addWidget(self.groupBox_preprocessing, 8, 0, 1, 2)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
+    def _add_noise_patterns_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_noise_patterns")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText("Load real noisy radarograms, extract air-clutter patches, preview them, and persist the pattern library.")
+        layout.addWidget(intro, 0, 0, 1, 4)
+        self.listWidget_noisy_profiles = QtWidgets.QListWidget(tab)
+        self.listWidget_noisy_profiles.setObjectName("listWidget_noisy_profiles")
+        layout.addWidget(self.listWidget_noisy_profiles, 1, 0, 5, 1)
+        self.pushButton_add_noisy_to_library = QtWidgets.QPushButton(tab)
+        self.pushButton_add_noisy_to_library.setObjectName("pushButton_add_noisy_to_library")
+        layout.addWidget(self.pushButton_add_noisy_to_library, 1, 1)
+        self.spinBox_pattern_x_start = QtWidgets.QSpinBox(tab)
+        self.spinBox_pattern_x_start.setObjectName("spinBox_pattern_x_start")
+        self.spinBox_pattern_x_start.setRange(0, 1000000)
+        self.spinBox_pattern_x_end = QtWidgets.QSpinBox(tab)
+        self.spinBox_pattern_x_end.setObjectName("spinBox_pattern_x_end")
+        self.spinBox_pattern_x_end.setRange(1, 1000000)
+        self.spinBox_pattern_z_start = QtWidgets.QSpinBox(tab)
+        self.spinBox_pattern_z_start.setObjectName("spinBox_pattern_z_start")
+        self.spinBox_pattern_z_start.setRange(0, 511)
+        self.spinBox_pattern_z_end = QtWidgets.QSpinBox(tab)
+        self.spinBox_pattern_z_end.setObjectName("spinBox_pattern_z_end")
+        self.spinBox_pattern_z_end.setRange(1, 512)
+        self.spinBox_pattern_z_end.setValue(128)
+        for row, (label, widget) in enumerate([
+            ("x start", self.spinBox_pattern_x_start),
+            ("x end", self.spinBox_pattern_x_end),
+            ("z start", self.spinBox_pattern_z_start),
+            ("z end", self.spinBox_pattern_z_end),
+        ], start=2):
+            layout.addWidget(QtWidgets.QLabel(label, tab), row, 1)
+            layout.addWidget(widget, row, 2)
+        self.comboBox_pattern_tag = QtWidgets.QComboBox(tab)
+        self.comboBox_pattern_tag.setObjectName("comboBox_pattern_tag")
+        for tag in ["pole", "powerline", "metal_fence", "building", "ringing", "vertical_spike", "unknown"]:
+            self.comboBox_pattern_tag.addItem(tag, tag)
+        layout.addWidget(QtWidgets.QLabel("tag", tab), 6, 1)
+        layout.addWidget(self.comboBox_pattern_tag, 6, 2)
+        self.pushButton_extract_manual_pattern = QtWidgets.QPushButton(tab)
+        self.pushButton_extract_manual_pattern.setObjectName("pushButton_extract_manual_pattern")
+        layout.addWidget(self.pushButton_extract_manual_pattern, 7, 1, 1, 2)
+        self.pushButton_extract_energy_patterns = QtWidgets.QPushButton(tab)
+        self.pushButton_extract_energy_patterns.setObjectName("pushButton_extract_energy_patterns")
+        layout.addWidget(self.pushButton_extract_energy_patterns, 8, 1, 1, 2)
+        self.listWidget_pattern_library = QtWidgets.QListWidget(tab)
+        self.listWidget_pattern_library.setObjectName("listWidget_pattern_library")
+        layout.addWidget(self.listWidget_pattern_library, 1, 3, 6, 1)
+        self.pushButton_preview_pattern = QtWidgets.QPushButton(tab)
+        self.pushButton_preview_pattern.setObjectName("pushButton_preview_pattern")
+        layout.addWidget(self.pushButton_preview_pattern, 7, 3)
+        self.pushButton_save_pattern_library = QtWidgets.QPushButton(tab)
+        self.pushButton_save_pattern_library.setObjectName("pushButton_save_pattern_library")
+        layout.addWidget(self.pushButton_save_pattern_library, 8, 3)
+        self.pushButton_load_pattern_library = QtWidgets.QPushButton(tab)
+        self.pushButton_load_pattern_library.setObjectName("pushButton_load_pattern_library")
+        layout.addWidget(self.pushButton_load_pattern_library, 9, 3)
+        self.textEdit_pattern_library = QtWidgets.QTextEdit(tab)
+        self.textEdit_pattern_library.setReadOnly(True)
+        self.textEdit_pattern_library.setObjectName("textEdit_pattern_library")
+        layout.addWidget(self.textEdit_pattern_library, 10, 0, 1, 4)
+        layout.setRowStretch(10, 1)
         self.tabWidget.addTab(tab, "")
         return tab
 
@@ -185,6 +249,12 @@ class Ui_MLClutterExperiment(object):
         self.pushButton_load_real_noisy.setText(_translate("MLClutterExperiment", "Load as Real Noisy"))
         self.groupBox_profile_stats.setTitle(_translate("MLClutterExperiment", "Profile statistics and validation"))
         self.groupBox_preprocessing.setTitle(_translate("MLClutterExperiment", "Preprocessing and normalization"))
+        self.pushButton_add_noisy_to_library.setText(_translate("MLClutterExperiment", "Add Loaded Real Noisy"))
+        self.pushButton_extract_manual_pattern.setText(_translate("MLClutterExperiment", "Extract Manual BBox Pattern"))
+        self.pushButton_extract_energy_patterns.setText(_translate("MLClutterExperiment", "Auto Extract High-Energy Patterns"))
+        self.pushButton_preview_pattern.setText(_translate("MLClutterExperiment", "Preview Pattern"))
+        self.pushButton_save_pattern_library.setText(_translate("MLClutterExperiment", "Save Pattern Library"))
+        self.pushButton_load_pattern_library.setText(_translate("MLClutterExperiment", "Load Pattern Library"))
         self.checkBox_enable_preprocessing.setText(_translate("MLClutterExperiment", "Enable preprocessing"))
         self.pushButton_apply_preprocessing.setText(_translate("MLClutterExperiment", "Normalize Clean Profile"))
         self.pushButton_inverse_preprocessing.setText(_translate("MLClutterExperiment", "Preview Inverse Transform"))

--- a/tests/test_ml_air_clutter_pattern_library.py
+++ b/tests/test_ml_air_clutter_pattern_library.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ml_air_clutter.noise_patterns import PatternExtractionConfig, extract_energy_patterns, extract_pattern_from_bbox
+from ml_air_clutter.pattern_library import NoisePattern, PatternLibrary
+
+
+def test_extract_pattern_from_manual_bbox_normalizes_and_masks():
+    profile = np.arange(16 * 512, dtype=float).reshape(16, 512)
+    mask = np.zeros_like(profile)
+    mask[2:6, 10:30] = 1
+
+    extracted = extract_pattern_from_bbox(profile, [2, 6, 10, 30], mask=mask)
+
+    assert extracted["array"].shape == (4, 20)
+    assert extracted["mask"].shape == (4, 20)
+    assert extracted["stats"]["shape"] == [4, 20]
+    assert abs(float(np.mean(extracted["array"]))) < 1e-12
+    assert extracted["stats"]["mask_coverage"] == 1.0
+
+
+def test_extract_energy_patterns_returns_high_energy_candidates():
+    profile = np.zeros((32, 512), dtype=float)
+    profile[8:16, 100:140] = 10.0
+    config = PatternExtractionConfig(
+        patch_width=8,
+        patch_height=64,
+        stride_x=8,
+        stride_z=32,
+        energy_percentile=90.0,
+        min_mask_coverage=0.05,
+        max_patterns=3,
+    )
+
+    patterns = extract_energy_patterns(profile, config)
+
+    assert 1 <= len(patterns) <= 3
+    assert patterns[0]["bbox"][0] == 8
+    assert patterns[0]["energy_score"] > 0
+
+
+def test_pattern_library_save_load_roundtrip(tmp_path):
+    array = np.ones((4, 8), dtype=float)
+    mask = np.ones_like(array)
+    pattern = NoisePattern.create(
+        source_profile="noisy_profile",
+        array=array,
+        mask=mask,
+        bbox=[1, 5, 2, 10],
+        tags=["ringing"],
+        comment="test pattern",
+        pattern_id="pattern-1",
+    )
+    library = PatternLibrary()
+    library.add_pattern(pattern)
+
+    index_path = library.save(tmp_path)
+    loaded = PatternLibrary.load(tmp_path)
+
+    assert index_path.name == "pattern_library_index.json"
+    assert loaded.summary() == {"num_patterns": 1, "tags": {"ringing": 1}}
+    np.testing.assert_allclose(loaded.get("pattern-1").array, array)
+    assert loaded.get("pattern-1").comment == "test pattern"


### PR DESCRIPTION
### Motivation
- Provide stage 5 functionality from the ML Clutter plan: allow loading real noisy radarograms and extracting real air-clutter patches to reduce the synthetic-to-real gap. 
- Enable cataloging, normalization and reuse of extracted patterns for dataset generation and mixed synthetic/pattern generators.

### Description
- Added `ml_air_clutter/noise_patterns.py` with `PatternExtractionConfig`, `extract_pattern_from_bbox`, `extract_energy_patterns`, normalization and validation helpers for extracting and describing real-noise patches. 
- Added `ml_air_clutter/pattern_library.py` implementing `NoisePattern` and `PatternLibrary` for in-memory catalog, JSON index persistence and saving/loading arrays/masks as `.npy` files. 
- Exported new APIs in `ml_air_clutter/__init__.py` so extraction and library classes are available from the package. 
- Extended the UI: new `Noise Patterns` tab in `qt/ml_clutter_experiment_form.py` and corresponding handlers in `ml_clutter_experiment.py` to register noisy sources, extract manual/auto patterns, preview patterns, and save/load libraries. 
- Added unit tests `tests/test_ml_air_clutter_pattern_library.py` covering manual bbox extraction, energy-based extraction, and library save/load roundtrip.

### Testing
- Compilation check passed with `python -m py_compile ml_air_clutter/noise_patterns.py ml_air_clutter/pattern_library.py ml_air_clutter/__init__.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py` (succeeded). 
- Style/check step `git diff --check` and local static validations ran without errors. 
- Unit tests were added (`tests/test_ml_air_clutter_pattern_library.py`) but full `pytest` execution could not complete because the environment lacked `numpy` and `pip` installation was blocked (attempted `python -m pip install numpy pytest` returned a network tunnel 403), so automated tests that require `numpy` were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34d1a0812c832f9796ba120f95f27d)