### PR TITLE
Implement paired ML clutter dataset stage

### DIFF
--- a/ml_air_clutter/dataset.py
+++ b/ml_air_clutter/dataset.py
@@ -1,0 +1,208 @@
+"""Paired clean/noisy patch dataset utilities for ML air-clutter experiments."""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PatchDatasetConfig:
+    """Serializable patching and split configuration for paired datasets."""
+
+    patch_width: int = 64
+    stride: int = 32
+    train_fraction: float = 0.7
+    validation_fraction: float = 0.15
+    test_fraction: float = 0.15
+    seed: int = 42
+    min_num_traces: int = 1
+    gap_width: Optional[int] = None
+
+    def to_dict(self):
+        return asdict(self)
+
+
+class PairValidationError(ValueError):
+    """Raised when a clean/noisy pair cannot be used as supervised data."""
+
+
+def _stats(data: np.ndarray) -> Dict[str, float]:
+    finite = data[np.isfinite(data)]
+    if finite.size == 0:
+        finite = np.array([np.nan])
+    return {
+        "min": float(np.nanmin(finite)),
+        "max": float(np.nanmax(finite)),
+        "mean": float(np.nanmean(finite)),
+        "std": float(np.nanstd(finite)),
+        "p01": float(np.nanpercentile(finite, 1)),
+        "p99": float(np.nanpercentile(finite, 99)),
+    }
+
+
+def validate_clean_noisy_pair(clean, noisy, min_num_traces: int = 1) -> Dict[str, object]:
+    """Validate paired arrays and return errors plus diagnostic warnings."""
+
+    clean = np.asarray(clean, dtype=float)
+    noisy = np.asarray(noisy, dtype=float)
+    errors: List[str] = []
+    warnings: List[str] = []
+    if clean.ndim != 2:
+        errors.append(f"clean must be 2D, got ndim={clean.ndim}")
+    if noisy.ndim != 2:
+        errors.append(f"noisy must be 2D, got ndim={noisy.ndim}")
+    if clean.ndim == 2 and noisy.ndim == 2 and clean.shape != noisy.shape:
+        errors.append(f"clean and noisy shapes must match, got {clean.shape} and {noisy.shape}")
+    shape = clean.shape if clean.ndim == 2 else ()
+    if clean.ndim == 2:
+        if clean.shape[1] != 512:
+            errors.append(f"pair must have 512 samples per trace, got clean shape={clean.shape}")
+            if clean.shape[0] == 512:
+                warnings.append("clean looks transposed as [512, num_traces]")
+        if clean.shape[0] < min_num_traces:
+            errors.append(f"pair must contain at least {min_num_traces} traces, got {clean.shape[0]}")
+    for name, data in (("clean", clean), ("noisy", noisy)):
+        if not np.isfinite(data).all():
+            errors.append(f"{name} contains NaN or infinite values")
+    clean_stats = _stats(clean) if clean.size else {}
+    noisy_stats = _stats(noisy) if noisy.size else {}
+    difference = noisy - clean if clean.shape == noisy.shape and clean.ndim == 2 else np.array([])
+    difference_stats = _stats(difference) if difference.size else {}
+    if not errors and difference.size:
+        amp = max(clean_stats["p99"] - clean_stats["p01"], 1e-8)
+        diff_std = difference_stats["std"]
+        if diff_std < amp * 1e-3:
+            warnings.append("noisy-clean difference is very small; pair may contain almost no clutter")
+        if diff_std > amp * 2.0:
+            warnings.append("noisy-clean difference is very large; profiles may be mismatched")
+        for key in ("min", "max", "p01", "p99"):
+            if abs(clean_stats[key] - noisy_stats[key]) > amp * 2.0:
+                warnings.append(f"clean/noisy {key} ranges differ strongly")
+                break
+    return {
+        "valid": not errors,
+        "errors": errors,
+        "warnings": warnings,
+        "shape": list(shape),
+        "clean_stats": clean_stats,
+        "noisy_stats": noisy_stats,
+        "difference_stats": difference_stats,
+    }
+
+
+def build_paired_patch_dataset(pairs: Iterable[Dict[str, object]], config: PatchDatasetConfig):
+    """Build leak-resistant patch samples and a JSON-serializable summary."""
+
+    pairs = list(pairs)
+    if not pairs:
+        raise PairValidationError("Add at least one clean/noisy pair before building the dataset.")
+    if config.patch_width <= 0 or config.stride <= 0:
+        raise PairValidationError("patch_width and stride must be positive.")
+    if not np.isclose(config.train_fraction + config.validation_fraction + config.test_fraction, 1.0):
+        raise PairValidationError("train/validation/test fractions must sum to 1.0.")
+
+    samples = {"train": [], "validation": [], "test": []}
+    pair_summaries = []
+    if len(pairs) >= 3:
+        ordered = sorted(pairs, key=lambda p: str(p["pair_id"]))
+        n = len(ordered)
+        train_end = max(1, int(round(n * config.train_fraction)))
+        val_end = min(n - 1, train_end + max(1, int(round(n * config.validation_fraction))))
+        split_by_pair = {p["pair_id"]: "train" for p in ordered[:train_end]}
+        split_by_pair.update({p["pair_id"]: "validation" for p in ordered[train_end:val_end]})
+        split_by_pair.update({p["pair_id"]: "test" for p in ordered[val_end:]})
+    else:
+        split_by_pair = {}
+
+    for pair in pairs:
+        clean = np.asarray(pair["clean"], dtype=float)
+        noisy = np.asarray(pair["noisy"], dtype=float)
+        report = validate_clean_noisy_pair(clean, noisy, config.min_num_traces)
+        if not report["valid"]:
+            raise PairValidationError(f"Pair {pair['pair_id']} is invalid: {'; '.join(report['errors'])}")
+        pair_summaries.append({
+            "pair_id": pair["pair_id"],
+            "clean_path": pair.get("clean_path", ""),
+            "noisy_path": pair.get("noisy_path", ""),
+            "shape": list(clean.shape),
+            "clean_stats": report["clean_stats"],
+            "noisy_stats": report["noisy_stats"],
+            "difference_stats": report["difference_stats"],
+            "warnings": report["warnings"],
+        })
+        for split, x_start, x_end in _iter_split_windows(clean.shape[0], config, split_by_pair.get(pair["pair_id"])):
+            sample = {
+                "noisy": noisy[x_start:x_end].copy(),
+                "clean": clean[x_start:x_end].copy(),
+                "pair_id": pair["pair_id"],
+                "source_clean_profile": pair.get("clean_path", pair.get("clean_name", "")),
+                "source_noisy_profile": pair.get("noisy_path", pair.get("noisy_name", "")),
+                "x_start": int(x_start),
+                "x_end": int(x_end),
+                "normalization": pair.get("normalization", {}),
+                "sample_meta": {"split_strategy": "by_pair_or_trace_blocks"},
+                "residual": noisy[x_start:x_end] - clean[x_start:x_end],
+            }
+            samples[split].append(sample)
+    summary = {
+        "dataset_schema": "paired_clean_noisy_v1",
+        "pairs": pair_summaries,
+        "patch_width": config.patch_width,
+        "stride": config.stride,
+        "split_strategy": "by_pair_or_trace_blocks",
+        "num_train_patches": len(samples["train"]),
+        "num_validation_patches": len(samples["validation"]),
+        "num_test_patches": len(samples["test"]),
+        "normalization": {},
+        "config": config.to_dict(),
+    }
+    return samples, summary
+
+
+def _iter_split_windows(num_traces: int, config: PatchDatasetConfig, fixed_split: Optional[str]):
+    if num_traces < config.patch_width:
+        return
+    starts = list(range(0, num_traces - config.patch_width + 1, config.stride))
+    if starts[-1] != num_traces - config.patch_width:
+        starts.append(num_traces - config.patch_width)
+    if fixed_split:
+        for start in starts:
+            yield fixed_split, start, start + config.patch_width
+        return
+    gap = config.gap_width if config.gap_width is not None else config.patch_width
+    train_limit = int(num_traces * config.train_fraction)
+    val_limit = int(num_traces * (config.train_fraction + config.validation_fraction))
+    for start in starts:
+        end = start + config.patch_width
+        center = (start + end) / 2.0
+        if end <= max(0, train_limit - gap):
+            split = "train"
+        elif start >= train_limit + gap and end <= max(train_limit + gap, val_limit - gap):
+            split = "validation"
+        elif start >= val_limit + gap:
+            split = "test"
+        else:
+            continue
+        yield split, start, end
+
+
+def save_dataset(directory, samples, summary) -> Path:
+    """Persist samples as compressed npz files plus dataset_summary.json."""
+
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    with (directory / "dataset_summary.json").open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, ensure_ascii=False)
+    for split, split_samples in samples.items():
+        split_dir = directory / split
+        split_dir.mkdir(exist_ok=True)
+        for index, sample in enumerate(split_samples):
+            np.savez_compressed(
+                split_dir / f"{sample['pair_id']}_{index:06d}.npz",
+                noisy=sample["noisy"], clean=sample["clean"], residual=sample["residual"],
+                meta=json.dumps({k: v for k, v in sample.items() if k not in {"noisy", "clean", "residual"}}, ensure_ascii=False),
+            )
+    return directory / "dataset_summary.json"

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -5,6 +5,13 @@ import numpy as np
 from PyQt5 import QtWidgets
 
 from ml_air_clutter.config import NormalizationConfig, SyntheticClutterConfig
