### PR TITLE
Fix real-pattern SNR scaling and depth anchoring

### DIFF
--- a/ml_air_clutter/pattern_generator.py
+++ b/ml_air_clutter/pattern_generator.py
@@ -96,11 +96,11 @@ def generate_pattern_clutter(clean_profile, pattern_library, config=None, synthe
 
     total_noise = pattern_clutter + synthetic_clutter
     pre_overlay_noise_rms = _rms(total_noise)
-    total_noise, beta = scale_clutter_to_target_snr(clean, total_noise, config.target_snr_db)
+    total_mask = np.maximum(pattern_mask, synthetic_mask)
+    total_noise, beta = scale_clutter_to_target_snr_for_overlay(clean, total_noise, total_mask, config)
     scaled_noise_rms = _rms(total_noise)
     pattern_clutter *= beta
     synthetic_clutter *= beta
-    total_mask = np.maximum(pattern_mask, synthetic_mask)
     noisy, effective_mask = overlay_noise(
         clean,
         total_noise,
@@ -303,12 +303,79 @@ def place_pattern(clean_shape, pattern, mask, rng, smooth_mask=True, target_z_st
 
 
 def _pattern_target_z_start(pattern, transform_meta):
+    del transform_meta  # Depth is anchored to the extracted pattern bbox, not to random augmentations.
     bbox = getattr(pattern, "bbox", None) or [0, 0, 0, 0]
-    source_z_start = int(bbox[2]) if len(bbox) >= 3 else 0
-    crop = transform_meta.get("crop")
-    if crop is not None and len(crop) == 4:
-        source_z_start += int(crop[2])
-    return source_z_start
+    return int(bbox[2]) if len(bbox) >= 3 else 0
+
+
+def scale_clutter_to_target_snr_for_overlay(clean, clutter, mask, config):
+    """Scale clutter so the final overlaid residual is closest to target SNR.
+
+    Dominant/soft-dominance overlays are nonlinear: the pre-overlay pattern RMS
+    is not the same as the residual left in ``noisy - clean``.  In particular,
+    changing ``num_patterns`` changes mask coverage and overlap, so a single
+    pre-overlay RMS normalization produces visibly different intensities.  This
+    helper chooses a global multiplier against the actual overlay residual,
+    keeping the requested SNR stable for one or many mixed real patterns.
+    """
+
+    target_snr_db = config.target_snr_db
+    if target_snr_db is None or not np.any(clutter):
+        return clutter, 1.0
+
+    clean = np.asarray(clean, dtype=float)
+    clutter = np.asarray(clutter, dtype=float)
+    signal_power = float(np.mean(clean ** 2))
+    target_noise_power = signal_power / (10.0 ** (float(target_snr_db) / 10.0))
+    if target_noise_power <= 0:
+        return clutter, 1.0
+
+    def objective(beta):
+        noisy, _ = overlay_noise(
+            clean,
+            clutter * beta,
+            mask,
+            config.overlay_mode,
+            config.overlay_midpoint,
+            soft_dominance_temperature=config.soft_dominance_temperature,
+        )
+        residual = noisy - clean
+        return abs(float(np.mean(residual ** 2)) - target_noise_power)
+
+    # Hard dominance can be non-monotonic around the overlay midpoint.  Use a
+    # bounded log-grid search followed by local golden-section refinement rather
+    # than assuming residual power grows monotonically with beta.
+    candidates = np.concatenate(([0.0], np.geomspace(1e-4, 1e6, num=241)))
+    errors = np.array([objective(float(beta)) for beta in candidates])
+    best_index = int(np.argmin(errors))
+    best = float(candidates[best_index])
+
+    left = float(candidates[max(0, best_index - 1)])
+    right = float(candidates[min(len(candidates) - 1, best_index + 1)])
+    if right > left:
+        inv_phi = (math.sqrt(5.0) - 1.0) / 2.0
+        c = right - inv_phi * (right - left)
+        d = left + inv_phi * (right - left)
+        fc = objective(c)
+        fd = objective(d)
+        for _ in range(48):
+            if fc < fd:
+                right = d
+                d = c
+                fd = fc
+                c = right - inv_phi * (right - left)
+                fc = objective(c)
+            else:
+                left = c
+                c = d
+                fc = fd
+                d = left + inv_phi * (right - left)
+                fd = objective(d)
+        refined = (left + right) / 2.0
+        if objective(refined) < objective(best):
+            best = refined
+
+    return clutter * best, float(best)
 
 
 def scale_clutter_to_target_snr(clean, clutter, target_snr_db):

--- a/tests/test_ml_air_clutter_pattern_generator.py
+++ b/tests/test_ml_air_clutter_pattern_generator.py
@@ -157,6 +157,50 @@ def test_overlay_noise_by_soft_dominance_blends_instead_of_hard_replace():
     np.testing.assert_allclose(effective_mask, [[1.0, 1.0, 0.0]])
 
 
+
+def test_pattern_generator_keeps_target_snr_stable_when_mixing_more_real_patterns():
+    clean = np.full((64, 512), 128.0, dtype=float)
+    common = dict(
+        seed=11,
+        target_snr_db=30.0,
+        random_crop=False,
+        jitter_std=0.0,
+        fade_probability=0.0,
+        polarity_flip_probability=0.0,
+        amplitude_scale_min=1.0,
+        amplitude_scale_max=1.0,
+    )
+
+    _, _, _, one_meta = generate_pattern_clutter(clean, _library(), PatternClutterConfig(num_patterns=1, **common))
+    _, _, _, many_meta = generate_pattern_clutter(clean, _library(), PatternClutterConfig(num_patterns=4, **common))
+
+    assert abs(one_meta["actual_snr_db"] - 30.0) < 0.05
+    assert abs(many_meta["actual_snr_db"] - 30.0) < 0.05
+    assert abs(one_meta["actual_snr_db"] - many_meta["actual_snr_db"]) < 0.05
+
+
+def test_random_crop_does_not_move_preserved_pattern_depth():
+    pattern = _library().get("p1")
+    clean = np.full((32, 512), 128.0, dtype=float)
+    cfg = PatternClutterConfig(
+        seed=2,
+        target_snr_db=None,
+        random_crop=True,
+        min_crop_fraction=0.5,
+        num_patterns=1,
+        jitter_std=0.0,
+        fade_probability=0.0,
+        polarity_flip_probability=0.0,
+        amplitude_scale_min=1.0,
+        amplitude_scale_max=1.0,
+    )
+
+    _, _, _, meta = generate_pattern_clutter(clean, PatternLibrary([pattern]), cfg)
+
+    assert "crop" in meta["placements"][0]["transform"]
+    assert meta["placements"][0]["placement"]["z_start"] == pattern.bbox[2]
+
+
 def test_place_pattern_clamps_preserved_depth_to_profile_bounds():
     arr = np.full((12, 64), 240.0, dtype=float)
     pattern = NoisePattern.create("src", arr, np.ones_like(arr), [0, 12, 500, 564], pattern_id="deep", tags=["ringing"])


### PR DESCRIPTION
### Motivation
- Real extracted patterns mixed into generators produced inconsistent visible intensities when changing the number of `Real patterns to mix` because SNR scaling used pre-overlay RMS rather than the actual post-overlay residual.  
- Preserved pattern depth could shift when pattern augmentations (random crop) were applied, which breaks the expectation that placed patterns keep their original depth.

### Description
- Added `scale_clutter_to_target_snr_for_overlay` to search for a global multiplier that makes the actual post-overlay residual power match the requested `target_snr_db`, using a bounded log-grid search and local refinement.  
- `generate_pattern_clutter` now computes `total_mask` and uses the new scaling helper so dominant/soft-dominance overlays keep the requested SNR independent of pattern count or overlap.  
- Anchored preserved placement depth by changing `_pattern_target_z_start` to ignore transform crop offsets and use the pattern `bbox` depth directly.  
- Added two regression tests: `test_pattern_generator_keeps_target_snr_stable_when_mixing_more_real_patterns` and `test_random_crop_does_not_move_preserved_pattern_depth` to validate SNR stability and depth anchoring.

### Testing
- Ran `python -m py_compile ml_air_clutter/pattern_generator.py tests/test_ml_air_clutter_pattern_generator.py` which succeeded.  
- Attempted `pytest -q tests/test_ml_air_clutter_pattern_generator.py` but test execution failed in this environment with `ModuleNotFoundError: No module named 'numpy'`, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3936585de8832fbd4311fccf3bf03f)