### PR TITLE
Normalize profiles to 0..256, add pair preparation and visualization flag

### DIFF
--- a/ml_air_clutter/dataset.py
+++ b/ml_air_clutter/dataset.py
@@ -43,6 +43,31 @@ def _stats(data: np.ndarray) -> Dict[str, float]:
     }
 
 
+def convert_profile_to_amplitude_0256(data) -> np.ndarray:
+    """Return a profile in the unsigned 0..256 amplitude display range.
+
+    ML Clutter source profiles are canonicalized at ingestion time so clean,
+    noisy and generated profiles are stored as amplitude images in ``0..256``.
+    If an external profile is still centered around zero, shift it once before
+    it enters the experiment state.
+    """
+
+    arr = np.asarray(data, dtype=float)
+    if arr.size and np.nanmin(arr) < 0.0:
+        arr = arr + 128.0
+    return np.clip(arr, 0.0, 256.0).copy()
+
+
+def prepare_amplitude_pair_0256(clean, noisy):
+    """Clip an already-canonical clean/noisy source pair to 0..256."""
+
+    clean_arr = np.asarray(clean, dtype=float)
+    noisy_arr = np.asarray(noisy, dtype=float)
+    if clean_arr.shape != noisy_arr.shape:
+        return clean_arr.copy(), noisy_arr.copy()
+    return np.clip(clean_arr, 0.0, 256.0).copy(), np.clip(noisy_arr, 0.0, 256.0).copy()
+
+
 def validate_clean_noisy_pair(clean, noisy, min_num_traces: int = 1) -> Dict[str, object]:
     """Validate paired arrays and return errors plus diagnostic warnings."""
 

--- a/ml_air_clutter/visualization.py
+++ b/ml_air_clutter/visualization.py
@@ -49,13 +49,16 @@ def build_paired_visualization(
     alpha: float = 1.0,
     trace_index: Optional[int] = None,
     title: str = "ML Clutter paired visualization",
+    include_pair_residual: bool = True,
 ) -> VisualizationBundle:
     """Build mandatory Stage-12 paired-pipeline visual layers.
 
     Required mode is ``Noisy``.  If ``clean`` is supplied the bundle includes
     ``Clean`` and, when prediction is available, ``Error map predicted-clean``.
     If ``clean_pred`` is supplied it also includes ``Predicted clean``,
-    ``Cleaned with alpha`` and ``Residual noisy-predicted``.
+    ``Cleaned with alpha`` and ``Residual noisy-predicted``. For dataset-pair
+    previews, ``include_pair_residual=False`` keeps the bundle to the actual
+    supervised pair only: clean target and noisy input.
     """
 
     noisy_arr = _as_2d("noisy", noisy)
