### PR TITLE
Fix ML clutter pair amplitude preview

### DIFF
--- a/ml_air_clutter/dataset.py
+++ b/ml_air_clutter/dataset.py
@@ -43,6 +43,32 @@ def _stats(data: np.ndarray) -> Dict[str, float]:
     }
 
 
+def convert_profile_to_amplitude_0256(data) -> np.ndarray:
+    """Return a profile in the unsigned 0..256 amplitude display range.
+
+    ML Clutter stores paired clean/noisy supervised data as amplitude images in
+    ``0..256``. Some source profiles and synthetic generator outputs can still
+    be centered around zero (approximately ``-128..+128``). Those profiles must
+    be shifted by +128 before clipping so previews show the clean signal and the
+    signal with overlaid noise, not the centered residual/noise layer.
+    """
+
+    arr = np.asarray(data, dtype=float)
+    if arr.size and np.nanmin(arr) < 0.0:
+        arr = arr + 128.0
+    return np.clip(arr, 0.0, 256.0).copy()
+
+
+def prepare_amplitude_pair_0256(clean, noisy):
+    """Normalize a clean/noisy pair to the 0..256 ML Clutter amplitude range."""
+
+    clean_arr = np.asarray(clean, dtype=float)
+    noisy_arr = np.asarray(noisy, dtype=float)
+    if clean_arr.shape != noisy_arr.shape:
+        return clean_arr.copy(), noisy_arr.copy()
+    return convert_profile_to_amplitude_0256(clean_arr), convert_profile_to_amplitude_0256(noisy_arr)
+
+
 def validate_clean_noisy_pair(clean, noisy, min_num_traces: int = 1) -> Dict[str, object]:
     """Validate paired arrays and return errors plus diagnostic warnings."""
 

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -12,6 +12,7 @@ from ml_air_clutter.dataset import (
     PairValidationError,
     PatchDatasetConfig,
     build_paired_patch_dataset,
+    prepare_amplitude_pair_0256,
     save_dataset,
     validate_clean_noisy_pair,
 )
@@ -408,11 +409,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     @staticmethod
     def _prepare_dataset_amplitude_pair(clean, noisy):
-        clean = np.asarray(clean, dtype=float)
-        noisy = np.asarray(noisy, dtype=float)
-        if clean.shape != noisy.shape:
-            return clean.copy(), noisy.copy()
-        return np.clip(clean, 0.0, 256.0).copy(), np.clip(noisy, 0.0, 256.0).copy()
+        return prepare_amplitude_pair_0256(clean, noisy)
 
     def preview_selected_pair(self):
         pair = self._selected_dataset_pair()

--- a/tests/test_ml_air_clutter_dataset.py
+++ b/tests/test_ml_air_clutter_dataset.py
@@ -7,6 +7,7 @@ from ml_air_clutter.dataset import (
     PairValidationError,
     PatchDatasetConfig,
     build_paired_patch_dataset,
+    prepare_amplitude_pair_0256,
     save_dataset,
     validate_clean_noisy_pair,
 )
@@ -77,3 +78,23 @@ def test_save_dataset_writes_summary_and_npz_samples(tmp_path):
     loaded_summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert loaded_summary["dataset_schema"] == "paired_clean_noisy_v1"
     assert list((tmp_path / "train").glob("*.npz"))
+
+
+def test_prepare_amplitude_pair_shifts_centered_profiles_to_0256():
+    clean = np.array([[-128.0, 0.0, 127.0, 128.0]])
+    noisy = np.array([[-100.0, 20.0, 128.0, 140.0]])
+
+    clean_0256, noisy_0256 = prepare_amplitude_pair_0256(clean, noisy)
+
+    np.testing.assert_allclose(clean_0256, [[0.0, 128.0, 255.0, 256.0]])
+    np.testing.assert_allclose(noisy_0256, [[28.0, 148.0, 256.0, 256.0]])
+
+
+def test_prepare_amplitude_pair_keeps_existing_0256_profiles():
+    clean = np.array([[0.0, 64.0, 128.0, 256.0]])
+    noisy = np.array([[10.0, 80.0, 140.0, 260.0]])
+
+    clean_0256, noisy_0256 = prepare_amplitude_pair_0256(clean, noisy)
+
+    np.testing.assert_allclose(clean_0256, clean)
+    np.testing.assert_allclose(noisy_0256, [[10.0, 80.0, 140.0, 256.0]])


### PR DESCRIPTION
### Motivation
- Previewing a dataset pair showed centered noise values (roughly -128..+128) instead of the expected unsigned amplitude images in the 0..256 display range, hiding the clean signal and noisy overlay.

### Description
- Add `convert_profile_to_amplitude_0256` and `prepare_amplitude_pair_0256` helpers to `ml_air_clutter/dataset.py` to shift centered profiles by +128 and clip to `0..256` before use.
- Replace the inline clipping in the Dataset UI with a call to `prepare_amplitude_pair_0256` by updating `MLClutterExperimentWindow._prepare_dataset_amplitude_pair` in `ml_clutter_experiment.py`.
- Add regression tests `test_prepare_amplitude_pair_shifts_centered_profiles_to_0256` and `test_prepare_amplitude_pair_keeps_existing_0256_profiles` to `tests/test_ml_air_clutter_dataset.py` to cover centered (-128..+128) and already-unsigned (0..256) inputs.

### Testing
- Ran `python -m compileall ml_air_clutter/dataset.py ml_clutter_experiment.py tests/test_ml_air_clutter_dataset.py` which succeeded.
- Ran `pytest tests/test_ml_air_clutter_dataset.py tests/test_ml_air_clutter_visualization.py` in the current environment and it failed during collection with `ModuleNotFoundError: No module named 'numpy'` (environment dependency issue); CI runs with numpy should exercise the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8f20447c832fb6fbb1ba08dce130)