+from ml_air_clutter.dataset import (
+    PairValidationError,
+    PatchDatasetConfig,
+    build_paired_patch_dataset,
+    save_dataset,
+    validate_clean_noisy_pair,
+)
 from ml_air_clutter.noise_patterns import (
     PatternExtractionConfig,
     extract_energy_patterns,
@@ -50,6 +57,9 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.experiment_profiles = {}
         self.synthetic_clutter_result = None
         self.pattern_clutter_result = None
+        self.dataset_pairs = []
+        self.dataset_samples = None
+        self.dataset_summary = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -58,6 +68,11 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_apply_preprocessing.clicked.connect(self.normalize_clean_profile)
         self.ui.pushButton_inverse_preprocessing.clicked.connect(self.preview_inverse_normalization)
         self.ui.pushButton_generate_synthetic_clutter.clicked.connect(self.generate_synthetic_clutter_preview)
+        self.ui.pushButton_add_clean_noisy_pair.clicked.connect(self.add_current_clean_noisy_pair)
+        self.ui.pushButton_preview_pair.clicked.connect(self.preview_selected_pair)
+        self.ui.pushButton_build_dataset.clicked.connect(self.build_dataset)
+        self.ui.pushButton_preview_random_patch.clicked.connect(self.preview_random_patch)
+        self.ui.pushButton_save_dataset.clicked.connect(self.save_dataset)
         self.ui.pushButton_add_noisy_to_library.clicked.connect(self.add_loaded_real_noisy_to_pattern_sources)
         self.ui.pushButton_extract_manual_pattern.clicked.connect(self.extract_manual_pattern)
         self.ui.pushButton_extract_energy_patterns.clicked.connect(self.extract_energy_patterns)
@@ -157,6 +172,135 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             self._register_real_noisy_profile(name, prepared, source)
         self._display_profile(prepared, f"ML Clutter {role.replace('_', ' ')}: {name}")
         self._log(f"Profile '{name}' loaded as {role.replace('_', ' ')} and displayed in MainWindow")
+
+    def add_current_clean_noisy_pair(self):
+        if self.clean_profile is None or self.real_noisy_profile is None:
+            self._show_dataset_stats("Load both Clean and Real Noisy profiles before adding a dataset pair.")
+            self._log("ML Clutter dataset: clean/noisy pair is incomplete", "red")
+            return
+        pair_id = f"pair_{len(self.dataset_pairs) + 1:03d}"
+        clean_name = f"clean_{pair_id}"
+        noisy_name = f"noisy_{pair_id}"
+        report = validate_clean_noisy_pair(self.clean_profile, self.real_noisy_profile, self.MIN_NUM_TRACES)
+        pair = {
+            "pair_id": pair_id,
+            "clean": self.clean_profile.copy(),
+            "noisy": self.real_noisy_profile.copy(),
+            "clean_name": clean_name,
+            "noisy_name": noisy_name,
+            "clean_path": clean_name,
+            "noisy_path": noisy_name,
+            "validation": report,
+            "normalization": self.experiment_config.get("normalization") or {},
+        }
+        self.dataset_pairs.append(pair)
+        self._refresh_dataset_pairs_ui()
+        self._show_dataset_stats(self._format_pair_validation_report(pair))
+        self._log(f"Dataset pair added: {pair_id} ({'valid' if report['valid'] else 'invalid'})")
+
+    def preview_selected_pair(self):
+        pair = self._selected_dataset_pair()
+        if pair is None:
+            self._show_dataset_stats("Select a clean/noisy pair before preview.")
+            return
+        self._display_profile(pair["clean"], f"ML Clutter dataset {pair['pair_id']} clean")
+        self._display_profile(pair["noisy"], f"ML Clutter dataset {pair['pair_id']} noisy")
+        self._display_profile(pair["noisy"] - pair["clean"], f"ML Clutter dataset {pair['pair_id']} residual")
+        self._show_dataset_stats(self._format_pair_validation_report(pair))
+
+    def build_dataset(self):
+        config = self._current_dataset_config()
+        try:
+            samples, summary = build_paired_patch_dataset(self.dataset_pairs, config)
+        except PairValidationError as exc:
+            self._show_dataset_stats(str(exc))
+            self._log(f"ML Clutter dataset build failed: {exc}", "red")
+            return
+        self.dataset_samples = samples
+        self.dataset_summary = summary
+        self._show_dataset_stats(json.dumps(summary, indent=2, ensure_ascii=False))
+        self._log(
+            "Dataset built: "
+            f"train={summary['num_train_patches']}, "
+            f"validation={summary['num_validation_patches']}, test={summary['num_test_patches']}"
+        )
+
+    def preview_random_patch(self):
+        if not self.dataset_samples:
+            self._show_dataset_stats("Build the dataset before previewing patches.")
+            return
+        available = [(split, sample) for split, split_samples in self.dataset_samples.items() for sample in split_samples]
+        if not available:
+            self._show_dataset_stats("Dataset has no patches. Check patch width, stride and split fractions.")
+            return
+        rng = np.random.default_rng(int(self.ui.spinBox_gen_seed.value()))
+        split, sample = available[int(rng.integers(0, len(available)))]
+        self._display_profile(sample["clean"], f"ML Clutter {split} patch clean {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
+        self._display_profile(sample["noisy"], f"ML Clutter {split} patch noisy {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
+        self._display_profile(sample["residual"], f"ML Clutter {split} patch residual {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
+        self._show_dataset_stats(json.dumps({k: v for k, v in sample.items() if k not in {"clean", "noisy", "residual"}}, indent=2, ensure_ascii=False))
+
+    def save_dataset(self):
+        if self.dataset_samples is None or self.dataset_summary is None:
+            self._show_dataset_stats("Build the dataset before saving it.")
+            return
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Save paired ML clutter dataset")
+        if not directory:
+            return
+        summary_path = save_dataset(directory, self.dataset_samples, self.dataset_summary)
+        self._show_dataset_stats(f"Dataset saved to {summary_path}\n" + json.dumps(self.dataset_summary, indent=2, ensure_ascii=False))
+        self._log(f"ML Clutter dataset saved: {summary_path}")
+
+    def _current_dataset_config(self):
+        return PatchDatasetConfig(
+            patch_width=int(self.ui.spinBox_dataset_patch_width.value()),
+            stride=int(self.ui.spinBox_dataset_stride.value()),
+            train_fraction=float(self.ui.doubleSpinBox_dataset_train.value()),
+            validation_fraction=float(self.ui.doubleSpinBox_dataset_val.value()),
+            test_fraction=float(self.ui.doubleSpinBox_dataset_test.value()),
+            seed=int(self.ui.spinBox_gen_seed.value()),
+            min_num_traces=self.MIN_NUM_TRACES,
+        )
+
+    def _selected_dataset_pair(self):
+        row = self.ui.tableWidget_dataset_pairs.currentRow()
+        if row < 0 or row >= len(self.dataset_pairs):
+            return None
+        return self.dataset_pairs[row]
+
+    def _refresh_dataset_pairs_ui(self):
+        table = self.ui.tableWidget_dataset_pairs
+        table.setRowCount(len(self.dataset_pairs))
+        for row, pair in enumerate(self.dataset_pairs):
+            report = pair["validation"]
+            values = [
+                pair["pair_id"], pair["clean_name"], pair["noisy_name"], str(tuple(report["shape"])),
+                "OK" if report["valid"] else "ERROR: " + "; ".join(report["errors"]),
+            ]
+            for col, value in enumerate(values):
+                table.setItem(row, col, QtWidgets.QTableWidgetItem(value))
+        table.resizeColumnsToContents()
+
+    @staticmethod
+    def _format_pair_validation_report(pair):
+        report = pair["validation"]
+        lines = [
+            f"Pair id: {pair['pair_id']}",
+            f"Clean source: {pair['clean_name']}",
+            f"Noisy source: {pair['noisy_name']}",
+            f"Shape: {report['shape']}",
+            f"Validation: {'OK' if report['valid'] else 'ERROR'}",
+        ]
+        if report["errors"]:
+            lines.append("Errors: " + "; ".join(report["errors"]))
+        if report["warnings"]:
+            lines.append("Warnings: " + "; ".join(report["warnings"]))
+        lines.extend([
+            "Clean stats:", json.dumps(report["clean_stats"], indent=2),
+            "Noisy stats:", json.dumps(report["noisy_stats"], indent=2),
+            "Difference stats:", json.dumps(report["difference_stats"], indent=2),
+        ])
+        return "\n".join(lines)
 
     def add_loaded_real_noisy_to_pattern_sources(self):
         if self.real_noisy_profile is None:
@@ -681,6 +825,10 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     def _show_pattern_stats(self, text):
         self.ui.textEdit_pattern_library.setPlainText(text)
+        self.ui.textEdit_results_log.append(text)
+
+    def _show_dataset_stats(self, text):
+        self.ui.textEdit_dataset_summary.setPlainText(text)
         self.ui.textEdit_results_log.append(text)
 
     def _log(self, text, color="green"):

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -18,10 +18,7 @@ class Ui_MLClutterExperiment(object):
         self.tab_profiles = self._add_profiles_tab()
         self.tab_noise_patterns = self._add_noise_patterns_tab()
         self.tab_generator = self._add_generator_tab()
-        self.tab_dataset = self._add_placeholder_tab(
-            "tab_dataset",
-            "Generate synthetic noisy/clean training pairs and patch datasets.",
-        )
+        self.tab_dataset = self._add_dataset_tab()
         self.tab_model = self._add_placeholder_tab(
             "tab_model",
             "Choose baseline CNN, DnCNN, or U-Net model settings.",
@@ -276,6 +273,78 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.addTab(tab, "")
         return tab
 
+    def _add_dataset_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_dataset")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText("Build the temporary paired clean/noisy supervised dataset: input = noisy, target = clean.")
+        layout.addWidget(intro, 0, 0, 1, 4)
+        self.pushButton_add_clean_noisy_pair = QtWidgets.QPushButton(tab)
+        self.pushButton_add_clean_noisy_pair.setObjectName("pushButton_add_clean_noisy_pair")
+        layout.addWidget(self.pushButton_add_clean_noisy_pair, 1, 0)
+        self.pushButton_preview_pair = QtWidgets.QPushButton(tab)
+        self.pushButton_preview_pair.setObjectName("pushButton_preview_pair")
+        layout.addWidget(self.pushButton_preview_pair, 1, 1)
+        self.pushButton_build_dataset = QtWidgets.QPushButton(tab)
+        self.pushButton_build_dataset.setObjectName("pushButton_build_dataset")
+        layout.addWidget(self.pushButton_build_dataset, 1, 2)
+        self.pushButton_preview_random_patch = QtWidgets.QPushButton(tab)
+        self.pushButton_preview_random_patch.setObjectName("pushButton_preview_random_patch")
+        layout.addWidget(self.pushButton_preview_random_patch, 1, 3)
+        self.tableWidget_dataset_pairs = QtWidgets.QTableWidget(tab)
+        self.tableWidget_dataset_pairs.setObjectName("tableWidget_dataset_pairs")
+        self.tableWidget_dataset_pairs.setColumnCount(5)
+        self.tableWidget_dataset_pairs.setHorizontalHeaderLabels(["Pair id", "Clean", "Noisy", "Shape", "Validation"])
+        self.tableWidget_dataset_pairs.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.tableWidget_dataset_pairs, 2, 0, 1, 4)
+        self.spinBox_dataset_patch_width = QtWidgets.QSpinBox(tab)
+        self.spinBox_dataset_patch_width.setObjectName("spinBox_dataset_patch_width")
+        self.spinBox_dataset_patch_width.setRange(1, 100000)
+        self.spinBox_dataset_patch_width.setValue(64)
+        self.spinBox_dataset_stride = QtWidgets.QSpinBox(tab)
+        self.spinBox_dataset_stride.setObjectName("spinBox_dataset_stride")
+        self.spinBox_dataset_stride.setRange(1, 100000)
+        self.spinBox_dataset_stride.setValue(32)
+        self.doubleSpinBox_dataset_train = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_dataset_train.setObjectName("doubleSpinBox_dataset_train")
+        self.doubleSpinBox_dataset_train.setRange(0.0, 1.0)
+        self.doubleSpinBox_dataset_train.setValue(0.7)
+        self.doubleSpinBox_dataset_val = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_dataset_val.setObjectName("doubleSpinBox_dataset_val")
+        self.doubleSpinBox_dataset_val.setRange(0.0, 1.0)
+        self.doubleSpinBox_dataset_val.setValue(0.15)
+        self.doubleSpinBox_dataset_test = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_dataset_test.setObjectName("doubleSpinBox_dataset_test")
+        self.doubleSpinBox_dataset_test.setRange(0.0, 1.0)
+        self.doubleSpinBox_dataset_test.setValue(0.15)
+        dataset_controls = [
+            ("patch width", self.spinBox_dataset_patch_width),
+            ("stride", self.spinBox_dataset_stride),
+            ("train", self.doubleSpinBox_dataset_train),
+            ("validation", self.doubleSpinBox_dataset_val),
+        ]
+        for col, (label, widget) in enumerate(dataset_controls):
+            layout.addWidget(QtWidgets.QLabel(label, tab), 3, col)
+            layout.addWidget(widget, 4, col)
+        layout.addWidget(QtWidgets.QLabel("test", tab), 5, 2)
+        layout.addWidget(self.doubleSpinBox_dataset_test, 5, 3)
+        self.pushButton_save_dataset = QtWidgets.QPushButton(tab)
+        self.pushButton_save_dataset.setObjectName("pushButton_save_dataset")
+        layout.addWidget(self.pushButton_save_dataset, 5, 0)
+        self.pushButton_load_dataset = QtWidgets.QPushButton(tab)
+        self.pushButton_load_dataset.setObjectName("pushButton_load_dataset")
+        self.pushButton_load_dataset.setEnabled(False)
+        layout.addWidget(self.pushButton_load_dataset, 5, 1)
+        self.textEdit_dataset_summary = QtWidgets.QTextEdit(tab)
+        self.textEdit_dataset_summary.setReadOnly(True)
+        self.textEdit_dataset_summary.setObjectName("textEdit_dataset_summary")
+        layout.addWidget(self.textEdit_dataset_summary, 6, 0, 1, 4)
+        layout.setRowStretch(6, 1)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
     def _add_placeholder_tab(self, object_name, message):
         tab = QtWidgets.QWidget()
         tab.setObjectName(object_name)
@@ -326,6 +395,12 @@ class Ui_MLClutterExperiment(object):
         self.checkBox_gen_vertical_spikes.setText(_translate("MLClutterExperiment", "Vertical spikes"))
         self.checkBox_gen_noise_zones.setText(_translate("MLClutterExperiment", "Wide noise zones"))
         self.pushButton_generate_synthetic_clutter.setText(_translate("MLClutterExperiment", "Generate Clutter Preview"))
+        self.pushButton_add_clean_noisy_pair.setText(_translate("MLClutterExperiment", "Add Clean/Noisy Pair"))
+        self.pushButton_preview_pair.setText(_translate("MLClutterExperiment", "Preview Pair"))
+        self.pushButton_build_dataset.setText(_translate("MLClutterExperiment", "Build Dataset"))
+        self.pushButton_preview_random_patch.setText(_translate("MLClutterExperiment", "Preview Random Patch"))
+        self.pushButton_save_dataset.setText(_translate("MLClutterExperiment", "Save Dataset"))
+        self.pushButton_load_dataset.setText(_translate("MLClutterExperiment", "Load Dataset"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))

--- a/tests/test_ml_air_clutter_dataset.py
+++ b/tests/test_ml_air_clutter_dataset.py
@@ -1,0 +1,79 @@
+import json
+
+import numpy as np
+import pytest
+
+from ml_air_clutter.dataset import (
+    PairValidationError,
+    PatchDatasetConfig,
+    build_paired_patch_dataset,
+    save_dataset,
+    validate_clean_noisy_pair,
+)
+
+
+def test_validate_clean_noisy_pair_accepts_matching_512_sample_arrays():
+    clean = np.zeros((96, 512), dtype=float)
+    noisy = clean + 0.1
+
+    report = validate_clean_noisy_pair(clean, noisy)
+
+    assert report["valid"] is True
+    assert report["shape"] == [96, 512]
+    assert report["errors"] == []
+    assert "difference_stats" in report
+
+
+def test_validate_clean_noisy_pair_rejects_mismatched_shapes():
+    report = validate_clean_noisy_pair(np.zeros((8, 512)), np.zeros((9, 512)))
+
+    assert report["valid"] is False
+    assert any("shapes must match" in error for error in report["errors"])
+
+
+def test_build_paired_patch_dataset_uses_trace_blocks_with_gap_for_single_pair():
+    clean = np.arange(160 * 512, dtype=float).reshape(160, 512)
+    noisy = clean + 5.0
+    config = PatchDatasetConfig(patch_width=16, stride=8, train_fraction=0.6, validation_fraction=0.2, test_fraction=0.2)
+
+    samples, summary = build_paired_patch_dataset([
+        {"pair_id": "pair_a", "clean": clean, "noisy": noisy, "clean_path": "clean.npy", "noisy_path": "noisy.npy"}
+    ], config)
+
+    assert summary["dataset_schema"] == "paired_clean_noisy_v1"
+    assert summary["num_train_patches"] == len(samples["train"])
+    assert summary["num_validation_patches"] == len(samples["validation"])
+    assert summary["num_test_patches"] == len(samples["test"])
+    assert samples["train"]
+    assert samples["validation"]
+    assert samples["test"]
+    train_max = max(sample["x_end"] for sample in samples["train"])
+    val_min = min(sample["x_start"] for sample in samples["validation"])
+    assert val_min - train_max >= config.patch_width
+    first = samples["train"][0]
+    assert np.array_equal(first["noisy"], noisy[first["x_start"]:first["x_end"]])
+    assert np.array_equal(first["clean"], clean[first["x_start"]:first["x_end"]])
+    assert np.array_equal(first["residual"], first["noisy"] - first["clean"])
+
+
+def test_build_paired_patch_dataset_rejects_invalid_pair():
+    config = PatchDatasetConfig(patch_width=8, stride=4)
+
+    with pytest.raises(PairValidationError):
+        build_paired_patch_dataset([{"pair_id": "bad", "clean": np.zeros((8, 256)), "noisy": np.zeros((8, 256))}], config)
+
+
+def test_save_dataset_writes_summary_and_npz_samples(tmp_path):
+    clean = np.zeros((48, 512), dtype=float)
+    noisy = clean + 1.0
+    samples, summary = build_paired_patch_dataset(
+        [{"pair_id": "pair_a", "clean": clean, "noisy": noisy}],
+        PatchDatasetConfig(patch_width=8, stride=8),
+    )
+
+    summary_path = save_dataset(tmp_path, samples, summary)
+
+    assert summary_path.exists()
+    loaded_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert loaded_summary["dataset_schema"] == "paired_clean_noisy_v1"
+    assert list((tmp_path / "train").glob("*.npz"))


### PR DESCRIPTION
### Motivation
- Provide Stage 7 functionality from the ML clutter plan by enabling construction of a supervised paired dataset (input=noisy, target=clean) for the baseline pipeline and UI-driven experiment flow. 
- Add leak-resistant patching and basic split logic so users can build, preview and persist datasets from existing clean/noisy profile pairs.

### Description
- New dataset module `ml_air_clutter/dataset.py` implementing `PatchDatasetConfig`, `validate_clean_noisy_pair`, `build_paired_patch_dataset`, `_iter_split_windows` and `save_dataset` to validate pairs, produce leak-aware patch samples, summarize splits and persist `.npz` samples plus `dataset_summary.json`.
- Replaced the Dataset placeholder with a working tab in `qt/ml_clutter_experiment_form.py` (`_add_dataset_tab`) that provides UI controls for adding pairs, patch/split settings, preview, build and save actions.
- Wired dataset flow into `ml_clutter_experiment.py`: added storage for `dataset_pairs`, `dataset_samples`, `dataset_summary`, UI handlers and methods `add_current_clean_noisy_pair`, `preview_selected_pair`, `build_dataset`, `preview_random_patch`, `save_dataset`, `_current_dataset_config`, plus `_show_dataset_stats` and UI signal connections.
- Added unit tests `tests/test_ml_air_clutter_dataset.py` covering pair validation, patch splitting with gap, rejection of invalid pairs, and persistence of summary/npz files.

### Testing
- Successfully compiled modified modules with `python -m py_compile ml_air_clutter/dataset.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py`.
- Ran `git diff --check` to verify no whitespace/errors in diffs.
- Added and ran `pytest -q tests/test_ml_air_clutter_dataset.py`, but collection/execution was blocked in this environment with `ModuleNotFoundError: No module named 'numpy'`, so tests could not be executed here (tests exist and are expected to pass when `numpy` is available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a4039af38832fb2d6a1cb84d4e2cc)