### PR TITLE
Align graph viewport with radarogram color scale

### DIFF
--- a/object.py
+++ b/object.py
@@ -196,7 +196,24 @@ radarogramma.addItem(img)
 
 hist = pg.HistogramLUTItem(gradientPosition='left')
 
+# The radarogram and the profile graph are stacked vertically, but the
+# radarogram row also contains a HistogramLUTItem (colour scale) to the
+# right of the image.  Without reserving the same horizontal space in
+# ui.graph, both widgets can have the same X range while their plotting
+# areas have different pixel widths, so vertical markers and curves look
+# shifted relative to each other.  Keep the colour scale width fixed and
+# add an invisible right axis with the same width to the graph; this makes
+# the radarogram ViewBox and graph ViewBox parallel on screen.
+RADAROGRAM_COLOR_SCALE_WIDTH = 80
+hist.setMaximumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+hist.setMinimumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
 ui.radarogram.addItem(hist)
+
+graph_right_axis = ui.graph.getAxis('right')
+graph_right_axis.setWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+graph_right_axis.setStyle(showValues=False)
+graph_right_axis.setPen(pg.mkPen(None))
+ui.graph.showAxis('right', True)
 
 
 roi = pg.ROI(pos=[0, 0], size=[ui.spinBox_roi.value(), 512], maxBounds=QRect(0, 0, 100000000, 512))


### PR DESCRIPTION
### Motivation
- The radarogram widget includes a `HistogramLUTItem` (colour scale) at the right edge which reduces the image plotting area width, so when `ui.graph` and the radarogram share the same X range their visible plotting areas differ and vertical markers/curves appear misaligned.
- Make the graph and radarogram viewports use the same pixel width so vertical lines and curves are visually parallel and coincident.

### Description
- In `object.py` reserve a fixed width for the radarogram colour scale by adding `RADAROGRAM_COLOR_SCALE_WIDTH` and calling `hist.setMaximumWidth(...)` and `hist.setMinimumWidth(...)` on the `HistogramLUTItem`.
- Add an invisible right axis to the profile `ui.graph` with the same width using `ui.graph.getAxis('right')`, `setWidth(...)`, `setStyle(showValues=False)`, `setPen(pg.mkPen(None))` and `ui.graph.showAxis('right', True)` so the graph ViewBox occupies the same horizontal pixel area as the radarogram ViewBox.

### Testing
- Ran `python -m py_compile object.py draw.py` to verify the modified modules compile successfully, and the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d124a3120832f884a19ff78d75668)