### PR TITLE
Implement ML Clutter training stage (training module + UI integration)

### DIFF
--- a/ml_air_clutter/train.py
+++ b/ml_air_clutter/train.py
@@ -1,0 +1,250 @@
+"""Training utilities for supervised ML air-clutter cleaning.
+
+The MVP training path learns direct restoration from paired patches:
+``noisy -> clean``.  Clutter residuals and masks remain diagnostic artifacts and
+are not required by the loss.
+"""
+
+import csv
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+
+from .model import ModelConfig, checkpoint_payload, count_parameters
+
+try:
+    import torch
+    from torch import nn
+    from torch.utils.data import DataLoader, Dataset
+except ImportError as exc:  # pragma: no cover - exercised only without PyTorch.
+    torch = None
+    nn = None
+    DataLoader = None
+    Dataset = object
+    _TORCH_IMPORT_ERROR = exc
+else:
+    _TORCH_IMPORT_ERROR = None
+
+
+@dataclass(frozen=True)
+class TrainingConfig:
+    """Serializable configuration for the paired clean/noisy train loop."""
+
+    epochs: int = 10
+    batch_size: int = 4
+    learning_rate: float = 1e-3
+    weight_decay: float = 0.0
+    grad_loss_weight: float = 0.1
+    early_stopping_patience: int = 5
+    min_delta: float = 1e-5
+    device: str = "auto"
+    seed: int = 42
+    output_dir: str = "experiments/ml_clutter/training_run"
+
+    def to_dict(self):
+        return asdict(self)
+
+
+class TrainingCancelled(RuntimeError):
+    """Raised by callbacks to stop training gracefully."""
+
+
+def _require_torch():
+    if torch is None or nn is None or DataLoader is None:
+        raise ImportError("PyTorch is required for ML Clutter training.") from _TORCH_IMPORT_ERROR
+
+
+def make_input_channels(noisy: np.ndarray, channels: Iterable[str]) -> np.ndarray:
+    """Build a [C, width, 512] input tensor from a noisy patch."""
+
+    noisy = np.asarray(noisy, dtype=np.float32)
+    built: List[np.ndarray] = []
+    for channel in channels:
+        if channel == "raw":
+            built.append(noisy)
+        elif channel == "envelope":
+            built.append(np.abs(noisy))
+        elif channel == "grad_x":
+            built.append(np.gradient(noisy, axis=0).astype(np.float32))
+        elif channel == "grad_z":
+            built.append(np.gradient(noisy, axis=1).astype(np.float32))
+        else:
+            raise ValueError(f"Unsupported input channel: {channel}")
+    if not built:
+        raise ValueError("At least one input channel is required for training.")
+    return np.stack(built, axis=0).astype(np.float32)
+
+
+class PairedPatchTorchDataset(Dataset):
+    """Torch dataset wrapper for in-memory paired patch samples."""
+
+    def __init__(self, samples: List[Dict[str, object]], input_channels: Iterable[str]):
+        _require_torch()
+        self.samples = list(samples)
+        self.input_channels = tuple(input_channels)
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, index):
+        sample = self.samples[index]
+        x = make_input_channels(sample["noisy"], self.input_channels) / 256.0
+        y = np.asarray(sample["clean"], dtype=np.float32)[None, ...] / 256.0
+        return torch.from_numpy(x), torch.from_numpy(y)
+
+
+def gradient_loss(prediction, target):
+    """L1 loss between x/z finite differences of prediction and target."""
+
+    loss = torch.mean(torch.abs(prediction[:, :, 1:, :] - prediction[:, :, :-1, :] - (target[:, :, 1:, :] - target[:, :, :-1, :])))
+    loss = loss + torch.mean(torch.abs(prediction[:, :, :, 1:] - prediction[:, :, :, :-1] - (target[:, :, :, 1:] - target[:, :, :, :-1])))
+    return loss
+
+
+def _resolve_device(requested: str):
+    if requested == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(requested)
+
+
+def _run_epoch(model, loader, optimizer, config: TrainingConfig, device, train: bool):
+    criterion = nn.L1Loss()
+    model.train(train)
+    total_loss = total_clean = total_grad = 0.0
+    total_items = 0
+    for inputs, targets in loader:
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+        if train:
+            optimizer.zero_grad(set_to_none=True)
+        with torch.set_grad_enabled(train):
+            predictions = model(inputs)
+            clean_loss = criterion(predictions, targets)
+            grad = gradient_loss(predictions, targets)
+            loss = clean_loss + float(config.grad_loss_weight) * grad
+            if train:
+                loss.backward()
+                optimizer.step()
+        batch_size = inputs.shape[0]
+        total_items += batch_size
+        total_loss += float(loss.detach().cpu()) * batch_size
+        total_clean += float(clean_loss.detach().cpu()) * batch_size
+        total_grad += float(grad.detach().cpu()) * batch_size
+    denom = max(total_items, 1)
+    return {"loss": total_loss / denom, "clean_l1": total_clean / denom, "grad_l1": total_grad / denom}
+
+
+def _validation_preview(model, sample, channels, device):
+    model.eval()
+    with torch.no_grad():
+        x = torch.from_numpy(make_input_channels(sample["noisy"], channels)[None, ...] / 256.0).to(device)
+        pred = model(x).detach().cpu().numpy()[0, 0] * 256.0
+    clean = np.asarray(sample["clean"], dtype=float)
+    noisy = np.asarray(sample["noisy"], dtype=float)
+    return {"clean": clean, "noisy": noisy, "clean_pred": pred, "error": pred - clean}
+
+
+def train_model(
+    model,
+    model_config: ModelConfig,
+    samples: Dict[str, List[Dict[str, object]]],
+    config: TrainingConfig,
+    progress_callback: Optional[Callable[[str, object], None]] = None,
+) -> Dict[str, object]:
+    """Train a direct-clean model and persist best/last checkpoints."""
+
+    _require_torch()
+    train_samples = list(samples.get("train", []))
+    val_samples = list(samples.get("validation", []))
+    if not train_samples:
+        raise ValueError("Training split is empty; build a dataset with train patches first.")
+    if not val_samples:
+        val_samples = train_samples
+    torch.manual_seed(int(config.seed))
+    np.random.seed(int(config.seed))
+    device = _resolve_device(config.device)
+    model.to(device)
+    train_loader = DataLoader(PairedPatchTorchDataset(train_samples, model_config.input_channels), batch_size=config.batch_size, shuffle=True)
+    val_loader = DataLoader(PairedPatchTorchDataset(val_samples, model_config.input_channels), batch_size=config.batch_size, shuffle=False)
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate, weight_decay=config.weight_decay)
+
+    output_dir = Path(config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "train_log.csv"
+    best_path = output_dir / "model_best.pt"
+    last_path = output_dir / "model_last.pt"
+    best_loss = float("inf")
+    best_epoch = 0
+    bad_epochs = 0
+    history = []
+    start_time = time.time()
+
+    with log_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["epoch", "train_loss", "train_clean_l1", "train_grad_l1", "val_loss", "val_clean_l1", "val_grad_l1"])
+        writer.writeheader()
+        for epoch in range(1, int(config.epochs) + 1):
+            train_metrics = _run_epoch(model, train_loader, optimizer, config, device, train=True)
+            val_metrics = _run_epoch(model, val_loader, optimizer, config, device, train=False)
+            row = {
+                "epoch": epoch,
+                "train_loss": train_metrics["loss"],
+                "train_clean_l1": train_metrics["clean_l1"],
+                "train_grad_l1": train_metrics["grad_l1"],
+                "val_loss": val_metrics["loss"],
+                "val_clean_l1": val_metrics["clean_l1"],
+                "val_grad_l1": val_metrics["grad_l1"],
+            }
+            writer.writerow(row)
+            fh.flush()
+            history.append(row)
+            improved = val_metrics["loss"] < best_loss - float(config.min_delta)
+            if improved:
+                best_loss = val_metrics["loss"]
+                best_epoch = epoch
+                bad_epochs = 0
+                _save_training_checkpoint(best_path, model, model_config, config, row, best_epoch, best_loss)
+            else:
+                bad_epochs += 1
+            _save_training_checkpoint(last_path, model, model_config, config, row, best_epoch, best_loss)
+            preview = _validation_preview(model, val_samples[0], model_config.input_channels, device)
+            if progress_callback:
+                progress_callback("epoch_finished", row)
+                progress_callback("preview_ready", preview)
+            if bad_epochs >= int(config.early_stopping_patience):
+                if progress_callback:
+                    progress_callback("log_message", f"Early stopping at epoch {epoch}; best epoch={best_epoch}.")
+                break
+    summary = {
+        "training_schema": "ml_air_clutter_training_v1",
+        "config": config.to_dict(),
+        "model_config": model_config.to_dict(),
+        "num_parameters": count_parameters(model),
+        "best_epoch": best_epoch,
+        "best_validation_loss": best_loss,
+        "epochs_completed": len(history),
+        "duration_seconds": time.time() - start_time,
+        "train_log": str(log_path),
+        "model_best": str(best_path),
+        "model_last": str(last_path),
+        "history": history,
+    }
+    with (output_dir / "training_summary.json").open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2, ensure_ascii=False)
+    if progress_callback:
+        progress_callback("training_finished", summary)
+    return summary
+
+
+def _save_training_checkpoint(path, model, model_config, training_config, metrics, best_epoch, best_loss):
+    payload = checkpoint_payload(model, model_config)
+    payload.update({
+        "training_config": training_config.to_dict(),
+        "metrics": metrics,
+        "best_epoch": best_epoch,
+        "best_validation_loss": best_loss,
+    })
+    torch.save(payload, path)

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 import numpy as np
-from PyQt5 import QtWidgets
+from PyQt5 import QtCore, QtWidgets
 
 from ml_air_clutter.config import NormalizationConfig, SyntheticClutterConfig
 from ml_air_clutter.dataset import (
@@ -23,8 +23,47 @@ from ml_air_clutter.pattern_generator import PatternClutterConfig, generate_patt
 from ml_air_clutter.pattern_library import NoisePattern, PatternLibrary
 from ml_air_clutter.preprocessing import Normalizer, build_preprocessing_report
 from ml_air_clutter.synthetic_clutter import generate_synthetic_clutter
+from ml_air_clutter.train import TrainingConfig, train_model
 from models_db.model import Profile, CurrentProfile, session
 from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
+
+
+class MLClutterTrainingWorker(QtCore.QObject):
+    epoch_finished = QtCore.pyqtSignal(dict)
+    preview_ready = QtCore.pyqtSignal(dict)
+    log_message = QtCore.pyqtSignal(str)
+    training_finished = QtCore.pyqtSignal(dict)
+    training_error = QtCore.pyqtSignal(str)
+
+    def __init__(self, model, model_config, samples, training_config):
+        super().__init__()
+        self.model = model
+        self.model_config = model_config
+        self.samples = samples
+        self.training_config = training_config
+
+    @QtCore.pyqtSlot()
+    def run(self):
+        try:
+            train_model(
+                self.model,
+                self.model_config,
+                self.samples,
+                self.training_config,
+                progress_callback=self._handle_progress,
+            )
+        except Exception as exc:  # pragma: no cover - UI signal bridge.
+            self.training_error.emit(str(exc))
+
+    def _handle_progress(self, event, payload):
+        if event == "epoch_finished":
+            self.epoch_finished.emit(payload)
+        elif event == "preview_ready":
+            self.preview_ready.emit(payload)
+        elif event == "log_message":
+            self.log_message.emit(str(payload))
+        elif event == "training_finished":
+            self.training_finished.emit(payload)
 
 
 class MLClutterExperimentWindow(QtWidgets.QDialog):
@@ -64,6 +103,9 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.dataset_summary = None
         self.model = None
         self.model_config = None
+        self.training_thread = None
+        self.training_worker = None
+        self.training_summary = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -88,6 +130,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_load_pattern_library.clicked.connect(self.load_pattern_library)
         self.ui.pushButton_create_model.clicked.connect(self.create_baseline_model)
         self.ui.pushButton_save_untrained_checkpoint.clicked.connect(self.save_untrained_checkpoint)
+        self.ui.pushButton_start_training.clicked.connect(self.start_training)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self.ui.listWidget_noisy_profiles.currentItemChanged.connect(lambda *_: self._on_noisy_source_changed())
         for spin_box in (
@@ -346,6 +389,77 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.experiment_config["model"] = {"config": config.to_dict(), "num_parameters": parameters}
         self._show_model_summary(self._format_model_summary(config, parameters))
         self._log(f"ML Clutter model created: {config.model_type}, channels={len(config.input_channels)}, params={parameters}")
+
+    def start_training(self):
+        if self.dataset_samples is None:
+            self._show_training_stats("Build the paired dataset before starting training.")
+            self._log("ML Clutter training: dataset is not built", "red")
+            return
+        if self.model is None or self.model_config is None:
+            self.create_baseline_model()
+            if self.model is None or self.model_config is None:
+                return
+        if self.training_thread is not None:
+            self._show_training_stats("Training is already running.")
+            return
+        config = self._current_training_config()
+        self.ui.progressBar_training.setRange(0, int(config.epochs))
+        self.ui.progressBar_training.setValue(0)
+        self.ui.pushButton_start_training.setEnabled(False)
+        self._show_training_stats("Training started in a background QThread. UI remains responsive.")
+        self.training_thread = QtCore.QThread(self)
+        self.training_worker = MLClutterTrainingWorker(self.model, self.model_config, self.dataset_samples, config)
+        self.training_worker.moveToThread(self.training_thread)
+        self.training_thread.started.connect(self.training_worker.run)
+        self.training_worker.epoch_finished.connect(self._on_training_epoch_finished)
+        self.training_worker.preview_ready.connect(self._on_training_preview_ready)
+        self.training_worker.log_message.connect(lambda text: self._show_training_stats(text, append=True))
+        self.training_worker.training_finished.connect(self._on_training_finished)
+        self.training_worker.training_error.connect(self._on_training_error)
+        self.training_worker.training_finished.connect(self.training_thread.quit)
+        self.training_worker.training_error.connect(self.training_thread.quit)
+        self.training_thread.finished.connect(self.training_worker.deleteLater)
+        self.training_thread.finished.connect(self._cleanup_training_thread)
+        self.training_thread.start()
+
+    def _current_training_config(self):
+        return TrainingConfig(
+            epochs=int(self.ui.spinBox_train_epochs.value()),
+            batch_size=int(self.ui.spinBox_train_batch_size.value()),
+            learning_rate=float(self.ui.doubleSpinBox_train_lr.value()),
+            grad_loss_weight=float(self.ui.doubleSpinBox_train_grad_lambda.value()),
+            early_stopping_patience=int(self.ui.spinBox_train_patience.value()),
+            seed=int(self.ui.spinBox_gen_seed.value()),
+        )
+
+    def _on_training_epoch_finished(self, metrics):
+        epoch = int(metrics.get("epoch", 0))
+        self.ui.progressBar_training.setValue(epoch)
+        self._show_training_stats(
+            f"Epoch {epoch}: train_loss={metrics.get('train_loss'):.6g}, val_loss={metrics.get('val_loss'):.6g}",
+            append=True,
+        )
+
+    def _on_training_preview_ready(self, arrays):
+        self._display_profile(arrays["error"], "ML Clutter validation preview error clean_pred-clean")
+        self._display_profile(arrays["clean_pred"], "ML Clutter validation preview clean_pred")
+        self._display_profile(arrays["noisy"], "ML Clutter validation preview noisy")
+        self._display_profile(arrays["clean"], "ML Clutter validation preview clean")
+
+    def _on_training_finished(self, summary):
+        self.training_summary = summary
+        self.experiment_config["training"] = summary
+        self._show_training_stats("Training finished.\n" + json.dumps(summary, indent=2, ensure_ascii=False))
+        self._log(f"ML Clutter training finished: best_epoch={summary['best_epoch']}, best_val_loss={summary['best_validation_loss']:.6g}")
+
+    def _on_training_error(self, message):
+        self._show_training_stats(f"Training failed: {message}")
+        self._log(f"ML Clutter training failed: {message}", "red")
+
+    def _cleanup_training_thread(self):
+        self.training_thread = None
+        self.training_worker = None
+        self.ui.pushButton_start_training.setEnabled(True)
 
     def save_untrained_checkpoint(self):
         if self.model is None or self.model_config is None:
@@ -954,6 +1068,13 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     def _show_dataset_stats(self, text):
         self.ui.textEdit_dataset_summary.setPlainText(text)
+        self.ui.textEdit_results_log.append(text)
+
+    def _show_training_stats(self, text, append=False):
+        if append:
+            self.ui.textEdit_training_log.append(text)
+        else:
+            self.ui.textEdit_training_log.setPlainText(text)
         self.ui.textEdit_results_log.append(text)
 
     def _log(self, text, color="green"):

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -20,10 +20,7 @@ class Ui_MLClutterExperiment(object):
         self.tab_generator = self._add_generator_tab()
         self.tab_dataset = self._add_dataset_tab()
         self.tab_model = self._add_model_tab()
-        self.tab_training = self._add_placeholder_tab(
-            "tab_training",
-            "Run training, validation, checkpoints, and training metrics.",
-        )
+        self.tab_training = self._add_training_tab()
         self.tab_inference = self._add_placeholder_tab(
             "tab_inference",
             "Apply trained clutter-removal models to synthetic or real profiles.",
@@ -404,6 +401,59 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.addTab(tab, "")
         return tab
 
+    def _add_training_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_training")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText("Train the supervised direct-clean model off the UI thread: input = noisy patch, target = clean patch.")
+        layout.addWidget(intro, 0, 0, 1, 4)
+        self.spinBox_train_epochs = QtWidgets.QSpinBox(tab)
+        self.spinBox_train_epochs.setObjectName("spinBox_train_epochs")
+        self.spinBox_train_epochs.setRange(1, 100000)
+        self.spinBox_train_epochs.setValue(10)
+        self.spinBox_train_batch_size = QtWidgets.QSpinBox(tab)
+        self.spinBox_train_batch_size.setObjectName("spinBox_train_batch_size")
+        self.spinBox_train_batch_size.setRange(1, 1024)
+        self.spinBox_train_batch_size.setValue(4)
+        self.doubleSpinBox_train_lr = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_train_lr.setObjectName("doubleSpinBox_train_lr")
+        self.doubleSpinBox_train_lr.setDecimals(6)
+        self.doubleSpinBox_train_lr.setRange(0.000001, 1.0)
+        self.doubleSpinBox_train_lr.setValue(0.001)
+        self.doubleSpinBox_train_grad_lambda = QtWidgets.QDoubleSpinBox(tab)
+        self.doubleSpinBox_train_grad_lambda.setObjectName("doubleSpinBox_train_grad_lambda")
+        self.doubleSpinBox_train_grad_lambda.setRange(0.0, 100.0)
+        self.doubleSpinBox_train_grad_lambda.setValue(0.1)
+        self.spinBox_train_patience = QtWidgets.QSpinBox(tab)
+        self.spinBox_train_patience.setObjectName("spinBox_train_patience")
+        self.spinBox_train_patience.setRange(1, 100000)
+        self.spinBox_train_patience.setValue(5)
+        controls = [
+            ("epochs", self.spinBox_train_epochs),
+            ("batch size", self.spinBox_train_batch_size),
+            ("learning rate", self.doubleSpinBox_train_lr),
+            ("gradient λ", self.doubleSpinBox_train_grad_lambda),
+            ("early stop patience", self.spinBox_train_patience),
+        ]
+        for row, (label, widget) in enumerate(controls, start=1):
+            layout.addWidget(QtWidgets.QLabel(label, tab), row, 0)
+            layout.addWidget(widget, row, 1)
+        self.pushButton_start_training = QtWidgets.QPushButton(tab)
+        self.pushButton_start_training.setObjectName("pushButton_start_training")
+        layout.addWidget(self.pushButton_start_training, 1, 2)
+        self.progressBar_training = QtWidgets.QProgressBar(tab)
+        self.progressBar_training.setObjectName("progressBar_training")
+        layout.addWidget(self.progressBar_training, 2, 2, 1, 2)
+        self.textEdit_training_log = QtWidgets.QTextEdit(tab)
+        self.textEdit_training_log.setReadOnly(True)
+        self.textEdit_training_log.setObjectName("textEdit_training_log")
+        layout.addWidget(self.textEdit_training_log, 6, 0, 1, 4)
+        layout.setRowStretch(6, 1)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
     def _add_placeholder_tab(self, object_name, message):
         tab = QtWidgets.QWidget()
         tab.setObjectName(object_name)
@@ -468,6 +518,7 @@ class Ui_MLClutterExperiment(object):
         self.checkBox_model_grad_z.setText(_translate("MLClutterExperiment", "grad_z (optional)"))
         self.pushButton_create_model.setText(_translate("MLClutterExperiment", "Create Model"))
         self.pushButton_save_untrained_checkpoint.setText(_translate("MLClutterExperiment", "Save Untrained Checkpoint"))
+        self.pushButton_start_training.setText(_translate("MLClutterExperiment", "Start Training"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))


### PR DESCRIPTION
### Motivation
- Реализовать этап обучения (Этап 9) экспериментального блока ML Clutter: обеспечить обучение модели по парной схеме `noisy -> clean` с минимальным MVP-набором loss/валидции/ чекпоинтов и не блокировать UI во время тренировки.
- Добавить средства для сбора метрик и preview'ов в процессе обучения, а также сохранить артефакты обучения для воспроизводимости эксперимента.

### Description
- Добавлен новый модуль `ml_air_clutter/train.py` с `TrainingConfig`, реализацией `make_input_channels`, `PairedPatchTorchDataset`, `gradient_loss`, и функцией `train_model` реализующей train/validation loop, CSV лог, `model_best.pt`, `model_last.pt` и `training_summary.json` сохранение.
- В `ml_clutter_experiment.py` добавлен `MLClutterTrainingWorker` (Qt `QObject`) и интеграция запуска обучения в `QThread`, включая сигналы `epoch_finished`, `preview_ready`, `log_message`, `training_finished` и `training_error`, а также обработчики `_on_training_epoch_finished`, `_on_training_preview_ready`, `_on_training_finished` и `_on_training_error` и метод `start_training`.
- UI: в `qt/ml_clutter_experiment_form.py` заменён placeholder-вкладки `Training` на полноценную вкладку с параметрами `epochs`, `batch size`, `learning rate`, `gradient λ`, `early stop patience`, кнопкой `Start Training`, прогрессбаром и полем логов; связка кнопки с `start_training` добавлена в `ml_clutter_experiment.py`.
- Остальные изменения: импорт `TrainingConfig, train_model` в эксперименте, добавление состояния `training_thread/worker/summary`, и вспомогательная функция `_show_training_stats` для отображения логов в UI.

### Testing
- Успешно скомпилированы изменённые модули с `python3 -m compileall ml_air_clutter ml_clutter_experiment.py qt/ml_clutter_experiment_form.py` (компиляция прошла без ошибок).
- Выполнялся локальный smoke-test вызова `train_model` в скрипте, но запуск не прошёл из-за отсутствующей системной зависимости `numpy` в окружении, поэтому полноценно прогон тренировки не был выполнен.
- Код закоммичен под сообщением `Implement ML clutter training stage` и готов для интеграционного тестирования в окружении с установленными `numpy` и `PyTorch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7371e330832f9962e90f232e1038)