### PR TITLE
Normalize paired amplitude handling and map model outputs to 0..256 domain

### DIFF
--- a/ml_air_clutter/dataset.py
+++ b/ml_air_clutter/dataset.py
@@ -59,12 +59,23 @@ def convert_profile_to_amplitude_0256(data) -> np.ndarray:
 
 
 def prepare_amplitude_pair_0256(clean, noisy):
-    """Clip an already-canonical clean/noisy source pair to 0..256."""
+    """Return a clean/noisy pair in the unsigned 0..256 amplitude range.
+
+    Some source radarograms are stored as centered signed amplitudes
+    (approximately ``-128..+128``), while the ML Clutter training pipeline
+    expects image-like unsigned amplitudes.  For paired data the same affine
+    shift must be applied to both clean and noisy arrays before clipping;
+    otherwise negative half-waves would be flattened to zero and the model would
+    learn a distorted target range.
+    """
 
     clean_arr = np.asarray(clean, dtype=float)
     noisy_arr = np.asarray(noisy, dtype=float)
     if clean_arr.shape != noisy_arr.shape:
-        return clean_arr.copy(), noisy_arr.copy()
+        return convert_profile_to_amplitude_0256(clean_arr), convert_profile_to_amplitude_0256(noisy_arr)
+    if clean_arr.size and noisy_arr.size and (np.nanmin(clean_arr) < 0.0 or np.nanmin(noisy_arr) < 0.0):
+        clean_arr = clean_arr + 128.0
+        noisy_arr = noisy_arr + 128.0
     return np.clip(clean_arr, 0.0, 256.0).copy(), np.clip(noisy_arr, 0.0, 256.0).copy()
 
 

--- a/ml_air_clutter/train.py
+++ b/ml_air_clutter/train.py
@@ -143,10 +143,23 @@ def _validation_preview(model, sample, channels, device):
     model.eval()
     with torch.no_grad():
         x = torch.from_numpy(make_input_channels(sample["noisy"], channels)[None, ...] / 256.0).to(device)
-        pred = model(x).detach().cpu().numpy()[0, 0] * 256.0
+        pred = _prediction_to_amplitude_0256(model(x).detach().cpu().numpy()[0, 0])
     clean = np.asarray(sample["clean"], dtype=float)
     noisy = np.asarray(sample["noisy"], dtype=float)
     return {"clean": clean, "noisy": noisy, "clean_pred": pred, "error": pred - clean}
+
+
+def _prediction_to_amplitude_0256(prediction: np.ndarray) -> np.ndarray:
+    """Convert normalized model output to display/original ML amplitude range.
+
+    The networks use an unconstrained final convolution, so raw normalized
+    predictions can be below 0 or above 1 while the model is still converging.
+    Downstream previews, metrics and saved inference artifacts should represent
+    the restored clean signal in the same 0..256 amplitude domain as the paired
+    clean/noisy data, not the unconstrained activation domain.
+    """
+
+    return np.clip(np.asarray(prediction, dtype=np.float32) * 256.0, 0.0, 256.0)
 
 
 def train_model(
@@ -271,7 +284,7 @@ def evaluate_model_on_splits(model, model_config: ModelConfig, samples: Dict[str
         for index, sample in enumerate(split_samples):
             with torch.no_grad():
                 x = torch.from_numpy(make_input_channels(sample["noisy"], model_config.input_channels)[None, ...] / 256.0).to(device)
-                prediction = model(x).detach().cpu().numpy()[0, 0] * 256.0
+                prediction = _prediction_to_amplitude_0256(model(x).detach().cpu().numpy()[0, 0])
             metrics = paired_cleaning_metrics(sample["clean"], sample["noisy"], prediction, data_range=256.0)
             metrics.update({
                 "sample_index": index,

--- a/tests/test_ml_air_clutter_dataset.py
+++ b/tests/test_ml_air_clutter_dataset.py
@@ -97,3 +97,13 @@ def test_prepare_amplitude_pair_keeps_existing_0256_profiles():
 
     np.testing.assert_allclose(clean_0256, clean)
     np.testing.assert_allclose(noisy_0256, [[10.0, 80.0, 140.0, 256.0]])
+
+
+def test_prepare_amplitude_pair_shifts_centered_pair_before_clipping():
+    clean = np.array([[-100.0, 0.0, 100.0]])
+    noisy = np.array([[-120.0, 10.0, 120.0]])
+
+    clean_0256, noisy_0256 = prepare_amplitude_pair_0256(clean, noisy)
+
+    np.testing.assert_allclose(clean_0256, [[28.0, 128.0, 228.0]])
+    np.testing.assert_allclose(noisy_0256, [[8.0, 138.0, 248.0]])

--- a/tests/test_ml_air_clutter_inference.py
+++ b/tests/test_ml_air_clutter_inference.py
@@ -3,6 +3,7 @@ import pytest
 
 from ml_air_clutter.inference import InferenceConfig, blend_inference_result, run_full_profile_inference
 from ml_air_clutter.model import ModelConfig
+from ml_air_clutter.train import _prediction_to_amplitude_0256
 
 
 torch = pytest.importorskip("torch")
@@ -37,3 +38,11 @@ def test_blend_inference_result_uses_alpha_between_noisy_and_prediction():
     np.testing.assert_allclose(blended["cleaned"], 6.0)
     np.testing.assert_allclose(blended["residual"], 8.0)
     assert blended["alpha"] == 0.5
+
+
+def test_prediction_to_amplitude_clips_unconstrained_model_output():
+    normalized_prediction = np.array([[-0.5, 0.25, 1.5]], dtype=np.float32)
+
+    amplitude = _prediction_to_amplitude_0256(normalized_prediction)
+
+    np.testing.assert_allclose(amplitude, [[0.0, 64.0, 256.0]])


### PR DESCRIPTION
### Motivation

- Ensure paired clean/noisy profiles are converted to a common unsigned amplitude domain so affine shifts are applied consistently and negative-centered sources are not clipped asymmetrically.  
- Ensure model outputs used for previews, metrics and saved inference artifacts are represented in the same 0..256 amplitude range as the training data.  

### Description

- Update `prepare_amplitude_pair_0256` to return arrays in the unsigned `0..256` range, converting mismatched-shaped inputs via `convert_profile_to_amplitude_0256`, and applying a single `+128` shift to both clean and noisy arrays when either contains negative values before clipping.  
- Add `_prediction_to_amplitude_0256` in `train.py` and replace inline `* 256.0` usages in `_validation_preview` and `evaluate_model_on_splits` with this helper to clamp and convert normalized model outputs into the `0..256` amplitude domain.  
- Expand docstrings to explain the intent and preserve existing behavior for already-canonical `0..256` profiles.  
- Add unit tests `test_prepare_amplitude_pair_shifts_centered_pair_before_clipping` and `test_prediction_to_amplitude_clips_unconstrained_model_output` and adjust dataset/inference tests accordingly.  

### Testing

- Ran the repository test suite with `pytest` including `tests/test_ml_air_clutter_dataset.py` and `tests/test_ml_air_clutter_inference.py`.  
- The added tests `test_prepare_amplitude_pair_shifts_centered_pair_before_clipping` and `test_prediction_to_amplitude_clips_unconstrained_model_output` were executed as part of the suite and passed.  
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b72b53b70832fb697f487b0c39373)