### PR TITLE
Implement ML Clutter baseline models and Model UI

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -5,6 +5,7 @@ from .noise_patterns import PatternExtractionConfig, extract_energy_patterns, ex
 from .pattern_library import NoisePattern, PatternLibrary
 from .pattern_generator import PatternClutterConfig, generate_pattern_clutter
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
+from .model import ModelConfig, count_parameters, create_model, load_model_checkpoint, save_model_checkpoint
 
 __all__ = [
     "NormalizationConfig",
@@ -13,6 +14,11 @@ __all__ = [
     "PatternLibrary",
     "PatternClutterConfig",
     "generate_pattern_clutter",
+    "ModelConfig",
+    "count_parameters",
+    "create_model",
+    "load_model_checkpoint",
+    "save_model_checkpoint",
     "NormalizationResult",
     "Normalizer",
     "build_preprocessing_report",

--- a/ml_air_clutter/model.py
+++ b/ml_air_clutter/model.py
@@ -1,0 +1,196 @@
+"""Baseline PyTorch models for paired ML air-clutter cleaning.
+
+The MVP models operate in supervised direct-clean mode: input patches contain a
+noisy radarogram and the network predicts the clean radarogram. Residual/clutter
+prediction is intentionally left out of the mandatory baseline workflow.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+try:
+    import torch
+    from torch import nn
+except ImportError as exc:  # pragma: no cover - exercised only without PyTorch.
+    torch = None
+    nn = None
+    _TORCH_IMPORT_ERROR = exc
+else:
+    _TORCH_IMPORT_ERROR = None
+
+
+SUPPORTED_MODEL_TYPES = ("baseline_cnn", "small_unet")
+SUPPORTED_INPUT_CHANNELS = ("raw", "envelope", "grad_x", "grad_z")
+SUPPORTED_OUTPUT_MODES = ("direct_clean",)
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    """Serializable configuration for the baseline cleaning model."""
+
+    model_type: str = "baseline_cnn"
+    input_channels: Tuple[str, ...] = ("raw",)
+    output_mode: str = "direct_clean"
+    base_channels: int = 16
+    num_layers: int = 5
+    kernel_size: int = 3
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        data["input_channels"] = list(self.input_channels)
+        return data
+
+
+def _require_torch():
+    if torch is None or nn is None:
+        raise ImportError("PyTorch is required for ML Clutter baseline models.") from _TORCH_IMPORT_ERROR
+
+
+def validate_model_config(config: ModelConfig) -> None:
+    """Validate the constrained MVP model configuration."""
+
+    if config.model_type not in SUPPORTED_MODEL_TYPES:
+        raise ValueError(f"Unsupported model_type={config.model_type!r}; expected one of {SUPPORTED_MODEL_TYPES}.")
+    if config.output_mode not in SUPPORTED_OUTPUT_MODES:
+        raise ValueError("Only direct_clean output mode is supported in the MVP baseline.")
+    if not config.input_channels:
+        raise ValueError("At least one input channel is required.")
+    unknown = [channel for channel in config.input_channels if channel not in SUPPORTED_INPUT_CHANNELS]
+    if unknown:
+        raise ValueError(f"Unsupported input channels: {unknown}; expected subset of {SUPPORTED_INPUT_CHANNELS}.")
+    if config.base_channels <= 0:
+        raise ValueError("base_channels must be positive.")
+    if config.num_layers < 3:
+        raise ValueError("num_layers must be at least 3 for baseline_cnn.")
+    if config.kernel_size <= 0 or config.kernel_size % 2 == 0:
+        raise ValueError("kernel_size must be a positive odd number.")
+
+
+if nn is not None:
+    class BaselineCNN(nn.Module):
+        """Small fully-convolutional direct-clean baseline."""
+
+        def __init__(self, in_channels: int, base_channels: int = 16, num_layers: int = 5, kernel_size: int = 3):
+            super().__init__()
+            padding = kernel_size // 2
+            layers = [nn.Conv2d(in_channels, base_channels, kernel_size, padding=padding), nn.ReLU(inplace=True)]
+            for _ in range(num_layers - 2):
+                layers.extend([
+                    nn.Conv2d(base_channels, base_channels, kernel_size, padding=padding),
+                    nn.BatchNorm2d(base_channels),
+                    nn.ReLU(inplace=True),
+                ])
+            layers.append(nn.Conv2d(base_channels, 1, kernel_size, padding=padding))
+            self.net = nn.Sequential(*layers)
+
+        def forward(self, x):
+            return self.net(x)
+
+
+    class _DoubleConv(nn.Module):
+        def __init__(self, in_channels: int, out_channels: int):
+            super().__init__()
+            self.net = nn.Sequential(
+                nn.Conv2d(in_channels, out_channels, 3, padding=1),
+                nn.BatchNorm2d(out_channels),
+                nn.ReLU(inplace=True),
+                nn.Conv2d(out_channels, out_channels, 3, padding=1),
+                nn.BatchNorm2d(out_channels),
+                nn.ReLU(inplace=True),
+            )
+
+        def forward(self, x):
+            return self.net(x)
+
+
+    class SmallUNet(nn.Module):
+        """Compact U-Net that preserves patch shape [B, C, width, 512]."""
+
+        def __init__(self, in_channels: int, base_channels: int = 16):
+            super().__init__()
+            self.enc1 = _DoubleConv(in_channels, base_channels)
+            self.pool1 = nn.MaxPool2d(2)
+            self.enc2 = _DoubleConv(base_channels, base_channels * 2)
+            self.pool2 = nn.MaxPool2d(2)
+            self.bottleneck = _DoubleConv(base_channels * 2, base_channels * 4)
+            self.up2 = nn.ConvTranspose2d(base_channels * 4, base_channels * 2, 2, stride=2)
+            self.dec2 = _DoubleConv(base_channels * 4, base_channels * 2)
+            self.up1 = nn.ConvTranspose2d(base_channels * 2, base_channels, 2, stride=2)
+            self.dec1 = _DoubleConv(base_channels * 2, base_channels)
+            self.out = nn.Conv2d(base_channels, 1, 1)
+
+        def forward(self, x):
+            e1 = self.enc1(x)
+            e2 = self.enc2(self.pool1(e1))
+            b = self.bottleneck(self.pool2(e2))
+            d2 = self.up2(b)
+            d2 = torch.cat([d2, e2[..., :d2.shape[-2], :d2.shape[-1]]], dim=1)
+            d2 = self.dec2(d2)
+            d1 = self.up1(d2)
+            d1 = torch.cat([d1, e1[..., :d1.shape[-2], :d1.shape[-1]]], dim=1)
+            d1 = self.dec1(d1)
+            return self.out(d1)
+else:
+    BaselineCNN = None
+    SmallUNet = None
+
+
+def create_model(config: ModelConfig):
+    """Create an untrained baseline model for noisy -> clean prediction."""
+
+    _require_torch()
+    validate_model_config(config)
+    in_channels = len(config.input_channels)
+    if config.model_type == "baseline_cnn":
+        return BaselineCNN(in_channels, config.base_channels, config.num_layers, config.kernel_size)
+    if config.model_type == "small_unet":
+        return SmallUNet(in_channels, config.base_channels)
+    raise ValueError(f"Unsupported model_type={config.model_type!r}")
+
+
+def count_parameters(model) -> int:
+    """Return the number of trainable parameters."""
+
+    _require_torch()
+    return int(sum(parameter.numel() for parameter in model.parameters() if parameter.requires_grad))
+
+
+def checkpoint_payload(model, config: ModelConfig) -> Dict[str, object]:
+    _require_torch()
+    return {
+        "schema": "ml_air_clutter_model_checkpoint_v1",
+        "config": config.to_dict(),
+        "output_mode": "direct_clean",
+        "state_dict": model.state_dict(),
+        "num_parameters": count_parameters(model),
+        "notes": "MVP checkpoint stores an untrained or trained direct clean predictor; residual/clutter targets are diagnostic only.",
+    }
+
+
+def save_model_checkpoint(path, model, config: ModelConfig) -> Path:
+    """Save a model checkpoint plus JSON sidecar metadata."""
+
+    _require_torch()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = checkpoint_payload(model, config)
+    torch.save(payload, path)
+    meta_path = path.with_suffix(path.suffix + ".json")
+    with meta_path.open("w", encoding="utf-8") as fh:
+        json.dump({k: v for k, v in payload.items() if k != "state_dict"}, fh, indent=2, ensure_ascii=False)
+    return path
+
+
+def load_model_checkpoint(path, map_location="cpu"):
+    """Load a checkpoint and recreate its configured baseline model."""
+
+    _require_torch()
+    payload = torch.load(path, map_location=map_location)
+    config_dict = payload["config"].copy()
+    config_dict["input_channels"] = tuple(config_dict.get("input_channels", ("raw",)))
+    config = ModelConfig(**config_dict)
+    model = create_model(config)
+    model.load_state_dict(payload["state_dict"])
+    return model, config, payload

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -12,6 +12,7 @@ from ml_air_clutter.dataset import (
     save_dataset,
     validate_clean_noisy_pair,
 )
+from ml_air_clutter.model import ModelConfig, count_parameters, create_model, save_model_checkpoint
 from ml_air_clutter.noise_patterns import (
     PatternExtractionConfig,
     extract_energy_patterns,
@@ -60,6 +61,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.dataset_pairs = []
         self.dataset_samples = None
         self.dataset_summary = None
+        self.model = None
+        self.model_config = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -81,6 +84,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_clear_pattern_library.clicked.connect(self.clear_pattern_library)
         self.ui.pushButton_save_pattern_library.clicked.connect(self.save_pattern_library)
         self.ui.pushButton_load_pattern_library.clicked.connect(self.load_pattern_library)
+        self.ui.pushButton_create_model.clicked.connect(self.create_baseline_model)
+        self.ui.pushButton_save_untrained_checkpoint.clicked.connect(self.save_untrained_checkpoint)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self.ui.listWidget_noisy_profiles.currentItemChanged.connect(lambda *_: self._on_noisy_source_changed())
         for spin_box in (
@@ -261,6 +266,74 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             seed=int(self.ui.spinBox_gen_seed.value()),
             min_num_traces=self.MIN_NUM_TRACES,
         )
+
+    def _current_model_config(self):
+        channels = []
+        if self.ui.checkBox_model_raw.isChecked():
+            channels.append("raw")
+        if self.ui.checkBox_model_envelope.isChecked():
+            channels.append("envelope")
+        if self.ui.checkBox_model_grad_x.isChecked():
+            channels.append("grad_x")
+        if self.ui.checkBox_model_grad_z.isChecked():
+            channels.append("grad_z")
+        return ModelConfig(
+            model_type=self.ui.comboBox_model_type.currentData() or "baseline_cnn",
+            input_channels=tuple(channels),
+            output_mode="direct_clean",
+            base_channels=int(self.ui.spinBox_model_base_channels.value()),
+            num_layers=int(self.ui.spinBox_model_num_layers.value()),
+        )
+
+    def create_baseline_model(self):
+        config = self._current_model_config()
+        try:
+            model = create_model(config)
+            parameters = count_parameters(model)
+        except (ImportError, ValueError) as exc:
+            self._show_model_summary(f"Failed to create model: {exc}")
+            self._log(f"ML Clutter model creation failed: {exc}", "red")
+            return
+        self.model = model
+        self.model_config = config
+        self.experiment_config["model"] = {"config": config.to_dict(), "num_parameters": parameters}
+        self._show_model_summary(self._format_model_summary(config, parameters))
+        self._log(f"ML Clutter model created: {config.model_type}, channels={len(config.input_channels)}, params={parameters}")
+
+    def save_untrained_checkpoint(self):
+        if self.model is None or self.model_config is None:
+            self.create_baseline_model()
+            if self.model is None or self.model_config is None:
+                return
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save untrained ML clutter checkpoint", "ml_clutter_untrained.pt", "PyTorch checkpoint (*.pt *.pth)")
+        if not path:
+            return
+        try:
+            saved_path = save_model_checkpoint(path, self.model, self.model_config)
+        except (ImportError, OSError, ValueError) as exc:
+            self._show_model_summary(f"Failed to save checkpoint: {exc}")
+            self._log(f"ML Clutter checkpoint save failed: {exc}", "red")
+            return
+        self._show_model_summary(self._format_model_summary(self.model_config, count_parameters(self.model)) + f"\n\nCheckpoint saved: {saved_path}")
+        self._log(f"ML Clutter untrained checkpoint saved: {saved_path}")
+
+    @staticmethod
+    def _format_model_summary(config, parameters):
+        return "\n".join([
+            "Baseline model summary",
+            f"Model type: {config.model_type}",
+            "Task: supervised direct-clean (input noisy -> target clean -> output clean_pred)",
+            f"Input channels: {', '.join(config.input_channels)}",
+            "Input patch shape: [channels, width, 512]",
+            "Output patch shape: [1, width, 512]",
+            f"Base channels: {config.base_channels}",
+            f"CNN layers: {config.num_layers}",
+            f"Trainable parameters: {parameters}",
+            "MVP note: residual/clutter targets are not required; residual remains a diagnostic artifact.",
+        ])
+
+    def _show_model_summary(self, text):
+        self.ui.textEdit_model_summary.setPlainText(text)
 
     def _selected_dataset_pair(self):
         row = self.ui.tableWidget_dataset_pairs.currentRow()

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -19,10 +19,7 @@ class Ui_MLClutterExperiment(object):
         self.tab_noise_patterns = self._add_noise_patterns_tab()
         self.tab_generator = self._add_generator_tab()
         self.tab_dataset = self._add_dataset_tab()
-        self.tab_model = self._add_placeholder_tab(
-            "tab_model",
-            "Choose baseline CNN, DnCNN, or U-Net model settings.",
-        )
+        self.tab_model = self._add_model_tab()
         self.tab_training = self._add_placeholder_tab(
             "tab_training",
             "Run training, validation, checkpoints, and training metrics.",
@@ -345,6 +342,65 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.addTab(tab, "")
         return tab
 
+    def _add_model_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_model")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText(
+            "Baseline supervised direct-clean model: input noisy patch -> output clean patch. "
+            "Residual/clutter modes are diagnostic only for the MVP."
+        )
+        layout.addWidget(intro, 0, 0, 1, 4)
+        self.comboBox_model_type = QtWidgets.QComboBox(tab)
+        self.comboBox_model_type.setObjectName("comboBox_model_type")
+        self.comboBox_model_type.addItem("Baseline CNN", "baseline_cnn")
+        self.comboBox_model_type.addItem("Small U-Net", "small_unet")
+        self.spinBox_model_base_channels = QtWidgets.QSpinBox(tab)
+        self.spinBox_model_base_channels.setObjectName("spinBox_model_base_channels")
+        self.spinBox_model_base_channels.setRange(1, 512)
+        self.spinBox_model_base_channels.setValue(16)
+        self.spinBox_model_num_layers = QtWidgets.QSpinBox(tab)
+        self.spinBox_model_num_layers.setObjectName("spinBox_model_num_layers")
+        self.spinBox_model_num_layers.setRange(3, 64)
+        self.spinBox_model_num_layers.setValue(5)
+        for row, (label, widget) in enumerate([
+            ("model", self.comboBox_model_type),
+            ("base channels", self.spinBox_model_base_channels),
+            ("CNN layers", self.spinBox_model_num_layers),
+        ], start=1):
+            layout.addWidget(QtWidgets.QLabel(label, tab), row, 0)
+            layout.addWidget(widget, row, 1)
+        self.checkBox_model_raw = QtWidgets.QCheckBox(tab)
+        self.checkBox_model_raw.setObjectName("checkBox_model_raw")
+        self.checkBox_model_raw.setChecked(True)
+        self.checkBox_model_envelope = QtWidgets.QCheckBox(tab)
+        self.checkBox_model_envelope.setObjectName("checkBox_model_envelope")
+        self.checkBox_model_grad_x = QtWidgets.QCheckBox(tab)
+        self.checkBox_model_grad_x.setObjectName("checkBox_model_grad_x")
+        self.checkBox_model_grad_z = QtWidgets.QCheckBox(tab)
+        self.checkBox_model_grad_z.setObjectName("checkBox_model_grad_z")
+        channel_box = QtWidgets.QGroupBox(tab)
+        channel_box.setObjectName("groupBox_model_channels")
+        channel_layout = QtWidgets.QVBoxLayout(channel_box)
+        for checkbox in (self.checkBox_model_raw, self.checkBox_model_envelope, self.checkBox_model_grad_x, self.checkBox_model_grad_z):
+            channel_layout.addWidget(checkbox)
+        layout.addWidget(channel_box, 1, 2, 3, 2)
+        self.pushButton_create_model = QtWidgets.QPushButton(tab)
+        self.pushButton_create_model.setObjectName("pushButton_create_model")
+        layout.addWidget(self.pushButton_create_model, 4, 0)
+        self.pushButton_save_untrained_checkpoint = QtWidgets.QPushButton(tab)
+        self.pushButton_save_untrained_checkpoint.setObjectName("pushButton_save_untrained_checkpoint")
+        layout.addWidget(self.pushButton_save_untrained_checkpoint, 4, 1)
+        self.textEdit_model_summary = QtWidgets.QTextEdit(tab)
+        self.textEdit_model_summary.setReadOnly(True)
+        self.textEdit_model_summary.setObjectName("textEdit_model_summary")
+        layout.addWidget(self.textEdit_model_summary, 5, 0, 1, 4)
+        layout.setRowStretch(5, 1)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
     def _add_placeholder_tab(self, object_name, message):
         tab = QtWidgets.QWidget()
         tab.setObjectName(object_name)
@@ -401,6 +457,13 @@ class Ui_MLClutterExperiment(object):
         self.pushButton_preview_random_patch.setText(_translate("MLClutterExperiment", "Preview Random Patch"))
         self.pushButton_save_dataset.setText(_translate("MLClutterExperiment", "Save Dataset"))
         self.pushButton_load_dataset.setText(_translate("MLClutterExperiment", "Load Dataset"))
+        self.groupBox_model_channels.setTitle(_translate("MLClutterExperiment", "Input channels"))
+        self.checkBox_model_raw.setText(_translate("MLClutterExperiment", "raw"))
+        self.checkBox_model_envelope.setText(_translate("MLClutterExperiment", "envelope (optional)"))
+        self.checkBox_model_grad_x.setText(_translate("MLClutterExperiment", "grad_x (optional)"))
+        self.checkBox_model_grad_z.setText(_translate("MLClutterExperiment", "grad_z (optional)"))
+        self.pushButton_create_model.setText(_translate("MLClutterExperiment", "Create Model"))
+        self.pushButton_save_untrained_checkpoint.setText(_translate("MLClutterExperiment", "Save Untrained Checkpoint"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))

--- a/tests/test_ml_air_clutter_model.py
+++ b/tests/test_ml_air_clutter_model.py
@@ -1,0 +1,37 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_MODEL_PATH = Path(__file__).resolve().parents[1] / "ml_air_clutter" / "model.py"
+_SPEC = importlib.util.spec_from_file_location("ml_air_clutter_model_under_test", _MODEL_PATH)
+model_module = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(model_module)
+
+ModelConfig = model_module.ModelConfig
+validate_model_config = model_module.validate_model_config
+
+
+def test_model_config_serializes_tuple_channels_as_json_list():
+    config = ModelConfig(model_type="small_unet", input_channels=("raw", "grad_x"), base_channels=8)
+
+    data = config.to_dict()
+
+    assert data["model_type"] == "small_unet"
+    assert data["input_channels"] == ["raw", "grad_x"]
+    json.dumps(data)
+
+
+def test_model_config_rejects_residual_mode_for_mvp():
+    config = ModelConfig(output_mode="residual")
+
+    with pytest.raises(ValueError, match="direct_clean"):
+        validate_model_config(config)
+
+
+def test_model_config_rejects_unknown_optional_channel():
+    config = ModelConfig(input_channels=("raw", "phase"))
+
+    with pytest.raises(ValueError, match="Unsupported input channels"):
+        validate_model_config(config)


### PR DESCRIPTION
### Motivation
- Implement Stage 8 (baseline model) of the ML Clutter experiment: provide a minimal supervised baseline to recover `clean` from `noisy` profiles in direct-clean mode.
- Expose model creation, parameter inspection and checkpoint save/load to the ML Clutter experiment UI so users can create and persist untrained baseline checkpoints.

### Description
- Added `ml_air_clutter/model.py` implementing `ModelConfig`, `validate_model_config`, `create_model`, `count_parameters`, `save_model_checkpoint`, and `load_model_checkpoint`, plus PyTorch `BaselineCNN` and `SmallUNet` builders (guarded when PyTorch is unavailable).
- Exported model helpers from `ml_air_clutter.__init__` so package-level imports are available (`ModelConfig`, `count_parameters`, `create_model`, `save_model_checkpoint`, `load_model_checkpoint`).
- Replaced the placeholder Model tab in the UI (`qt/ml_clutter_experiment_form.py`) with a `Model` tab containing model-type, base-channels, layer, and input-channel controls plus `Create Model` and `Save Untrained Checkpoint` buttons.
- Wired the experiment controller (`ml_clutter_experiment.py`) to collect model settings, create a baseline model, show a model summary (including parameter count), and save an untrained checkpoint; preserved MVP constraint that only `direct_clean` output mode is supported.
- Added focused unit tests `tests/test_ml_air_clutter_model.py` validating `ModelConfig.to_dict()` serialization and configuration validation rules for MVP constraints and unknown channels.

### Testing
- Ran static/byte-compile checks with `python -m py_compile ml_air_clutter/model.py ml_air_clutter/__init__.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py`, which succeeded.
- Ran the focused model tests with `PYTHONPATH=. pytest -q tests/test_ml_air_clutter_model.py`, which passed (`3 passed`).
- Attempted to run the broader dataset tests (`pytest -q tests/test_ml_air_clutter_model.py tests/test_ml_air_clutter_dataset.py`) but collection failed in this environment due to missing `numpy` in the active interpreter (environment limitation, not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a495b5f5c832f82c2793ea57af20e)