### PR TITLE
Add paired-cleaning quality metrics, reporting, and a Matplotlib UI dashboard

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -5,6 +5,7 @@ from .noise_patterns import PatternExtractionConfig, extract_energy_patterns, ex
 from .pattern_library import NoisePattern, PatternLibrary
 from .pattern_generator import PatternClutterConfig, generate_pattern_clutter
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
+from .metrics import paired_cleaning_metrics, summarize_metric_rows
 from .model import ModelConfig, count_parameters, create_model, load_model_checkpoint, save_model_checkpoint
 
 __all__ = [
@@ -14,6 +15,8 @@ __all__ = [
     "PatternLibrary",
     "PatternClutterConfig",
     "generate_pattern_clutter",
+    "paired_cleaning_metrics",
+    "summarize_metric_rows",
     "ModelConfig",
     "count_parameters",
     "create_model",

--- a/ml_air_clutter/metrics.py
+++ b/ml_air_clutter/metrics.py
@@ -1,0 +1,166 @@
+"""Quality metrics for paired ML air-clutter cleaning experiments."""
+
+import json
+import math
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+
+
+def mae(prediction, target) -> float:
+    prediction, target = _paired_arrays(prediction, target)
+    return float(np.mean(np.abs(prediction - target)))
+
+
+def rmse(prediction, target) -> float:
+    prediction, target = _paired_arrays(prediction, target)
+    return float(np.sqrt(np.mean((prediction - target) ** 2)))
+
+
+def snr_db(reference, error) -> float:
+    reference = np.asarray(reference, dtype=float)
+    error = np.asarray(error, dtype=float)
+    signal_power = float(np.mean(reference ** 2))
+    noise_power = float(np.mean(error ** 2))
+    if noise_power <= 0:
+        return float("inf")
+    if signal_power <= 0:
+        return float("-inf")
+    return float(10.0 * math.log10(signal_power / noise_power))
+
+
+def psnr_db(prediction, target, data_range: Optional[float] = 256.0) -> float:
+    value = rmse(prediction, target)
+    if value <= 0:
+        return float("inf")
+    if data_range is None:
+        target = np.asarray(target, dtype=float)
+        data_range = float(np.max(target) - np.min(target)) if target.size else 0.0
+    if data_range <= 0:
+        return float("nan")
+    return float(20.0 * math.log10(float(data_range) / value))
+
+
+def trace_correlation(prediction, target) -> float:
+    prediction, target = _paired_arrays(prediction, target)
+    a = prediction.reshape(-1)
+    b = target.reshape(-1)
+    if a.size < 2 or np.std(a) <= 0 or np.std(b) <= 0:
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def structural_correlation(prediction, target) -> float:
+    """Lightweight SSIM-like structural correlation for visual-quality tracking."""
+
+    prediction, target = _paired_arrays(prediction, target)
+    a = prediction - np.mean(prediction)
+    b = target - np.mean(target)
+    denom = float(np.sqrt(np.sum(a ** 2) * np.sum(b ** 2)))
+    if denom <= 0:
+        return float("nan")
+    return float(np.sum(a * b) / denom)
+
+
+def high_energy_error(prediction, target, quantile: float = 0.75) -> Dict[str, float]:
+    prediction, target = _paired_arrays(prediction, target)
+    threshold = float(np.quantile(np.abs(target), quantile)) if target.size else 0.0
+    mask = np.abs(target) >= threshold
+    if not np.any(mask):
+        return {"threshold": threshold, "mae": float("nan"), "rmse": float("nan"), "coverage": 0.0}
+    return {
+        "threshold": threshold,
+        "mae": mae(prediction[mask], target[mask]),
+        "rmse": rmse(prediction[mask], target[mask]),
+        "coverage": float(np.mean(mask)),
+    }
+
+
+def gradient_rmse(prediction, target) -> float:
+    prediction, target = _paired_arrays(prediction, target)
+    gx_pred, gz_pred = np.gradient(prediction, axis=0), np.gradient(prediction, axis=1)
+    gx_true, gz_true = np.gradient(target, axis=0), np.gradient(target, axis=1)
+    return rmse(np.stack([gx_pred, gz_pred]), np.stack([gx_true, gz_true]))
+
+
+def paired_cleaning_metrics(clean, noisy, clean_pred, data_range: Optional[float] = 256.0) -> Dict[str, object]:
+    """Compare noisy-before and predicted-after arrays against paired clean ground truth."""
+
+    clean, noisy = _paired_arrays(clean, noisy)
+    clean_pred, clean = _paired_arrays(clean_pred, clean)
+    before_error = noisy - clean
+    after_error = clean_pred - clean
+    residual = clean_pred - noisy
+    before_snr = snr_db(clean, before_error)
+    after_snr = snr_db(clean, after_error)
+    return {
+        "mae_before": mae(noisy, clean),
+        "mae_after": mae(clean_pred, clean),
+        "mae_improvement": mae(noisy, clean) - mae(clean_pred, clean),
+        "rmse_before": rmse(noisy, clean),
+        "rmse_after": rmse(clean_pred, clean),
+        "rmse_improvement": rmse(noisy, clean) - rmse(clean_pred, clean),
+        "snr_before_db": before_snr,
+        "snr_after_db": after_snr,
+        "snr_gain_db": after_snr - before_snr,
+        "psnr_before_db": psnr_db(noisy, clean, data_range),
+        "psnr_after_db": psnr_db(clean_pred, clean, data_range),
+        "structural_correlation_before": structural_correlation(noisy, clean),
+        "structural_correlation_after": structural_correlation(clean_pred, clean),
+        "trace_correlation_after": trace_correlation(clean_pred, clean),
+        "gradient_rmse_before": gradient_rmse(noisy, clean),
+        "gradient_rmse_after": gradient_rmse(clean_pred, clean),
+        "high_energy_error_after": high_energy_error(clean_pred, clean),
+        "residual_energy": float(np.mean(residual ** 2)),
+        "residual_mean_abs": float(np.mean(np.abs(residual))),
+        "changed_energy_ratio": _energy(residual) / max(_energy(noisy), 1e-12),
+    }
+
+
+def summarize_metric_rows(rows: Iterable[Dict[str, object]]) -> Dict[str, object]:
+    rows = list(rows)
+    summary: Dict[str, object] = {"num_samples": len(rows)}
+    if not rows:
+        return summary
+    numeric_keys = [key for key, value in rows[0].items() if isinstance(value, (int, float, np.floating))]
+    for key in numeric_keys:
+        values = np.asarray([row[key] for row in rows], dtype=float)
+        finite = values[np.isfinite(values)]
+        summary[key] = float(np.mean(finite)) if finite.size else float("nan")
+    return summary
+
+
+def write_metrics_report(path, report: Dict[str, object]) -> Path:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(_json_safe(report), fh, indent=2, ensure_ascii=False)
+    return path
+
+
+def _paired_arrays(a, b):
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    if a.shape != b.shape:
+        raise ValueError(f"Metric arrays must have matching shapes, got {a.shape} and {b.shape}")
+    if not np.isfinite(a).all() or not np.isfinite(b).all():
+        raise ValueError("Metric arrays must contain only finite values")
+    return a, b
+
+
+def _energy(data) -> float:
+    data = np.asarray(data, dtype=float)
+    return float(np.mean(data ** 2))
+
+
+def _json_safe(value):
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (np.integer, np.floating)):
+        value = float(value)
+    if isinstance(value, float) and (math.isinf(value) or math.isnan(value)):
+        return str(value)
+    return value

--- a/ml_air_clutter/train.py
+++ b/ml_air_clutter/train.py
@@ -14,6 +14,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 
+from .metrics import paired_cleaning_metrics, summarize_metric_rows, write_metrics_report
 from .model import ModelConfig, checkpoint_payload, count_parameters
 
 try:
@@ -218,6 +219,9 @@ def train_model(
                 if progress_callback:
                     progress_callback("log_message", f"Early stopping at epoch {epoch}; best epoch={best_epoch}.")
                 break
+    metric_report = evaluate_model_on_splits(model, model_config, samples, device)
+    metrics_path = write_metrics_report(output_dir / "metrics.json", metric_report)
+
     summary = {
         "training_schema": "ml_air_clutter_training_v1",
         "config": config.to_dict(),
@@ -230,6 +234,8 @@ def train_model(
         "train_log": str(log_path),
         "model_best": str(best_path),
         "model_last": str(last_path),
+        "metrics_report": str(metrics_path),
+        "metrics": metric_report,
         "history": history,
     }
     with (output_dir / "training_summary.json").open("w", encoding="utf-8") as fh:
@@ -248,3 +254,44 @@ def _save_training_checkpoint(path, model, model_config, training_config, metric
         "best_validation_loss": best_loss,
     })
     torch.save(payload, path)
+
+
+def evaluate_model_on_splits(model, model_config: ModelConfig, samples: Dict[str, List[Dict[str, object]]], device=None) -> Dict[str, object]:
+    """Run paired before/after quality metrics for validation and test samples."""
+
+    _require_torch()
+    if device is None:
+        device = next(model.parameters()).device
+    report = {"metrics_schema": "ml_air_clutter_quality_metrics_v1", "splits": {}}
+    model.eval()
+    for split in ("train", "validation", "test"):
+        split_samples = list(samples.get(split, []))
+        rows = []
+        previews = []
+        for index, sample in enumerate(split_samples):
+            with torch.no_grad():
+                x = torch.from_numpy(make_input_channels(sample["noisy"], model_config.input_channels)[None, ...] / 256.0).to(device)
+                prediction = model(x).detach().cpu().numpy()[0, 0] * 256.0
+            metrics = paired_cleaning_metrics(sample["clean"], sample["noisy"], prediction, data_range=256.0)
+            metrics.update({
+                "sample_index": index,
+                "pair_id": sample.get("pair_id", ""),
+                "x_start": sample.get("x_start", 0),
+                "x_end": sample.get("x_end", 0),
+            })
+            rows.append(metrics)
+            if len(previews) < 3:
+                previews.append({
+                    "sample_index": index,
+                    "pair_id": sample.get("pair_id", ""),
+                    "x_start": sample.get("x_start", 0),
+                    "x_end": sample.get("x_end", 0),
+                    "mae_before": metrics["mae_before"],
+                    "mae_after": metrics["mae_after"],
+                    "snr_gain_db": metrics["snr_gain_db"],
+                })
+        report["splits"][split] = {
+            "summary": summarize_metric_rows(rows),
+            "samples_preview": previews,
+        }
+    return report

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 import numpy as np
 from PyQt5 import QtCore, QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.figure import Figure
 
 from ml_air_clutter.config import NormalizationConfig, SyntheticClutterConfig
 from ml_air_clutter.dataset import (
@@ -26,6 +29,122 @@ from ml_air_clutter.synthetic_clutter import generate_synthetic_clutter
 from ml_air_clutter.train import TrainingConfig, train_model
 from models_db.model import Profile, CurrentProfile, session
 from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
+
+
+class MLClutterMetricsWindow(QtWidgets.QDialog):
+    """Matplotlib dashboard for ML Clutter training and quality metrics."""
+
+    def __init__(self, training_summary, parent=None):
+        super().__init__(parent)
+        self.training_summary = training_summary or {}
+        self.setWindowTitle("ML Clutter Quality Metrics")
+        self.resize(1180, 820)
+        layout = QtWidgets.QVBoxLayout(self)
+        self.figure = Figure(figsize=(11.5, 8.0), dpi=100)
+        self.canvas = FigureCanvas(self.figure)
+        self.toolbar = NavigationToolbar(self.canvas, self)
+        layout.addWidget(self.toolbar)
+        layout.addWidget(self.canvas)
+        self._draw()
+
+    def _draw(self):
+        self.figure.clear()
+        metrics = self.training_summary.get("metrics", {})
+        history = self.training_summary.get("history", [])
+        grid = self.figure.add_gridspec(2, 2, hspace=0.38, wspace=0.28)
+        self._draw_loss_curves(self.figure.add_subplot(grid[0, 0]), history)
+        self._draw_before_after_bars(
+            self.figure.add_subplot(grid[0, 1]),
+            metrics,
+            ("mae_before", "mae_after", "rmse_before", "rmse_after"),
+            "Error before/after cleanup",
+            "error",
+        )
+        self._draw_before_after_bars(
+            self.figure.add_subplot(grid[1, 0]),
+            metrics,
+            ("snr_before_db", "snr_after_db", "psnr_before_db", "psnr_after_db"),
+            "SNR / PSNR before/after cleanup",
+            "dB",
+        )
+        self._draw_residual_and_correlation(self.figure.add_subplot(grid[1, 1]), metrics)
+        self.figure.suptitle("ML Clutter quality metrics", fontsize=14, fontweight="bold")
+        self.canvas.draw_idle()
+
+    @staticmethod
+    def _split_summaries(metrics):
+        splits = metrics.get("splits", {}) if isinstance(metrics, dict) else {}
+        return [(split, payload.get("summary", {})) for split, payload in splits.items() if payload.get("summary", {}).get("num_samples", 0)]
+
+    @staticmethod
+    def _finite(value):
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        if not np.isfinite(value):
+            return 0.0
+        return value
+
+    def _draw_loss_curves(self, ax, history):
+        if not history:
+            ax.text(0.5, 0.5, "No training history", ha="center", va="center")
+            ax.set_axis_off()
+            return
+        epochs = [row.get("epoch", idx + 1) for idx, row in enumerate(history)]
+        for key, label in (("train_loss", "train"), ("val_loss", "validation"), ("train_clean_l1", "train L1"), ("val_clean_l1", "validation L1")):
+            values = [self._finite(row.get(key)) for row in history]
+            if values:
+                ax.plot(epochs, values, marker="o", linewidth=1.4, label=label)
+        ax.set_title("Training losses")
+        ax.set_xlabel("epoch")
+        ax.set_ylabel("loss")
+        ax.grid(True, alpha=0.25)
+        ax.legend(fontsize=8)
+
+    def _draw_before_after_bars(self, ax, metrics, keys, title, ylabel):
+        summaries = self._split_summaries(metrics)
+        if not summaries:
+            ax.text(0.5, 0.5, "No paired metrics", ha="center", va="center")
+            ax.set_axis_off()
+            return
+        labels = [split for split, _ in summaries]
+        x = np.arange(len(labels), dtype=float)
+        width = 0.18
+        offsets = np.linspace(-1.5 * width, 1.5 * width, len(keys))
+        for offset, key in zip(offsets, keys):
+            values = [self._finite(summary.get(key)) for _, summary in summaries]
+            ax.bar(x + offset, values, width=width, label=key.replace("_", " "))
+        ax.set_title(title)
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=15, ha="right")
+        ax.set_ylabel(ylabel)
+        ax.grid(True, axis="y", alpha=0.25)
+        ax.legend(fontsize=8)
+
+    def _draw_residual_and_correlation(self, ax, metrics):
+        summaries = self._split_summaries(metrics)
+        if not summaries:
+            ax.text(0.5, 0.5, "No residual diagnostics", ha="center", va="center")
+            ax.set_axis_off()
+            return
+        labels = [split for split, _ in summaries]
+        x = np.arange(len(labels), dtype=float)
+        width = 0.22
+        series = [
+            ("changed_energy_ratio", "changed energy"),
+            ("structural_correlation_after", "structural corr after"),
+            ("trace_correlation_after", "trace corr after"),
+        ]
+        for idx, (key, label) in enumerate(series):
+            values = [self._finite(summary.get(key)) for _, summary in summaries]
+            ax.bar(x + (idx - 1) * width, values, width=width, label=label)
+        ax.set_title("Over-cleaning diagnostics")
+        ax.set_xticks(x)
+        ax.set_xticklabels(labels, rotation=15, ha="right")
+        ax.set_ylabel("ratio / correlation")
+        ax.grid(True, axis="y", alpha=0.25)
+        ax.legend(fontsize=8)
 
 
 class MLClutterTrainingWorker(QtCore.QObject):
@@ -106,6 +225,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_thread = None
         self.training_worker = None
         self.training_summary = None
+        self.metrics_window = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -450,6 +570,10 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_summary = summary
         self.experiment_config["training"] = summary
         self._show_training_stats("Training finished.\n" + json.dumps(summary, indent=2, ensure_ascii=False))
+        metrics = summary.get("metrics", {})
+        self.experiment_config["metrics"] = metrics
+        self._show_results_log(self._format_metrics_report(metrics, summary.get("metrics_report", "")))
+        self._open_metrics_window(summary)
         self._log(f"ML Clutter training finished: best_epoch={summary['best_epoch']}, best_val_loss={summary['best_validation_loss']:.6g}")
 
     def _on_training_error(self, message):
@@ -460,6 +584,32 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_thread = None
         self.training_worker = None
         self.ui.pushButton_start_training.setEnabled(True)
+
+    @staticmethod
+    def _format_metrics_report(metrics, metrics_path=""):
+        if not metrics:
+            return "Quality metrics are not available yet. Train a model to compare noisy-before and clean_pred-after."
+        lines = [
+            "ML Clutter quality metrics report",
+            "Task: paired supervised direct-clean evaluation",
+            "Comparison: noisy vs clean before cleanup; clean_pred vs clean after cleanup",
+        ]
+        if metrics_path:
+            lines.append(f"Saved metrics JSON: {metrics_path}")
+        for split, payload in metrics.get("splits", {}).items():
+            summary = payload.get("summary", {})
+            lines.extend([
+                "",
+                f"[{split}] samples={summary.get('num_samples', 0)}",
+                f"MAE before/after: {summary.get('mae_before', float('nan')):.6g} -> {summary.get('mae_after', float('nan')):.6g}",
+                f"RMSE before/after: {summary.get('rmse_before', float('nan')):.6g} -> {summary.get('rmse_after', float('nan')):.6g}",
+                f"SNR before/after/gain dB: {summary.get('snr_before_db', float('nan')):.6g} -> {summary.get('snr_after_db', float('nan')):.6g} / {summary.get('snr_gain_db', float('nan')):.6g}",
+                f"PSNR before/after dB: {summary.get('psnr_before_db', float('nan')):.6g} -> {summary.get('psnr_after_db', float('nan')):.6g}",
+                f"Structural corr before/after: {summary.get('structural_correlation_before', float('nan')):.6g} -> {summary.get('structural_correlation_after', float('nan')):.6g}",
+                f"Residual changed-energy ratio: {summary.get('changed_energy_ratio', float('nan')):.6g}",
+            ])
+        lines.extend(["", json.dumps(metrics, indent=2, ensure_ascii=False)])
+        return "\n".join(lines)
 
     def save_untrained_checkpoint(self):
         if self.model is None or self.model_config is None:
@@ -495,6 +645,15 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     def _show_model_summary(self, text):
         self.ui.textEdit_model_summary.setPlainText(text)
+
+    def _show_results_log(self, text):
+        self.ui.textEdit_results_log.setPlainText(text)
+
+    def _open_metrics_window(self, summary):
+        self.metrics_window = MLClutterMetricsWindow(summary, self)
+        self.metrics_window.show()
+        self.metrics_window.raise_()
+        self.metrics_window.activateWindow()
 
     def _selected_dataset_pair(self):
         row = self.ui.tableWidget_dataset_pairs.currentRow()

--- a/tests/test_ml_air_clutter_metrics.py
+++ b/tests/test_ml_air_clutter_metrics.py
@@ -1,0 +1,40 @@
+import json
+
+import numpy as np
+
+from ml_air_clutter.metrics import paired_cleaning_metrics, summarize_metric_rows, write_metrics_report
+
+
+def test_paired_cleaning_metrics_compare_before_and_after():
+    clean = np.full((4, 512), 100.0)
+    noisy = clean + 10.0
+    clean_pred = clean + 2.0
+
+    metrics = paired_cleaning_metrics(clean, noisy, clean_pred)
+
+    assert metrics["mae_before"] == 10.0
+    assert metrics["mae_after"] == 2.0
+    assert metrics["rmse_before"] == 10.0
+    assert metrics["rmse_after"] == 2.0
+    assert metrics["snr_gain_db"] > 0
+    assert metrics["psnr_after_db"] > metrics["psnr_before_db"]
+    assert metrics["residual_energy"] > 0
+
+
+def test_summarize_metric_rows_averages_numeric_metrics():
+    summary = summarize_metric_rows([
+        {"mae_before": 4.0, "mae_after": 2.0, "nested": {"ignored": True}},
+        {"mae_before": 2.0, "mae_after": 1.0, "nested": {"ignored": True}},
+    ])
+
+    assert summary["num_samples"] == 2
+    assert summary["mae_before"] == 3.0
+    assert summary["mae_after"] == 1.5
+
+
+def test_write_metrics_report_serializes_non_finite_values(tmp_path):
+    path = write_metrics_report(tmp_path / "metrics.json", {"value": float("inf")})
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    assert data["value"] == "inf"


### PR DESCRIPTION
### Motivation

- Provide standardized, automated quality metrics for paired supervised (noisy -> clean) training to track before/after cleaning performance and diagnose over-cleaning. 
- Persist a machine-readable metrics report alongside training artifacts to enable analysis and visualization.

### Description

- Add a new `metrics.py` module that implements a suite of quality metrics including `paired_cleaning_metrics`, `summarize_metric_rows`, `write_metrics_report`, and helpers like `mae`, `rmse`, `snr_db`, `psnr_db`, `structural_correlation`, and `high_energy_error`.
- Export the metrics helpers from the package by updating `ml_air_clutter/__init__.py` to include `paired_cleaning_metrics` and `summarize_metric_rows`.
- Integrate metrics into training by adding `evaluate_model_on_splits` in `train.py`, calling it at the end of `train_model`, writing `metrics.json` via `write_metrics_report`, and embedding the report into the returned `training_summary` under `metrics` and `metrics_report`.
- Add a Matplotlib-based dashboard `MLClutterMetricsWindow` and associated UI hooks in `ml_clutter_experiment.py` to display summary plots and textual reports after training, and add a simple `_format_metrics_report` helper to render the metrics into the results log.

### Testing

- Add unit tests `tests/test_ml_air_clutter_metrics.py` covering `paired_cleaning_metrics`, `summarize_metric_rows`, and `write_metrics_report` with expected numeric and JSON-serialization behavior.
- Ran the new tests with `pytest tests/test_ml_air_clutter_metrics.py` and they passed.
- No automated UI tests were added for the new Matplotlib window; it is exercised at runtime via the GUI integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a794b4808832f893acdc95bdb22fc)