@@ -63,9 +66,12 @@ def build_paired_visualization(
     pred_arr = _same_shape("noisy", noisy_arr, "clean_pred", clean_pred) if clean_pred is not None else None
     alpha = float(np.clip(alpha, 0.0, 1.0))
 
-    radarograms: Dict[str, np.ndarray] = {"Noisy": noisy_arr.copy()}
-    if clean_arr is not None:
-        radarograms["Clean"] = clean_arr.copy()
+    if clean_arr is not None and not include_pair_residual and pred_arr is None:
+        radarograms: Dict[str, np.ndarray] = {"Clean": clean_arr.copy(), "Noisy": noisy_arr.copy()}
+    else:
+        radarograms = {"Noisy": noisy_arr.copy()}
+        if clean_arr is not None:
+            radarograms["Clean"] = clean_arr.copy()
     if pred_arr is not None:
         cleaned = (1.0 - alpha) * noisy_arr + alpha * pred_arr
         radarograms["Predicted clean"] = pred_arr.copy()
@@ -73,7 +79,7 @@ def build_paired_visualization(
         radarograms["Residual noisy-predicted"] = noisy_arr - pred_arr
         if clean_arr is not None:
             radarograms["Error map predicted-clean"] = pred_arr - clean_arr
-    elif clean_arr is not None:
+    elif clean_arr is not None and include_pair_residual:
         radarograms["Residual noisy-clean"] = noisy_arr - clean_arr
 
     if trace_index is None:

--- a/ml_clutter_experiment.py
+++ b/ml_clutter_experiment.py
@@ -12,6 +12,8 @@ from ml_air_clutter.dataset import (
     PairValidationError,
     PatchDatasetConfig,
     build_paired_patch_dataset,
+    convert_profile_to_amplitude_0256,
+    prepare_amplitude_pair_0256,
     save_dataset,
     validate_clean_noisy_pair,
 )
@@ -286,7 +288,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             self._show_stats(f"Profile id{profile_id} was not found in the database.")
             self._log(f"ML Clutter: profile id{profile_id} was not found", "red")
             return
-        data = self._profile_signal_to_array(profile.signal)
+        data = convert_profile_to_amplitude_0256(self._profile_signal_to_array(profile.signal))
         self.experiment_profiles[profile.id] = {"profile": profile, "data": data}
 
         existing_item = self._find_experiment_item(profile.id)
@@ -408,11 +410,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
 
     @staticmethod
     def _prepare_dataset_amplitude_pair(clean, noisy):
-        clean = np.asarray(clean, dtype=float)
-        noisy = np.asarray(noisy, dtype=float)
-        if clean.shape != noisy.shape:
-            return clean.copy(), noisy.copy()
-        return np.clip(clean, 0.0, 256.0).copy(), np.clip(noisy, 0.0, 256.0).copy()
+        return prepare_amplitude_pair_0256(clean, noisy)
 
     def preview_selected_pair(self):
         pair = self._selected_dataset_pair()
@@ -423,6 +421,7 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
             clean=pair["clean"],
             noisy=pair["noisy"],
             title=f"ML Clutter dataset {pair['pair_id']} paired preview",
+            include_pair_residual=False,
         )
         self._display_visualization_bundle(bundle, f"ML Clutter dataset {pair['pair_id']}")
         self._show_dataset_stats(
@@ -1194,6 +1193,8 @@ class MLClutterExperimentWindow(QtWidgets.QDialog):
                 data = data.T
                 validation = self.validate_profile(data)
                 validation["transposed"] = True
+        if validation["valid"]:
+            data = convert_profile_to_amplitude_0256(data)
         return data, validation
 
     @classmethod

--- a/tests/test_ml_air_clutter_dataset.py
+++ b/tests/test_ml_air_clutter_dataset.py
@@ -7,6 +7,8 @@ from ml_air_clutter.dataset import (
     PairValidationError,
     PatchDatasetConfig,
     build_paired_patch_dataset,
+    convert_profile_to_amplitude_0256,
+    prepare_amplitude_pair_0256,
     save_dataset,
     validate_clean_noisy_pair,
 )
@@ -77,3 +79,21 @@ def test_save_dataset_writes_summary_and_npz_samples(tmp_path):
     loaded_summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert loaded_summary["dataset_schema"] == "paired_clean_noisy_v1"
     assert list((tmp_path / "train").glob("*.npz"))
+
+
+def test_convert_profile_to_amplitude_0256_canonicalizes_centered_source():
+    source = np.array([[-128.0, 0.0, 127.0, 128.0]])
+
+    canonical = convert_profile_to_amplitude_0256(source)
+
+    np.testing.assert_allclose(canonical, [[0.0, 128.0, 255.0, 256.0]])
+
+
+def test_prepare_amplitude_pair_keeps_existing_0256_profiles():
+    clean = np.array([[0.0, 64.0, 128.0, 256.0]])
+    noisy = np.array([[10.0, 80.0, 140.0, 260.0]])
+
+    clean_0256, noisy_0256 = prepare_amplitude_pair_0256(clean, noisy)
+
+    np.testing.assert_allclose(clean_0256, clean)
+    np.testing.assert_allclose(noisy_0256, [[10.0, 80.0, 140.0, 256.0]])

--- a/tests/test_ml_air_clutter_visualization.py
+++ b/tests/test_ml_air_clutter_visualization.py
@@ -40,6 +40,18 @@ def test_build_paired_visualization_supports_pair_without_prediction():
     np.testing.assert_allclose(bundle.radarograms["Residual noisy-clean"], 1.0)
 
 
+def test_build_paired_visualization_can_show_dataset_pair_without_residual():
+    clean = np.full((2, 512), 128.0)
+    noisy = clean + 20.0
+
+    bundle = build_paired_visualization(clean=clean, noisy=noisy, include_pair_residual=False)
+
+    assert list(bundle.radarograms) == ["Clean", "Noisy"]
+    np.testing.assert_allclose(bundle.radarograms["Clean"], 128.0)
+    np.testing.assert_allclose(bundle.radarograms["Noisy"], 148.0)
+    assert "Residual noisy-clean" not in bundle.radarograms
+
+
 def test_build_paired_visualization_rejects_shape_mismatch():
     with pytest.raises(ValueError, match="does not match"):
         build_paired_visualization(noisy=np.zeros((2, 512)), clean=np.zeros((3, 512)))


### PR DESCRIPTION
### Motivation

- Ensure external profiles are canonicalized to the same amplitude display range used by the dataset format (`0..256`).
- Provide a small, reusable utility to clip already-canonical pairs and avoid accidental negative-centered inputs in the experiment state.
- Allow dataset preview mode to optionally omit residuals so paired dataset previews show only the supervised pair.

### Description

- Added `convert_profile_to_amplitude_0256` to shift zero-centered profiles by `+128` when negative values are present and clip results into `0..256` using `np.clip`.
- Added `prepare_amplitude_pair_0256` to clip matching clean/noisy arrays into `0..256` while preserving mismatched shapes unchanged.
- Updated UI/experiment code to call `convert_profile_to_amplitude_0256` when profiles are loaded or added and to use `prepare_amplitude_pair_0256` when preparing dataset pairs.
- Added `include_pair_residual` parameter to `build_paired_visualization` to optionally suppress the `Residual noisy-clean` output for clean/noisy-only previews and wired the preview call to pass `include_pair_residual=False`.

### Testing

- Ran `tests/test_ml_air_clutter_dataset.py` which includes `test_convert_profile_to_amplitude_0256_canonicalizes_centered_source` and `test_prepare_amplitude_pair_keeps_existing_0256_profiles`, and they passed.
- Ran `tests/test_ml_air_clutter_visualization.py` which includes `test_build_paired_visualization_can_show_dataset_pair_without_residual`, and it passed.
- Existing dataset and visualization unit tests were executed and all asserted expectations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8f20447c832fb6fbb1ba08dce130)