### PR TITLE
Implement full-profile sliding-window inference for ML Clutter

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -4,6 +4,7 @@ from .config import NormalizationConfig
 from .noise_patterns import PatternExtractionConfig, extract_energy_patterns, extract_frequency_band_patterns, extract_pattern_from_bbox
 from .pattern_library import NoisePattern, PatternLibrary
 from .pattern_generator import PatternClutterConfig, generate_pattern_clutter
+from .inference import InferenceConfig, blend_inference_result, run_full_profile_inference, save_inference_result
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
 from .metrics import paired_cleaning_metrics, summarize_metric_rows
 from .model import ModelConfig, count_parameters, create_model, load_model_checkpoint, save_model_checkpoint
@@ -14,6 +15,10 @@ __all__ = [
     "PatternExtractionConfig",
     "PatternLibrary",
     "PatternClutterConfig",
+    "InferenceConfig",
+    "blend_inference_result",
+    "run_full_profile_inference",
+    "save_inference_result",
     "generate_pattern_clutter",
     "paired_cleaning_metrics",
     "summarize_metric_rows",

--- a/ml_air_clutter/inference.py
+++ b/ml_air_clutter/inference.py
@@ -1,0 +1,142 @@
+"""Full-profile inference utilities for ML air-clutter cleaning."""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import numpy as np
+
+from .train import _require_torch, make_input_channels, torch
+
+
+@dataclass(frozen=True)
+class InferenceConfig:
+    """Serializable sliding-window inference configuration."""
+
+    patch_width: int = 64
+    stride: int = 32
+    alpha: float = 1.0
+    device: str = "auto"
+    clip_min: float = 0.0
+    clip_max: float = 256.0
+    window: str = "hann"
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def _resolve_device(requested: str):
+    if requested == "auto":
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    return torch.device(requested)
+
+
+def _patch_starts(num_traces: int, patch_width: int, stride: int) -> List[int]:
+    if patch_width <= 0 or stride <= 0:
+        raise ValueError("patch_width and stride must be positive.")
+    if num_traces < patch_width:
+        raise ValueError(f"profile has {num_traces} traces, fewer than patch_width={patch_width}.")
+    starts = list(range(0, num_traces - patch_width + 1, stride))
+    last = num_traces - patch_width
+    if starts[-1] != last:
+        starts.append(last)
+    return starts
+
+
+def _blend_window(patch_width: int, kind: str) -> np.ndarray:
+    if kind == "uniform" or patch_width == 1:
+        values = np.ones(patch_width, dtype=np.float32)
+    elif kind == "hann":
+        values = np.hanning(patch_width).astype(np.float32)
+        if not np.any(values > 0):
+            values = np.ones(patch_width, dtype=np.float32)
+        values = np.maximum(values, 1e-3)
+    else:
+        raise ValueError("window must be 'hann' or 'uniform'.")
+    return values[:, None]
+
+
+def run_full_profile_inference(model, model_config, noisy_profile, config: InferenceConfig = None) -> Dict[str, object]:
+    """Predict a clean full profile using overlapping model patches.
+
+    The model is expected to be a direct-clean predictor trained on patches in
+    the 0..256 amplitude range. Overlapping patch predictions are accumulated
+    with a 1D x-axis blend window and normalized by accumulated weights.
+    """
+
+    _require_torch()
+    config = config or InferenceConfig()
+    noisy = np.asarray(noisy_profile, dtype=np.float32)
+    if noisy.ndim != 2:
+        raise ValueError(f"noisy_profile must be 2D, got ndim={noisy.ndim}.")
+    if not np.isfinite(noisy).all():
+        raise ValueError("noisy_profile contains NaN or infinite values.")
+    starts = _patch_starts(noisy.shape[0], int(config.patch_width), int(config.stride))
+    device = _resolve_device(config.device)
+    original_device = next(model.parameters()).device
+    model.to(device)
+    model.eval()
+    output_sum = np.zeros_like(noisy, dtype=np.float32)
+    weight_sum = np.zeros_like(noisy, dtype=np.float32)
+    window = _blend_window(int(config.patch_width), config.window).astype(np.float32)
+    with torch.no_grad():
+        for start in starts:
+            end = start + int(config.patch_width)
+            patch = noisy[start:end]
+            x = make_input_channels(patch, model_config.input_channels)[None, ...] / 256.0
+            tensor = torch.from_numpy(x.astype(np.float32)).to(device)
+            pred = model(tensor).detach().cpu().numpy()[0, 0].astype(np.float32) * 256.0
+            output_sum[start:end] += pred * window
+            weight_sum[start:end] += window
+    model.to(original_device)
+    if np.any(weight_sum <= 0):
+        raise RuntimeError("sliding-window inference left uncovered traces; check patch_width/stride.")
+    clean_pred = output_sum / weight_sum
+    clean_pred = np.clip(clean_pred, float(config.clip_min), float(config.clip_max))
+    alpha = float(np.clip(config.alpha, 0.0, 1.0))
+    cleaned = (1.0 - alpha) * noisy + alpha * clean_pred
+    residual = noisy - clean_pred
+    return {
+        "noisy": noisy.copy(),
+        "clean_pred": clean_pred.astype(np.float32),
+        "cleaned": cleaned.astype(np.float32),
+        "residual": residual.astype(np.float32),
+        "meta": {
+            "inference_schema": "ml_air_clutter_full_profile_inference_v1",
+            "config": config.to_dict(),
+            "effective_alpha": alpha,
+            "num_windows": len(starts),
+            "window_starts": [int(s) for s in starts],
+            "profile_shape": list(noisy.shape),
+            "input_channels": list(model_config.input_channels),
+        },
+    }
+
+
+def blend_inference_result(noisy, clean_pred, alpha: float):
+    """Recompute cleaned and residual arrays for an existing prediction."""
+
+    noisy = np.asarray(noisy, dtype=np.float32)
+    clean_pred = np.asarray(clean_pred, dtype=np.float32)
+    if noisy.shape != clean_pred.shape:
+        raise ValueError("noisy and clean_pred shapes must match.")
+    alpha = float(np.clip(alpha, 0.0, 1.0))
+    cleaned = (1.0 - alpha) * noisy + alpha * clean_pred
+    return {"cleaned": cleaned.astype(np.float32), "residual": (noisy - clean_pred).astype(np.float32), "alpha": alpha}
+
+
+def save_inference_result(path, result: Dict[str, object]) -> Path:
+    """Save full-profile inference arrays and metadata as a compressed NPZ."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        path,
+        noisy=result["noisy"],
+        clean_pred=result["clean_pred"],
+        cleaned=result["cleaned"],
+        residual=result["residual"],
+        meta=json.dumps(result.get("meta", {}), ensure_ascii=False),
+    )
+    return path

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -15,6 +15,7 @@ from ml_air_clutter.dataset import (
     save_dataset,
     validate_clean_noisy_pair,
 )
+from ml_air_clutter.inference import InferenceConfig, blend_inference_result, run_full_profile_inference, save_inference_result
 from ml_air_clutter.model import ModelConfig, count_parameters, create_model, save_model_checkpoint
 from ml_air_clutter.noise_patterns import (
     PatternExtractionConfig,
@@ -226,6 +227,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_worker = None
         self.training_summary = None
         self.metrics_window = None
+        self.inference_result = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -251,6 +253,10 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_create_model.clicked.connect(self.create_baseline_model)
         self.ui.pushButton_save_untrained_checkpoint.clicked.connect(self.save_untrained_checkpoint)
         self.ui.pushButton_start_training.clicked.connect(self.start_training)
+        self.ui.pushButton_run_inference.clicked.connect(self.run_inference)
+        self.ui.pushButton_preview_inference.clicked.connect(self.preview_inference_result)
+        self.ui.pushButton_save_inference.clicked.connect(self.save_inference_result)
+        self.ui.horizontalSlider_inference_alpha.valueChanged.connect(self.update_inference_alpha)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self.ui.listWidget_noisy_profiles.currentItemChanged.connect(lambda *_: self._on_noisy_source_changed())
         for spin_box in (
@@ -610,6 +616,83 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             ])
         lines.extend(["", json.dumps(metrics, indent=2, ensure_ascii=False)])
         return "\n".join(lines)
+
+    def run_inference(self):
+        if self.model is None or self.model_config is None:
+            self._show_inference_log("Create or train a model before running full-profile inference.")
+            return
+        noisy = self._selected_inference_profile()
+        if noisy is None:
+            self._show_inference_log("Load or generate a source profile before inference.")
+            return
+        config = self._current_inference_config()
+        try:
+            self.inference_result = run_full_profile_inference(self.model, self.model_config, noisy, config)
+        except Exception as exc:
+            self._show_inference_log(f"Inference failed: {exc}")
+            self._log(f"ML Clutter inference failed: {exc}", "red")
+            return
+        self.preview_inference_result()
+        self._show_inference_log(json.dumps(self.inference_result["meta"], indent=2, ensure_ascii=False))
+        self._log(f"ML Clutter inference finished: windows={self.inference_result['meta']['num_windows']}, alpha={self.inference_result['meta']['effective_alpha']:.2f}")
+
+    def update_inference_alpha(self):
+        alpha = float(self.ui.horizontalSlider_inference_alpha.value()) / 100.0
+        self.ui.label_inference_alpha_value.setText(f"{alpha:.2f}")
+        if self.inference_result is None:
+            return
+        blended = blend_inference_result(self.inference_result["noisy"], self.inference_result["clean_pred"], alpha)
+        self.inference_result["cleaned"] = blended["cleaned"]
+        self.inference_result["residual"] = blended["residual"]
+        self.inference_result.setdefault("meta", {})["effective_alpha"] = blended["alpha"]
+        self.inference_result.setdefault("meta", {}).setdefault("config", {})["alpha"] = blended["alpha"]
+        self.preview_inference_result()
+
+    def preview_inference_result(self):
+        if self.inference_result is None:
+            self._show_inference_log("Run inference before previewing alpha-blended results.")
+            return
+        self._display_profile(self.inference_result["residual"], "ML Clutter inference residual noisy-clean_pred")
+        self._display_profile(self.inference_result["cleaned"], "ML Clutter inference cleaned alpha blend")
+        self._display_profile(self.inference_result["clean_pred"], "ML Clutter inference clean_pred")
+        self._display_profile(self.inference_result["noisy"], "ML Clutter inference noisy source")
+
+    def save_inference_result(self):
+        if self.inference_result is None:
+            self._show_inference_log("Run inference before saving the result.")
+            return
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(self, "Save ML clutter inference result", "ml_clutter_inference_result.npz", "NumPy compressed archive (*.npz)")
+        if not path:
+            return
+        try:
+            saved_path = save_inference_result(path, self.inference_result)
+        except OSError as exc:
+            self._show_inference_log(f"Failed to save inference result: {exc}")
+            return
+        self._show_inference_log(f"Inference result saved: {saved_path}\n" + json.dumps(self.inference_result.get("meta", {}), indent=2, ensure_ascii=False))
+        self._log(f"ML Clutter inference result saved: {saved_path}")
+
+    def _current_inference_config(self):
+        return InferenceConfig(
+            patch_width=int(self.ui.spinBox_inference_patch_width.value()),
+            stride=int(self.ui.spinBox_inference_stride.value()),
+            alpha=float(self.ui.horizontalSlider_inference_alpha.value()) / 100.0,
+        )
+
+    def _selected_inference_profile(self):
+        source = self.ui.comboBox_inference_source.currentData()
+        if source == "real_noisy":
+            return self.real_noisy_profile
+        if source == "generated":
+            if self.last_generated_clutter_result is None:
+                return None
+            return self.last_generated_clutter_result.get("noisy")
+        if source == "clean":
+            return self.clean_profile
+        return None
+
+    def _show_inference_log(self, text):
+        self.ui.textEdit_inference_log.setPlainText(text)
 
     def save_untrained_checkpoint(self):
         if self.model is None or self.model_config is None:

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -21,10 +21,7 @@ class Ui_MLClutterExperiment(object):
         self.tab_dataset = self._add_dataset_tab()
         self.tab_model = self._add_model_tab()
         self.tab_training = self._add_training_tab()
-        self.tab_inference = self._add_placeholder_tab(
-            "tab_inference",
-            "Apply trained clutter-removal models to synthetic or real profiles.",
-        )
+        self.tab_inference = self._add_inference_tab()
         self.tab_results = self._add_results_tab()
 
         self.verticalLayout.addWidget(self.tabWidget)
@@ -454,6 +451,62 @@ class Ui_MLClutterExperiment(object):
         self.tabWidget.addTab(tab, "")
         return tab
 
+
+    def _add_inference_tab(self):
+        tab = QtWidgets.QWidget()
+        tab.setObjectName("tab_inference")
+        layout = QtWidgets.QGridLayout(tab)
+        intro = QtWidgets.QLabel(tab)
+        intro.setWordWrap(True)
+        intro.setText("Run sliding-window full-profile inference, preview noisy / clean_pred / cleaned / residual, tune alpha, and save the result.")
+        layout.addWidget(intro, 0, 0, 1, 4)
+        self.spinBox_inference_patch_width = QtWidgets.QSpinBox(tab)
+        self.spinBox_inference_patch_width.setObjectName("spinBox_inference_patch_width")
+        self.spinBox_inference_patch_width.setRange(1, 100000)
+        self.spinBox_inference_patch_width.setValue(64)
+        self.spinBox_inference_stride = QtWidgets.QSpinBox(tab)
+        self.spinBox_inference_stride.setObjectName("spinBox_inference_stride")
+        self.spinBox_inference_stride.setRange(1, 100000)
+        self.spinBox_inference_stride.setValue(32)
+        self.horizontalSlider_inference_alpha = QtWidgets.QSlider(QtCore.Qt.Horizontal, tab)
+        self.horizontalSlider_inference_alpha.setObjectName("horizontalSlider_inference_alpha")
+        self.horizontalSlider_inference_alpha.setRange(0, 100)
+        self.horizontalSlider_inference_alpha.setValue(100)
+        self.label_inference_alpha_value = QtWidgets.QLabel("1.00", tab)
+        self.label_inference_alpha_value.setObjectName("label_inference_alpha_value")
+        self.comboBox_inference_source = QtWidgets.QComboBox(tab)
+        self.comboBox_inference_source.setObjectName("comboBox_inference_source")
+        self.comboBox_inference_source.addItem("Loaded real noisy profile", "real_noisy")
+        self.comboBox_inference_source.addItem("Generated noisy preview", "generated")
+        self.comboBox_inference_source.addItem("Loaded clean profile", "clean")
+        controls = [
+            ("source profile", self.comboBox_inference_source),
+            ("patch width", self.spinBox_inference_patch_width),
+            ("stride", self.spinBox_inference_stride),
+        ]
+        for row, (label, widget) in enumerate(controls, start=1):
+            layout.addWidget(QtWidgets.QLabel(label, tab), row, 0)
+            layout.addWidget(widget, row, 1)
+        layout.addWidget(QtWidgets.QLabel("alpha", tab), 4, 0)
+        layout.addWidget(self.horizontalSlider_inference_alpha, 4, 1, 1, 2)
+        layout.addWidget(self.label_inference_alpha_value, 4, 3)
+        self.pushButton_run_inference = QtWidgets.QPushButton(tab)
+        self.pushButton_run_inference.setObjectName("pushButton_run_inference")
+        layout.addWidget(self.pushButton_run_inference, 1, 2)
+        self.pushButton_preview_inference = QtWidgets.QPushButton(tab)
+        self.pushButton_preview_inference.setObjectName("pushButton_preview_inference")
+        layout.addWidget(self.pushButton_preview_inference, 2, 2)
+        self.pushButton_save_inference = QtWidgets.QPushButton(tab)
+        self.pushButton_save_inference.setObjectName("pushButton_save_inference")
+        layout.addWidget(self.pushButton_save_inference, 3, 2)
+        self.textEdit_inference_log = QtWidgets.QTextEdit(tab)
+        self.textEdit_inference_log.setReadOnly(True)
+        self.textEdit_inference_log.setObjectName("textEdit_inference_log")
+        layout.addWidget(self.textEdit_inference_log, 5, 0, 1, 4)
+        layout.setRowStretch(5, 1)
+        self.tabWidget.addTab(tab, "")
+        return tab
+
     def _add_placeholder_tab(self, object_name, message):
         tab = QtWidgets.QWidget()
         tab.setObjectName(object_name)
@@ -519,6 +572,9 @@ class Ui_MLClutterExperiment(object):
         self.pushButton_create_model.setText(_translate("MLClutterExperiment", "Create Model"))
         self.pushButton_save_untrained_checkpoint.setText(_translate("MLClutterExperiment", "Save Untrained Checkpoint"))
         self.pushButton_start_training.setText(_translate("MLClutterExperiment", "Start Training"))
+        self.pushButton_run_inference.setText(_translate("MLClutterExperiment", "Run Inference"))
+        self.pushButton_preview_inference.setText(_translate("MLClutterExperiment", "Preview Current Alpha"))
+        self.pushButton_save_inference.setText(_translate("MLClutterExperiment", "Save Result"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))

--- a/tests/test_ml_air_clutter_inference.py
+++ b/tests/test_ml_air_clutter_inference.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from ml_air_clutter.inference import InferenceConfig, blend_inference_result, run_full_profile_inference
+from ml_air_clutter.model import ModelConfig
+
+
+torch = pytest.importorskip("torch")
+
+
+class IdentityCleanModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.zeros(()))
+
+    def forward(self, x):
+        return x[:, :1] + self.bias
+
+
+def test_full_profile_inference_covers_tail_and_blends_alpha():
+    noisy = np.arange(10 * 512, dtype=np.float32).reshape(10, 512) % 256
+    model = IdentityCleanModel()
+    config = ModelConfig(input_channels=("raw",))
+    result = run_full_profile_inference(model, config, noisy, InferenceConfig(patch_width=4, stride=3, alpha=0.25, window="uniform"))
+
+    assert result["clean_pred"].shape == noisy.shape
+    np.testing.assert_allclose(result["clean_pred"], noisy, atol=1e-5)
+    np.testing.assert_allclose(result["cleaned"], noisy, atol=1e-5)
+    assert result["meta"]["window_starts"] == [0, 3, 6]
+
+
+def test_blend_inference_result_uses_alpha_between_noisy_and_prediction():
+    noisy = np.full((2, 3), 10.0, dtype=np.float32)
+    clean_pred = np.full((2, 3), 2.0, dtype=np.float32)
+    blended = blend_inference_result(noisy, clean_pred, 0.5)
+
+    np.testing.assert_allclose(blended["cleaned"], 6.0)
+    np.testing.assert_allclose(blended["residual"], 8.0)
+    assert blended["alpha"] == 0.5


### PR DESCRIPTION
### Motivation
- Реализовать этап 11 плана: запуск full-profile sliding-window inference для модели `noisy -> clean_pred` с покрытием хвоста, усреднением перекрывающихся патчей и возможностью мягкого alpha-смешивания. 
- Обеспечить взаимодействие inference с UI: превью `noisy`, `clean_pred`, `cleaned`, `residual` и сохранение результатов эксперимента.

### Description
- Добавлен модуль `ml_air_clutter/inference.py` с `InferenceConfig`, `run_full_profile_inference`, `blend_inference_result` и `save_inference_result` для sliding-window предсказания, нормировки по весам окна и сохранения compressed `.npz`-артефакта. 
- Экспорт inference-хелперов из пакета в `ml_air_clutter/__init__.py`. 
- Заменён placeholder-вкладка `Inference` в UI (`qt/ml_clutter_experiment_form.py`) на полноценную вкладку с выбором источника профиля, `patch width`/`stride`, alpha-слайдером и кнопками `Run Inference`, `Preview Current Alpha`, `Save Result`. 
- Подключена логика в `ml_clutter_experiment.py`: команды запуска inference, превью результатов в `MainWindow`, интерактивное обновление alpha и сохранение артефакта; добавлен тестовый файл `tests/test_ml_air_clutter_inference.py` с проверками покрытия хвоста и alpha-бленда. 

### Testing
- Выполнена статическая проверка синтаксиса командой `python -m py_compile ml_air_clutter/inference.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py tests/test_ml_air_clutter_inference.py`, и она прошла успешно. 
- Локальный запуск unit-теста `pytest -q tests/test_ml_air_clutter_inference.py` был запланирован, но сборка тестов прервана из-за отсутствия dependency в окружении: `ModuleNotFoundError: No module named 'numpy'`, поэтому автоматическое выполнение тестов в текущем контейнере не завершено. 
- Все изменения были подготовлены и добавлены в ветку вместе с тестовым файлом для CI, ожидая среды с установленными `numpy`/`torch` для полного прогона тестов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7f7775f8832fae4081ca436249a0)