### PR TITLE
Fix ML clutter preview signal plotting

### DIFF
--- a/geovel.py
+++ b/geovel.py
@@ -1,5 +1,7 @@
 import traceback
 
+import numpy as np
+
 from load import *
 from filtering import *
 from draw import *
@@ -121,6 +123,25 @@ ui.pushButton_savgol.clicked.connect(calc_savgol)
 ui.pushButton_filtfilt.clicked.connect(calc_filtfilt)
 
 
+def draw_ml_clutter_preview(data, title):
+    draw_image(data)
+    radar = np.asarray(data, dtype=float)
+    if radar.ndim == 2 and radar.size:
+        if radar.shape[0] > 1:
+            mean_signal = np.nanmean(radar, axis=0)
+            center_signal = radar[radar.shape[0] // 2]
+            y_axis = range(len(mean_signal))
+            ui.signal.plot(y=y_axis, x=mean_signal, clear=True, pen='r')
+            ui.signal.plot(y=y_axis, x=center_signal, pen='b')
+        else:
+            trace = radar[0]
+            ui.signal.plot(y=range(len(trace)), x=trace, clear=True, pen='b')
+        ui.signal.showGrid(x=True, y=True)
+        ui.signal.invertY(True)
+        ui.signal.getAxis('left').setLabel('Samples')
+    set_info(title, 'blue')
+
+
 def open_ml_clutter_experiment():
     global ml_clutter_experiment_window
     if 'ml_clutter_experiment_window' not in globals() or ml_clutter_experiment_window is None:
@@ -129,7 +150,7 @@ def open_ml_clutter_experiment():
             profile_id_getter=get_profile_id,
             profile_name_getter=get_profile_name,
             info_callback=set_info,
-            visualization_callback=lambda data, title: (draw_image(data), set_info(title, 'blue')),
+            visualization_callback=draw_ml_clutter_preview,
         )
     ml_clutter_experiment_window.show()
     ml_clutter_experiment_window.raise_()

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -230,8 +230,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         if pattern is None:
             self._show_pattern_stats("Select a pattern from the library before preview.")
             return
-        self._display_profile(pattern.array, f"ML Clutter pattern {pattern.pattern_id}")
         self._display_profile(pattern.mask, f"ML Clutter pattern mask {pattern.pattern_id}")
+        self._display_profile(pattern.array, f"ML Clutter pattern {pattern.pattern_id}")
         self._show_pattern_stats(self._format_pattern_report(pattern))
 
     def delete_selected_pattern(self):


### PR DESCRIPTION
### Motivation
- Allow ML Clutter preview actions to also update the main `signal` PlotWidget so users can visually inspect the signal (mean/center/single-trace) alongside the radarogram image. 
- Ensure the Preview Pattern action leaves the actual extracted pattern visible instead of being hidden by its mask. 

### Description
- Added `draw_ml_clutter_preview` in `geovel.py` which calls `draw_image`, plots the mean trace and center trace (or single trace) on `ui.signal` via `ui.signal.plot`, and configures grid, inverted Y axis, and axis label. 
- Added `import numpy as np` in `geovel.py` and wired `open_ml_clutter_experiment` to use `draw_ml_clutter_preview` as the `visualization_callback` for the ML Clutter window. 
- Reordered preview display in `ml_clutter_experiment.py` so the pattern mask is shown first and then the actual pattern array is displayed, preventing the mask from overwriting the visible pattern. 

### Testing
- Compiled `geovel.py` and `ml_clutter_experiment.py` with `python -m py_compile` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f87e37fc832f98fe1d3563a64cfb)