### PR TITLE
Align profile graph to radarogram viewbox and fix image range handling

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -99,7 +99,8 @@ def change_background():
 
 def on_range_changed():
     X, Y = radarogramma.viewRange()
-    ui.graph.setXRange(X[0], X[1])
+    ui.graph.setXRange(X[0], X[1], padding=0)
+    schedule_graph_alignment()
 
 
 def crop_from_right(image):

--- a/func.py
+++ b/func.py
@@ -254,7 +254,10 @@ def draw_image(radar):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -271,6 +274,7 @@ def draw_image(radar):
         radarogramma.getAxis('left').setScale(8)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
 
 def draw_image_deep_prof(radar, scale):
@@ -342,7 +346,10 @@ def draw_image_deep_prof(radar, scale):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -351,6 +358,7 @@ def draw_image_deep_prof(radar, scale):
     radarogramma.getAxis('left').setScale(scale)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
     # radarogramma.removeItem(roi)
 

--- a/object.py
+++ b/object.py
@@ -14,7 +14,7 @@ from models_db.model_cluster import *
 
 import tqdm as tqdm
 from PIL import Image, ImageDraw, ImageFont
-from PyQt5.QtCore import QRect, Qt
+from PyQt5.QtCore import QRect, Qt, QTimer
 from PyQt5.QtWidgets import QFileDialog, QCheckBox, QListWidgetItem, QApplication, QMessageBox, QColorDialog, QTableWidget, QTableWidgetItem
 from PyQt5.QtGui import QBrush, QColor, QCursor
 from pyqtgraph.Qt import QtWidgets
@@ -196,7 +196,97 @@ radarogramma.addItem(img)
 
 hist = pg.HistogramLUTItem(gradientPosition='left')
 
+# The radarogram and the profile graph are stacked vertically, but their
+# plotting areas can be narrowed by different decorations and by small
+# GraphicsView/Layout margins.  Keep the large side areas predictable, then
+# measure the real on-screen ViewBox positions after Qt has laid out the
+# widgets and compensate the graph axes so both plotting rectangles start and
+# end at the same pixels.
+RADAROGRAM_COLOR_SCALE_WIDTH = 80
+RADAROGRAM_LEFT_AXIS_WIDTH = 75
+hist.setMaximumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+hist.setMinimumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
 ui.radarogram.addItem(hist)
+
+for graphics_view in (ui.radarogram, ui.graph):
+    graphics_view.setContentsMargins(0, 0, 0, 0)
+    graphics_view.setFrameStyle(QtWidgets.QFrame.NoFrame)
+
+for plot_item in (radarogramma, ui.graph.plotItem):
+    plot_item.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setHorizontalSpacing(0)
+    plot_item.vb.setDefaultPadding(0)
+
+for axis in (radarogramma.getAxis('left'), ui.graph.getAxis('left')):
+    axis.setWidth(RADAROGRAM_LEFT_AXIS_WIDTH)
+    axis.setStyle(tickTextOffset=5, tickLength=5)
+
+graph_right_axis = ui.graph.getAxis('right')
+graph_right_axis.setWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+graph_right_axis.setStyle(showValues=False)
+graph_right_axis.setPen(pg.mkPen(None))
+ui.graph.showAxis('right', True)
+
+
+def align_graph_to_radarogram():
+    """Align profile graph ViewBox to the radarogram ViewBox in widget pixels.
+
+    Fixed axis widths remove most of the offset, but PyQtGraph's
+    GraphicsLayoutWidget and PlotWidget can still keep slightly different
+    scene/layout margins.  Measuring the actual ViewBox rectangles after Qt
+    layout gives the exact remaining offset and lets us compensate it through
+    the graph's left/right reserved axis space.
+    """
+    try:
+        radar_rect = radarogramma.vb.sceneBoundingRect()
+        graph_rect = ui.graph.plotItem.vb.sceneBoundingRect()
+        if not radar_rect.isValid() or not graph_rect.isValid():
+            return
+
+        radar_left = ui.radarogram.mapFromScene(radar_rect.topLeft()).x()
+        graph_left = ui.graph.mapFromScene(graph_rect.topLeft()).x()
+        radar_right = ui.radarogram.mapFromScene(radar_rect.topRight()).x()
+        graph_right = ui.graph.mapFromScene(graph_rect.topRight()).x()
+
+        graph_left_axis = ui.graph.getAxis('left')
+        graph_right_axis = ui.graph.getAxis('right')
+        left_width = graph_left_axis.width() + radar_left - graph_left
+        right_width = graph_right_axis.width() + graph_right - radar_right
+
+        graph_left_axis.setWidth(max(0, int(round(left_width))))
+        graph_right_axis.setWidth(max(0, int(round(right_width))))
+    except Exception:
+        # Alignment is a visual convenience; never block the application if a
+        # widget is not ready during startup or teardown.
+        pass
+
+def schedule_graph_alignment():
+    QTimer.singleShot(0, align_graph_to_radarogram)
+
+
+# Backward-compatible aliases: func.py imports object.py with `from object
+# import *`, so leading-underscore helpers are not exported.  Keep the old
+# spelling and the misspelled variant safe for any existing callbacks.
+_schedule_graph_alignment = schedule_graph_alignment
+_schedule_graph_aligment = schedule_graph_alignment
+schedule_graph_aligment = schedule_graph_alignment
+
+
+def _wrap_resize_alignment(widget):
+    original_resize_event = widget.resizeEvent
+
+    def resize_event(event):
+        original_resize_event(event)
+        schedule_graph_alignment()
+
+    widget.resizeEvent = resize_event
+
+
+_wrap_resize_alignment(ui.radarogram)
+_wrap_resize_alignment(ui.graph)
+schedule_graph_alignment()
+QTimer.singleShot(100, align_graph_to_radarogram)
 
 
 roi = pg.ROI(pos=[0, 0], size=[ui.spinBox_roi.value(), 512], maxBounds=QRect(0, 0, 100000000, 512))


### PR DESCRIPTION
### Motivation
- Ensure the profile graph plotting area lines up exactly with the radarogram plotting area so axes and color scales visually match. 
- Remove inconsistent automatic padding when displaying image data so the displayed ranges correspond exactly to the image pixel grid. 
- Make layout and alignment robust across widget resize and initial Qt layout timing.

### Description
- Added layout and alignment helpers in `object.py`: fixed color-scale and left-axis widths, removed extra margins on plot widgets, and implemented `align_graph_to_radarogram` and `schedule_graph_alignment` (with `QTimer`) to measure scene rectangles and adjust axis widths to align the two ViewBoxes; wrapped resize events to re-schedule alignment and invoked alignment at startup. 
- Kept backward-compatible aliases for the new scheduling function and imported `QTimer` where required. 
- Updated image handling in `func.py` to convert `radar` to a NumPy array (`radar_array`) before calling `img.setImage(...)` and set explicit ranges on `radarogramma` via `setXRange`/`setYRange` with `padding=0`, and call `schedule_graph_alignment()` after drawing. 
- Updated `draw.py` to call `ui.graph.setXRange` with `padding=0` and to schedule graph alignment on range changes.

### Testing
- No automated tests were added for these UI/layout changes. 
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d124a3120832f884a19ff78d75668)