### PR TITLE
Use displayed ImageItem for signal plotting; add ML clutter preview plotting and fix pattern preview order

### DIFF
--- a/func.py
+++ b/func.py
@@ -437,18 +437,38 @@ def build_list(indexes_1, indexes_minus_1):
 
 
 def updatePlot():
-    # Получаем данные с радара из базы данных
-    rad = session.query(CurrentProfile.signal).first()
-    # Преобразуем данные из строки json в словарь python
-    radar = json.loads(rad[0])
-    # Выбираем область интереса (ROI) изображения
-    selected = roi.getArrayRegion(np.array(radar), img)
-    # Вычисляем половину размера области интереса
-    n = ui.spinBox_roi.value()//2
-    # Очищаем график перед отрисовкой новых данных
-    ui.signal.plot(y=range(0, 512), x=selected.mean(axis=0), clear=True, pen='r')
-    # Добавляем график визуализации одного из профилей данных
-    ui.signal.plot(y=range(0, 512), x=selected[n])
+    # Для интерактивного окна сигнала используем именно ту радарограмму,
+    # которая сейчас показана в ImageItem. Это важно для предпросмотров
+    # ML Clutter: они отображаются без записи в CurrentProfile, поэтому
+    # чтение сигнала из БД может дать профиль другой длины. В таком случае
+    # ROI на правой части предпросмотра выходит за пределы старого профиля и
+    # график превращается в прямую линию.
+    radar = getattr(img, 'image', None)
+    if radar is None:
+        rad = session.query(CurrentProfile.signal).first()
+        if rad is None:
+            return
+        radar = json.loads(rad[0])
+    radar = np.asarray(radar, dtype=float)
+    if radar.ndim != 2 or radar.size == 0:
+        return
+
+    # Выбираем область интереса на текущем изображении. Масштаб подписи оси X
+    # (2.5 м на измерение) не меняет индексы массива ImageItem, поэтому ROI
+    # должен вырезаться из массива текущего изображения, а не из БД.
+    selected = roi.getArrayRegion(radar, img)
+    if selected is None or selected.size == 0:
+        return
+    selected = np.asarray(selected, dtype=float)
+    if selected.ndim == 1:
+        selected = selected.reshape(1, -1)
+    if selected.shape[0] == 0 or selected.shape[1] == 0:
+        return
+
+    trace_index = min(max(0, ui.spinBox_roi.value() // 2), selected.shape[0] - 1)
+    y_axis = range(selected.shape[1])
+    ui.signal.plot(y=y_axis, x=np.nanmean(selected, axis=0), clear=True, pen='r')
+    ui.signal.plot(y=y_axis, x=selected[trace_index])
     # Включаем отображение координатной сетки на графике
     ui.signal.showGrid(x=True, y=True)
     # Инвертируем направление оси Y на графике

--- a/geovel.py
+++ b/geovel.py
@@ -1,5 +1,7 @@
 import traceback
 
+import numpy as np
+
 from load import *
 from filtering import *
 from draw import *
@@ -121,6 +123,25 @@ ui.pushButton_savgol.clicked.connect(calc_savgol)
 ui.pushButton_filtfilt.clicked.connect(calc_filtfilt)
 
 
+def draw_ml_clutter_preview(data, title):
+    draw_image(data)
+    radar = np.asarray(data, dtype=float)
+    if radar.ndim == 2 and radar.size:
+        if radar.shape[0] > 1:
+            mean_signal = np.nanmean(radar, axis=0)
+            center_signal = radar[radar.shape[0] // 2]
+            y_axis = range(len(mean_signal))
+            ui.signal.plot(y=y_axis, x=mean_signal, clear=True, pen='r')
+            ui.signal.plot(y=y_axis, x=center_signal, pen='b')
+        else:
+            trace = radar[0]
+            ui.signal.plot(y=range(len(trace)), x=trace, clear=True, pen='b')
+        ui.signal.showGrid(x=True, y=True)
+        ui.signal.invertY(True)
+        ui.signal.getAxis('left').setLabel('Samples')
+    set_info(title, 'blue')
+
+
 def open_ml_clutter_experiment():
     global ml_clutter_experiment_window
     if 'ml_clutter_experiment_window' not in globals() or ml_clutter_experiment_window is None:
@@ -129,7 +150,7 @@ def open_ml_clutter_experiment():
             profile_id_getter=get_profile_id,
             profile_name_getter=get_profile_name,
             info_callback=set_info,
-            visualization_callback=lambda data, title: (draw_image(data), set_info(title, 'blue')),
+            visualization_callback=draw_ml_clutter_preview,
         )
     ml_clutter_experiment_window.show()
     ml_clutter_experiment_window.raise_()

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -230,8 +230,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         if pattern is None:
             self._show_pattern_stats("Select a pattern from the library before preview.")
             return
-        self._display_profile(pattern.array, f"ML Clutter pattern {pattern.pattern_id}")
         self._display_profile(pattern.mask, f"ML Clutter pattern mask {pattern.pattern_id}")
+        self._display_profile(pattern.array, f"ML Clutter pattern {pattern.pattern_id}")
         self._show_pattern_stats(self._format_pattern_report(pattern))
 
     def delete_selected_pattern(self):


### PR DESCRIPTION
### Motivation
- Ensure the interactive signal plot always reflects the image currently shown in the `ImageItem` (especially for ML clutter previews which are not stored in `CurrentProfile`), and avoid mismatches that produced flat lines when ROI indices were out of range. 
- Provide a dedicated visualization helper for ML clutter previews so previews render consistent signal plots alongside the image. 
- Make pattern preview behavior clearer by adjusting the order of displayed pattern mask and array.

### Description
- Rewrote `updatePlot` to prefer the image attached to `img.image` and fall back to the DB `CurrentProfile.signal` only if needed, added robust validation of `radar` and `selected` arrays, normalized shapes, computed a safe `trace_index`, and adjusted the X/Y axis handling and plotting calls. 
- Added `draw_ml_clutter_preview` in `geovel.py` (and imported `numpy` there) to draw the image and plot mean/center traces for ML clutter previews, and wired it as the `visualization_callback` in `open_ml_clutter_experiment`. 
- Changed `preview_selected_pattern` in `ml_clutter_experiment.py` to display the pattern mask before the pattern array to improve preview clarity.

### Testing
- Ran the project test suite with `pytest -q` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f87e37fc832f98fe1d3563a64cfb)