### PR TITLE
Implement ML clutter stage 12 visualization API

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -8,6 +8,7 @@ from .inference import InferenceConfig, blend_inference_result, run_full_profile
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
 from .metrics import paired_cleaning_metrics, summarize_metric_rows
 from .model import ModelConfig, count_parameters, create_model, load_model_checkpoint, save_model_checkpoint
+from .visualization import VisualizationBundle, build_experiment_log, build_paired_visualization, build_training_metric_curves
 
 __all__ = [
     "NormalizationConfig",
@@ -30,6 +31,10 @@ __all__ = [
     "NormalizationResult",
     "Normalizer",
     "build_preprocessing_report",
+    "VisualizationBundle",
+    "build_experiment_log",
+    "build_paired_visualization",
+    "build_training_metric_curves",
     "extract_energy_patterns",
     "extract_frequency_band_patterns",
     "extract_pattern_from_bbox",

--- a/ml_air_clutter/visualization.py
+++ b/ml_air_clutter/visualization.py
@@ -1,0 +1,114 @@
+"""Unified visualization helpers for the ML air-clutter experiment.
+
+The UI still delegates the actual drawing to ``MainWindow``; this module owns the
+small, deterministic transformation API used to decide which arrays, traces,
+metric curves and log lines belong to a preview.  Keeping this logic outside the
+Qt dialog makes the paired ``noisy -> clean`` pipeline easy to test and reuse.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass
+class VisualizationBundle:
+    """Container with all artifacts needed by the UI visualization layer."""
+
+    radarograms: Dict[str, np.ndarray] = field(default_factory=dict)
+    traces: Dict[str, np.ndarray] = field(default_factory=dict)
+    metric_curves: Dict[str, List[float]] = field(default_factory=dict)
+    log_lines: List[str] = field(default_factory=list)
+
+    def log_text(self) -> str:
+        return "\n".join(self.log_lines)
+
+
+def _as_2d(name: str, data) -> np.ndarray:
+    arr = np.asarray(data, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a 2D radarogram, got ndim={arr.ndim}.")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} contains non-finite values.")
+    return arr
+
+
+def _same_shape(reference_name: str, reference: np.ndarray, name: str, data) -> np.ndarray:
+    arr = _as_2d(name, data)
+    if arr.shape != reference.shape:
+        raise ValueError(f"{name} shape {arr.shape} does not match {reference_name} shape {reference.shape}.")
+    return arr
+
+
+def build_paired_visualization(
+    *,
+    noisy,
+    clean=None,
+    clean_pred=None,
+    alpha: float = 1.0,
+    trace_index: Optional[int] = None,
+    title: str = "ML Clutter paired visualization",
+) -> VisualizationBundle:
+    """Build mandatory Stage-12 paired-pipeline visual layers.
+
+    Required mode is ``Noisy``.  If ``clean`` is supplied the bundle includes
+    ``Clean`` and, when prediction is available, ``Error map predicted-clean``.
+    If ``clean_pred`` is supplied it also includes ``Predicted clean``,
+    ``Cleaned with alpha`` and ``Residual noisy-predicted``.
+    """
+
+    noisy_arr = _as_2d("noisy", noisy)
+    clean_arr = _same_shape("noisy", noisy_arr, "clean", clean) if clean is not None else None
+    pred_arr = _same_shape("noisy", noisy_arr, "clean_pred", clean_pred) if clean_pred is not None else None
+    alpha = float(np.clip(alpha, 0.0, 1.0))
+
+    radarograms: Dict[str, np.ndarray] = {"Noisy": noisy_arr.copy()}
+    if clean_arr is not None:
+        radarograms["Clean"] = clean_arr.copy()
+    if pred_arr is not None:
+        cleaned = (1.0 - alpha) * noisy_arr + alpha * pred_arr
+        radarograms["Predicted clean"] = pred_arr.copy()
+        radarograms["Cleaned with alpha"] = cleaned
+        radarograms["Residual noisy-predicted"] = noisy_arr - pred_arr
+        if clean_arr is not None:
+            radarograms["Error map predicted-clean"] = pred_arr - clean_arr
+    elif clean_arr is not None:
+        radarograms["Residual noisy-clean"] = noisy_arr - clean_arr
+
+    if trace_index is None:
+        trace_index = noisy_arr.shape[0] // 2
+    trace_index = int(np.clip(trace_index, 0, noisy_arr.shape[0] - 1))
+    traces = {name: array[trace_index].copy() for name, array in radarograms.items()}
+    log_lines = [
+        title,
+        f"Shape: {tuple(noisy_arr.shape)}",
+        f"Trace comparison index: {trace_index}",
+        f"Alpha: {alpha:.3f}",
+        "Visible radarogram modes: " + ", ".join(radarograms.keys()),
+    ]
+    return VisualizationBundle(radarograms=radarograms, traces=traces, log_lines=log_lines)
+
+
+def build_training_metric_curves(history: Sequence[Mapping[str, object]]) -> Dict[str, List[float]]:
+    """Extract finite training curves from epoch history dictionaries."""
+
+    curves: Dict[str, List[float]] = {}
+    for key in ("train_loss", "val_loss", "train_clean_l1", "val_clean_l1"):
+        values: List[float] = []
+        for row in history or []:
+            try:
+                value = float(row.get(key))
+            except (TypeError, ValueError):
+                continue
+            if np.isfinite(value):
+                values.append(value)
+        if values:
+            curves[key] = values
+    return curves
+
+
+def build_experiment_log(*sections: object) -> str:
+    """Join non-empty UI log sections into a readable experiment log."""
+
+    return "\n\n".join(str(section).strip() for section in sections if str(section).strip())

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -28,6 +28,7 @@ from ml_air_clutter.pattern_library import NoisePattern, PatternLibrary
 from ml_air_clutter.preprocessing import Normalizer, build_preprocessing_report
 from ml_air_clutter.synthetic_clutter import generate_synthetic_clutter
 from ml_air_clutter.train import TrainingConfig, train_model
+from ml_air_clutter.visualization import build_experiment_log, build_paired_visualization, build_training_metric_curves
 from models_db.model import Profile, CurrentProfile, session
 from qt.ml_clutter_experiment_form import Ui_MLClutterExperiment
 
@@ -415,14 +416,16 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         if pair is None:
             self._show_dataset_stats("Select a clean/noisy pair before preview.")
             return
-        residual = pair["noisy"] - pair["clean"]
-        self._display_profile(residual, f"ML Clutter dataset {pair['pair_id']} residual diagnostic")
-        self._display_profile(pair["clean"], f"ML Clutter dataset {pair['pair_id']} clean target")
-        self._display_profile(pair["noisy"], f"ML Clutter dataset {pair['pair_id']} noisy input")
+        bundle = build_paired_visualization(
+            clean=pair["clean"],
+            noisy=pair["noisy"],
+            title=f"ML Clutter dataset {pair['pair_id']} paired preview",
+        )
+        self._display_visualization_bundle(bundle, f"ML Clutter dataset {pair['pair_id']}")
         self._show_dataset_stats(
             self._format_pair_validation_report(pair)
-            + "\n\nPreview order: residual diagnostic, clean target, noisy input. "
-            + "The main view is left on the noisy input, not on the centered residual."
+            + "\n\n"
+            + bundle.log_text()
         )
 
     def build_dataset(self):
@@ -452,13 +455,16 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             return
         rng = np.random.default_rng(int(self.ui.spinBox_gen_seed.value()))
         split, sample = available[int(rng.integers(0, len(available)))]
-        self._display_profile(sample["residual"], f"ML Clutter {split} patch residual diagnostic {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
-        self._display_profile(sample["clean"], f"ML Clutter {split} patch clean target {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
-        self._display_profile(sample["noisy"], f"ML Clutter {split} patch noisy input {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
+        bundle = build_paired_visualization(
+            clean=sample["clean"],
+            noisy=sample["noisy"],
+            title=f"ML Clutter {split} patch paired preview {sample['pair_id']} {sample['x_start']}:{sample['x_end']}",
+        )
+        self._display_visualization_bundle(bundle, f"ML Clutter {split} patch {sample['pair_id']} {sample['x_start']}:{sample['x_end']}")
         self._show_dataset_stats(
             json.dumps({k: v for k, v in sample.items() if k not in {"clean", "noisy", "residual"}}, indent=2, ensure_ascii=False)
-            + "\n\nPreview order: residual diagnostic, clean target, noisy input. "
-            + "The main view is left on the noisy input, not on the centered residual."
+            + "\n\n"
+            + bundle.log_text()
         )
 
     def save_dataset(self):
@@ -567,10 +573,14 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         )
 
     def _on_training_preview_ready(self, arrays):
-        self._display_profile(arrays["error"], "ML Clutter validation preview error clean_pred-clean")
-        self._display_profile(arrays["clean_pred"], "ML Clutter validation preview clean_pred")
-        self._display_profile(arrays["noisy"], "ML Clutter validation preview noisy")
-        self._display_profile(arrays["clean"], "ML Clutter validation preview clean")
+        bundle = build_paired_visualization(
+            clean=arrays["clean"],
+            noisy=arrays["noisy"],
+            clean_pred=arrays["clean_pred"],
+            alpha=float(self.ui.horizontalSlider_inference_alpha.value()) / 100.0,
+            title="ML Clutter validation preview",
+        )
+        self._display_visualization_bundle(bundle, "ML Clutter validation preview")
 
     def _on_training_finished(self, summary):
         self.training_summary = summary
@@ -578,7 +588,11 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self._show_training_stats("Training finished.\n" + json.dumps(summary, indent=2, ensure_ascii=False))
         metrics = summary.get("metrics", {})
         self.experiment_config["metrics"] = metrics
-        self._show_results_log(self._format_metrics_report(metrics, summary.get("metrics_report", "")))
+        curves = build_training_metric_curves(summary.get("history", []))
+        self._show_results_log(build_experiment_log(
+            self._format_metrics_report(metrics, summary.get("metrics_report", "")),
+            "Training metric curves available: " + ", ".join(curves.keys()) if curves else "Training metric curves are not available.",
+        ))
         self._open_metrics_window(summary)
         self._log(f"ML Clutter training finished: best_epoch={summary['best_epoch']}, best_val_loss={summary['best_validation_loss']:.6g}")
 
@@ -652,10 +666,16 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         if self.inference_result is None:
             self._show_inference_log("Run inference before previewing alpha-blended results.")
             return
-        self._display_profile(self.inference_result["residual"], "ML Clutter inference residual noisy-clean_pred")
-        self._display_profile(self.inference_result["cleaned"], "ML Clutter inference cleaned alpha blend")
-        self._display_profile(self.inference_result["clean_pred"], "ML Clutter inference clean_pred")
-        self._display_profile(self.inference_result["noisy"], "ML Clutter inference noisy source")
+        clean = self.clean_profile if self.clean_profile is not None and self.clean_profile.shape == self.inference_result["noisy"].shape else None
+        bundle = build_paired_visualization(
+            clean=clean,
+            noisy=self.inference_result["noisy"],
+            clean_pred=self.inference_result["clean_pred"],
+            alpha=float(self.inference_result.get("meta", {}).get("effective_alpha", 1.0)),
+            title="ML Clutter inference paired visualization",
+        )
+        self._display_visualization_bundle(bundle, "ML Clutter inference")
+        self._show_inference_log(build_experiment_log(self.inference_result.get("meta", {}), bundle.log_text()))
 
     def save_inference_result(self):
         if self.inference_result is None:
@@ -1233,6 +1253,13 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             f"Stats: {json.dumps(pattern.stats, indent=2)}",
         ])
 
+
+    def _display_visualization_bundle(self, bundle, title_prefix):
+        for mode, array in bundle.radarograms.items():
+            self._display_profile(array, f"{title_prefix}: {mode}")
+        trace_lines = [f"{name}: min={float(np.min(trace)):.6g}, max={float(np.max(trace)):.6g}" for name, trace in bundle.traces.items()]
+        if trace_lines:
+            self.ui.textEdit_results_log.append("Trace comparison\n" + "\n".join(trace_lines))
 
     def _display_profile(self, data, title):
         if self.visualization_callback:

--- a/tests/test_ml_air_clutter_visualization.py
+++ b/tests/test_ml_air_clutter_visualization.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+
+from ml_air_clutter.visualization import (
+    build_experiment_log,
+    build_paired_visualization,
+    build_training_metric_curves,
+)
+
+
+def test_build_paired_visualization_contains_stage_12_modes():
+    clean = np.full((3, 512), 100.0)
+    noisy = clean + 10.0
+    pred = clean + 2.0
+
+    bundle = build_paired_visualization(clean=clean, noisy=noisy, clean_pred=pred, alpha=0.5, trace_index=1)
+
+    assert list(bundle.radarograms) == [
+        "Noisy",
+        "Clean",
+        "Predicted clean",
+        "Cleaned with alpha",
+        "Residual noisy-predicted",
+        "Error map predicted-clean",
+    ]
+    np.testing.assert_allclose(bundle.radarograms["Cleaned with alpha"], 106.0)
+    np.testing.assert_allclose(bundle.radarograms["Residual noisy-predicted"], 8.0)
+    np.testing.assert_allclose(bundle.radarograms["Error map predicted-clean"], 2.0)
+    assert bundle.traces["Noisy"].shape == (512,)
+    assert "Trace comparison index: 1" in bundle.log_text()
+
+
+def test_build_paired_visualization_supports_pair_without_prediction():
+    clean = np.zeros((2, 512))
+    noisy = np.ones((2, 512))
+
+    bundle = build_paired_visualization(clean=clean, noisy=noisy)
+
+    assert "Residual noisy-clean" in bundle.radarograms
+    np.testing.assert_allclose(bundle.radarograms["Residual noisy-clean"], 1.0)
+
+
+def test_build_paired_visualization_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="does not match"):
+        build_paired_visualization(noisy=np.zeros((2, 512)), clean=np.zeros((3, 512)))
+
+
+def test_build_training_metric_curves_filters_non_finite_values():
+    curves = build_training_metric_curves([
+        {"train_loss": 2.0, "val_loss": 3.0},
+        {"train_loss": float("nan"), "val_loss": 1.0},
+    ])
+
+    assert curves["train_loss"] == [2.0]
+    assert curves["val_loss"] == [3.0, 1.0]
+
+
+def test_build_experiment_log_joins_non_empty_sections():
+    assert build_experiment_log(" first ", "", {"alpha": 1}) == "first\n\n{'alpha': 1}"


### PR DESCRIPTION
### Motivation

- Provide a single, testable visualization API for Stage 12 (paired pipeline) so dataset previews, training validation and inference previews share consistent modes and logs.
- Make the UI logic simpler and reusable by moving deterministic assembly of radarogram layers, trace comparisons and metric-curve extraction out of the Qt dialog.

### Description

- Added `ml_air_clutter/visualization.py` implementing `VisualizationBundle`, `build_paired_visualization`, `build_training_metric_curves` and `build_experiment_log` to assemble paired-view radarogram modes, traces and log text.
- Integrated the new API into `ml_clutter_experiment.py` so previews for dataset pairs, random patches, training validation previews and inference previews use the unified bundle and log output; added `_display_visualization_bundle` helper to emit bundle layers and trace diagnostics to the existing visualization callback/log.
- Exported the new helpers from `ml_air_clutter/__init__.py` so they are part of the package public API.
- Added unit tests `tests/test_ml_air_clutter_visualization.py` covering Stage-12 modes, shape validation, training curve extraction and experiment log assembly.

### Testing

- Ran static/quick checks: `python -B -m py_compile ml_air_clutter/visualization.py ml_clutter_experiment.py ml_air_clutter/__init__.py` and they passed.
- Attempted unit tests: `python -m pytest tests/test_ml_air_clutter_visualization.py` failed to run because the test environment lacks `numpy` (ModuleNotFoundError), blocking test execution.
- Attempted to install `numpy` with `pip`, but installation was blocked by network/proxy (403 Forbidden), so tests remain unexecuted in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8599b788832fb94978f44782fa54)