### PR TITLE
Add reproducible experiment artifact saving for ML Clutter

### DIFF
--- a/ml_air_clutter/__init__.py
+++ b/ml_air_clutter/__init__.py
@@ -6,6 +6,7 @@ from .pattern_library import NoisePattern, PatternLibrary
 from .pattern_generator import PatternClutterConfig, generate_pattern_clutter
 from .inference import InferenceConfig, blend_inference_result, run_full_profile_inference, save_inference_result
 from .preprocessing import NormalizationResult, Normalizer, build_preprocessing_report
+from .experiment_io import make_experiment_run_dir, save_experiment_artifacts
 from .metrics import paired_cleaning_metrics, summarize_metric_rows
 from .model import ModelConfig, count_parameters, create_model, load_model_checkpoint, save_model_checkpoint
 from .visualization import VisualizationBundle, build_experiment_log, build_paired_visualization, build_training_metric_curves
@@ -21,6 +22,8 @@ __all__ = [
     "run_full_profile_inference",
     "save_inference_result",
     "generate_pattern_clutter",
+    "make_experiment_run_dir",
+    "save_experiment_artifacts",
     "paired_cleaning_metrics",
     "summarize_metric_rows",
     "ModelConfig",

--- a/ml_air_clutter/experiment_io.py
+++ b/ml_air_clutter/experiment_io.py
@@ -1,0 +1,182 @@
+"""Persistence helpers for reproducible ML air-clutter experiment runs."""
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+
+def _json_safe(value):
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def make_experiment_run_dir(root="experiments/ml_clutter", experiment_name="experiment") -> Path:
+    """Create a timestamped run directory for a reproducible experiment."""
+
+    safe_name = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in str(experiment_name)).strip("_")
+    if not safe_name:
+        safe_name = "experiment"
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
+    root = Path(root)
+    candidate = root / f"{stamp}_{safe_name}"
+    suffix = 1
+    while candidate.exists():
+        candidate = root / f"{stamp}_{safe_name}_{suffix}"
+        suffix += 1
+    candidate.mkdir(parents=True, exist_ok=False)
+    return candidate
+
+
+def build_split_manifest(samples: Dict[str, List[Dict[str, object]]]) -> Dict[str, object]:
+    """Return a JSON-serializable manifest of train/validation/test patch membership."""
+
+    manifest = {"split_schema": "ml_air_clutter_split_v1", "splits": {}}
+    for split_name in ("train", "validation", "test"):
+        rows = []
+        for index, sample in enumerate(samples.get(split_name, [])):
+            rows.append({
+                "sample_index": index,
+                "pair_id": sample.get("pair_id", ""),
+                "source_clean_profile": sample.get("source_clean_profile", ""),
+                "source_noisy_profile": sample.get("source_noisy_profile", ""),
+                "x_start": int(sample.get("x_start", 0)),
+                "x_end": int(sample.get("x_end", 0)),
+                "normalization": sample.get("normalization", {}),
+                "sample_meta": sample.get("sample_meta", {}),
+            })
+        manifest["splits"][split_name] = rows
+    manifest["counts"] = {name: len(rows) for name, rows in manifest["splits"].items()}
+    return manifest
+
+
+def save_preview_arrays(preview_dir: Path, samples: Dict[str, List[Dict[str, object]]], training_summary: Optional[Dict[str, object]] = None) -> Dict[str, str]:
+    """Save deterministic preview arrays for later inspection."""
+
+    preview_dir.mkdir(parents=True, exist_ok=True)
+    saved = {}
+    sample = None
+    split_name = ""
+    for name in ("validation", "test", "train"):
+        if samples.get(name):
+            split_name = name
+            sample = samples[name][0]
+            break
+    if sample is not None:
+        for key in ("clean", "noisy", "residual"):
+            if key in sample:
+                path = preview_dir / f"{split_name}_{key}.npy"
+                np.save(path, np.asarray(sample[key]))
+                saved[f"{split_name}_{key}"] = str(path)
+    metrics = (training_summary or {}).get("metrics", {}) if isinstance(training_summary, dict) else {}
+    for split, payload in metrics.get("splits", {}).items():
+        path = preview_dir / f"{split}_metrics_preview.json"
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(_json_safe(payload.get("samples_preview", [])), fh, indent=2, ensure_ascii=False)
+        saved[f"{split}_metrics_preview"] = str(path)
+    return saved
+
+
+def write_markdown_report(path: Path, config: Dict[str, object], dataset_summary: Optional[Dict[str, object]], split_manifest: Dict[str, object], training_summary: Optional[Dict[str, object]], metrics: Optional[Dict[str, object]], preview_files: Dict[str, str]) -> Path:
+    """Write a compact reproducibility report for the experiment run."""
+
+    lines = [
+        "# ML Clutter experiment report",
+        "",
+        f"Generated at: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Reproducibility inputs",
+        f"- Seed: `{config.get('seed', config.get('generator_seed', 'unknown'))}`",
+        f"- Dataset schema: `{(dataset_summary or {}).get('dataset_schema', 'not built')}`",
+        f"- Split counts: `{split_manifest.get('counts', {})}`",
+        "",
+        "## Required artifacts",
+    ]
+    for filename in ("config.json", "dataset_summary.json", "split.json", "train_log.csv", "metrics.json", "model_best.pt"):
+        lines.append(f"- `{filename}`")
+    lines.extend(["", "## Training summary"])
+    if training_summary:
+        lines.extend([
+            f"- Best epoch: `{training_summary.get('best_epoch')}`",
+            f"- Best validation loss: `{training_summary.get('best_validation_loss')}`",
+            f"- Epochs completed: `{training_summary.get('epochs_completed')}`",
+            f"- Model best: `{training_summary.get('model_best')}`",
+            f"- Model last: `{training_summary.get('model_last')}`",
+        ])
+    else:
+        lines.append("Training has not been run yet.")
+    lines.extend(["", "## Metrics"])
+    for split, payload in (metrics or {}).get("splits", {}).items():
+        summary = payload.get("summary", {})
+        lines.append(
+            f"- **{split}**: samples={summary.get('num_samples', 0)}, "
+            f"MAE {summary.get('mae_before')} -> {summary.get('mae_after')}, "
+            f"SNR gain={summary.get('snr_gain_db')} dB"
+        )
+    lines.extend(["", "## Preview files"])
+    if preview_files:
+        lines.extend(f"- `{name}`: `{file_path}`" for name, file_path in sorted(preview_files.items()))
+    else:
+        lines.append("No preview arrays were available.")
+    lines.extend(["", "## Full configuration", "", "```json", json.dumps(_json_safe(config), indent=2, ensure_ascii=False), "```", ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _copy_if_exists(source, destination: Path) -> Optional[Path]:
+    if not source:
+        return None
+    source = Path(source)
+    if not source.exists() or source.resolve() == destination.resolve():
+        return source if source.exists() else None
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination
+
+
+def save_experiment_artifacts(directory, config: Dict[str, object], dataset_summary: Optional[Dict[str, object]], samples: Optional[Dict[str, List[Dict[str, object]]]], training_summary: Optional[Dict[str, object]] = None, metrics: Optional[Dict[str, object]] = None) -> Dict[str, str]:
+    """Persist the minimum reproducibility bundle for an ML Clutter run."""
+
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    config = dict(config or {})
+    config.setdefault("saved_at", datetime.now(timezone.utc).isoformat())
+    split_manifest = build_split_manifest(samples or {})
+    paths = {}
+    for filename, payload in (
+        ("config.json", config),
+        ("dataset_summary.json", dataset_summary or {}),
+        ("split.json", split_manifest),
+    ):
+        path = root / filename
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(_json_safe(payload), fh, indent=2, ensure_ascii=False)
+        paths[filename] = str(path)
+    training_summary = training_summary or {}
+    metrics = metrics or training_summary.get("metrics") or {}
+    if metrics:
+        metrics_path = root / "metrics.json"
+        with metrics_path.open("w", encoding="utf-8") as fh:
+            json.dump(_json_safe(metrics), fh, indent=2, ensure_ascii=False)
+        paths["metrics.json"] = str(metrics_path)
+    for source_key, filename in (("train_log", "train_log.csv"), ("model_best", "model_best.pt"), ("model_last", "model_last.pt")):
+        copied = _copy_if_exists(training_summary.get(source_key), root / filename)
+        if copied is not None:
+            paths[filename] = str(copied)
+    preview_files = save_preview_arrays(root / "previews", samples or {}, training_summary)
+    paths.update({f"previews/{name}": path for name, path in preview_files.items()})
+    report_path = write_markdown_report(root / "report.md", config, dataset_summary, split_manifest, training_summary, metrics, preview_files)
+    paths["report.md"] = str(report_path)
+    return paths

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -15,6 +15,7 @@ from ml_air_clutter.dataset import (
     save_dataset,
     validate_clean_noisy_pair,
 )
+from ml_air_clutter.experiment_io import make_experiment_run_dir, save_experiment_artifacts
 from ml_air_clutter.inference import InferenceConfig, blend_inference_result, run_full_profile_inference, save_inference_result
 from ml_air_clutter.model import ModelConfig, count_parameters, create_model, save_model_checkpoint
 from ml_air_clutter.noise_patterns import (
@@ -229,6 +230,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_summary = None
         self.metrics_window = None
         self.inference_result = None
+        self.current_experiment_dir = None
 
         self.ui.pushButton_refresh_profiles.clicked.connect(self.add_current_selected_profile)
         self.ui.pushButton_use_current_profile.clicked.connect(self.use_drawn_current_profile)
@@ -257,6 +259,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.ui.pushButton_run_inference.clicked.connect(self.run_inference)
         self.ui.pushButton_preview_inference.clicked.connect(self.preview_inference_result)
         self.ui.pushButton_save_inference.clicked.connect(self.save_inference_result)
+        self.ui.pushButton_save_experiment_artifacts.clicked.connect(self.save_experiment_artifacts)
         self.ui.horizontalSlider_inference_alpha.valueChanged.connect(self.update_inference_alpha)
         self.ui.listWidget_profiles.currentItemChanged.connect(lambda *_: self.show_selected_profile_stats())
         self.ui.listWidget_noisy_profiles.currentItemChanged.connect(lambda *_: self._on_noisy_source_changed())
@@ -555,6 +558,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_thread.start()
 
     def _current_training_config(self):
+        run_dir = make_experiment_run_dir(experiment_name="paired_direct_clean")
+        self.current_experiment_dir = run_dir
         return TrainingConfig(
             epochs=int(self.ui.spinBox_train_epochs.value()),
             batch_size=int(self.ui.spinBox_train_batch_size.value()),
@@ -562,6 +567,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             grad_loss_weight=float(self.ui.doubleSpinBox_train_grad_lambda.value()),
             early_stopping_patience=int(self.ui.spinBox_train_patience.value()),
             seed=int(self.ui.spinBox_gen_seed.value()),
+            output_dir=str(run_dir),
         )
 
     def _on_training_epoch_finished(self, metrics):
@@ -588,6 +594,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self._show_training_stats("Training finished.\n" + json.dumps(summary, indent=2, ensure_ascii=False))
         metrics = summary.get("metrics", {})
         self.experiment_config["metrics"] = metrics
+        self._save_current_experiment_artifacts(directory=summary.get("config", {}).get("output_dir"), quiet=True)
         curves = build_training_metric_curves(summary.get("history", []))
         self._show_results_log(build_experiment_log(
             self._format_metrics_report(metrics, summary.get("metrics_report", "")),
@@ -604,6 +611,71 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
         self.training_thread = None
         self.training_worker = None
         self.ui.pushButton_start_training.setEnabled(True)
+
+    def save_experiment_artifacts(self):
+        directory = QtWidgets.QFileDialog.getExistingDirectory(self, "Save reproducible ML clutter experiment")
+        if not directory:
+            return
+        self._save_current_experiment_artifacts(directory=directory, quiet=False)
+
+    def _save_current_experiment_artifacts(self, directory=None, quiet=False):
+        if self.dataset_samples is None or self.dataset_summary is None:
+            message = "Build the paired dataset before saving reproducible experiment artifacts."
+            if not quiet:
+                self._show_results_log(message)
+            return None
+        target_dir = Path(directory) if directory else (self.current_experiment_dir or make_experiment_run_dir(experiment_name="paired_direct_clean"))
+        self.current_experiment_dir = target_dir
+        config = self._current_reproducibility_config()
+        try:
+            paths = save_experiment_artifacts(
+                target_dir,
+                config=config,
+                dataset_summary=self.dataset_summary,
+                samples=self.dataset_samples,
+                training_summary=self.training_summary,
+                metrics=(self.training_summary or {}).get("metrics", self.experiment_config.get("metrics")),
+            )
+        except OSError as exc:
+            self._show_results_log(f"Failed to save experiment artifacts: {exc}")
+            self._log(f"ML Clutter reproducibility save failed: {exc}", "red")
+            return None
+        message = "Reproducible experiment artifacts saved:\n" + json.dumps(paths, indent=2, ensure_ascii=False)
+        if not quiet:
+            self._show_results_log(message)
+        else:
+            self.ui.textEdit_results_log.append(message)
+        self._log(f"ML Clutter reproducibility bundle saved: {target_dir}")
+        return paths
+
+    def _current_reproducibility_config(self):
+        return {
+            "experiment_schema": "ml_air_clutter_experiment_v1",
+            "seed": int(self.ui.spinBox_gen_seed.value()),
+            "normalization": self.experiment_config.get("normalization"),
+            "synthetic_clutter": self.experiment_config.get("synthetic_clutter"),
+            "pattern_clutter": self.experiment_config.get("pattern_clutter"),
+            "pattern_library": self.experiment_config.get("pattern_library"),
+            "dataset_config": self._current_dataset_config().to_dict(),
+            "dataset_pairs": [self._dataset_pair_manifest(pair) for pair in self.dataset_pairs],
+            "model": self.experiment_config.get("model"),
+            "training_config": (self.training_summary or {}).get("config"),
+            "inference_config": self._current_inference_config().to_dict(),
+        }
+
+    @staticmethod
+    def _dataset_pair_manifest(pair):
+        return {
+            "pair_id": pair.get("pair_id"),
+            "clean_name": pair.get("clean_name"),
+            "noisy_name": pair.get("noisy_name"),
+            "clean_path": pair.get("clean_path"),
+            "noisy_path": pair.get("noisy_path"),
+            "source_label": pair.get("source_label"),
+            "amplitude_range": pair.get("amplitude_range"),
+            "normalization": pair.get("normalization"),
+            "validation": pair.get("validation"),
+        }
 
     @staticmethod
     def _format_metrics_report(metrics, metrics_path=""):

--- a/qt/ml_clutter_experiment_form.py
+++ b/qt/ml_clutter_experiment_form.py
@@ -523,6 +523,9 @@ class Ui_MLClutterExperiment(object):
         tab = QtWidgets.QWidget()
         tab.setObjectName("tab_results")
         layout = QtWidgets.QVBoxLayout(tab)
+        self.pushButton_save_experiment_artifacts = QtWidgets.QPushButton(tab)
+        self.pushButton_save_experiment_artifacts.setObjectName("pushButton_save_experiment_artifacts")
+        layout.addWidget(self.pushButton_save_experiment_artifacts)
         self.textEdit_results_log = QtWidgets.QTextEdit(tab)
         self.textEdit_results_log.setReadOnly(True)
         self.textEdit_results_log.setObjectName("textEdit_results_log")
@@ -575,6 +578,7 @@ class Ui_MLClutterExperiment(object):
         self.pushButton_run_inference.setText(_translate("MLClutterExperiment", "Run Inference"))
         self.pushButton_preview_inference.setText(_translate("MLClutterExperiment", "Preview Current Alpha"))
         self.pushButton_save_inference.setText(_translate("MLClutterExperiment", "Save Result"))
+        self.pushButton_save_experiment_artifacts.setText(_translate("MLClutterExperiment", "Save Experiment Artifacts"))
         tab_names = ["Profiles", "Noise Patterns", "Generator", "Dataset", "Model", "Training", "Inference", "Results"]
         for index, name in enumerate(tab_names):
             self.tabWidget.setTabText(index, _translate("MLClutterExperiment", name))


### PR DESCRIPTION
### Motivation
- Ensure ML Clutter experiments are reproducible by persisting a minimal, self-contained bundle of inputs and outputs for each run.
- Provide deterministic previews and a compact human-readable `report.md` so results, splits and configs can be inspected and compared later.
- Expose a UI action to let users manually persist an experiment bundle and automatically persist artifacts after training completes.

### Description
- Added a new persistence helper module `ml_air_clutter/experiment_io.py` with `make_experiment_run_dir`, `save_experiment_artifacts`, `build_split_manifest`, `save_preview_arrays` and `write_markdown_report` to create timestamped run dirs and write `config.json`, `dataset_summary.json`, `split.json`, `metrics.json` (when available), previews, checkpoints/logs and `report.md`.
- Integrated the helpers into the experiment UI by exporting `make_experiment_run_dir`/`save_experiment_artifacts` from `ml_air_clutter/__init__.py` and wiring them into `MLClutterExperimentWindow` in `ml_clutter_experiment.py` to create per-run directories and automatically save reproducibility artifacts when training finishes.
- Added a Results-tab button `Save Experiment Artifacts` (UI in `qt/ml_clutter_experiment_form.py`) and implemented `save_experiment_artifacts` / `_save_current_experiment_artifacts` + `_current_reproducibility_config` to validate dataset presence, assemble manifest/config, and call the persistence helpers.
- The artifact bundle behavior includes deterministic preview arrays, split manifest, copying `train_log.csv` and best/last model checkpoints when present, and a compact `report.md` describing the run.

### Testing
- Performed static/compile checks with `python -m py_compile ml_air_clutter/experiment_io.py ml_air_clutter/__init__.py ml_clutter_experiment.py qt/ml_clutter_experiment_form.py`, which succeeded.
- Ran `git diff --check` style verification (`git diff --check HEAD~1..HEAD`) with no issues detected.
- Attempted a small smoke invocation of `save_experiment_artifacts` in a temporary directory, but it could not complete in the current environment due to missing runtime dependency `numpy` (error: `ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a89b35f7c832f8efa2cf3e9d41406)