### PR TITLE
Align profile graph to radarogram view, fix export sizing and padding

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -99,7 +99,8 @@ def change_background():
 
 def on_range_changed():
     X, Y = radarogramma.viewRange()
-    ui.graph.setXRange(X[0], X[1])
+    ui.graph.setXRange(X[0], X[1], padding=0)
+    schedule_graph_alignment()
 
 
 def crop_from_right(image):
@@ -208,6 +209,8 @@ def save_image():
 
     # Создаем объект экспортера PyQtGraph для основного изображения и настраиваем фиксированный размер изображения
     exporter = ImageExporter(radarogramma)
+    export_width = 868
+    exporter.parameters()['width'] = export_width
     exporter.parameters()['height'] = 610
     count_measure = len(
         json.loads(session.query(Profile.signal).filter(Profile.id == get_profile_id()).first()[0]))
@@ -217,9 +220,12 @@ def save_image():
 
     # Сохранение изображения с графиком
     if ui.checkBox_save_graph.isChecked():
-        # Создаем объект экспортера для графика
-        graph_exporter = ImageExporter(ui.graph.scene())
-        graph_exporter.parameters()['width'] = 868
+        # Создаем объект экспортера для графика. Экспортируем именно PlotItem,
+        # а не всю scene(), и используем ту же ширину, что у радарограммы.
+        # Так сохраненное изображение получает те же служебные отступы слева/справа,
+        # что и видимое окно после align_graph_to_radarogram().
+        graph_exporter = ImageExporter(ui.graph.plotItem)
+        graph_exporter.parameters()['width'] = export_width
 
         list_paths = []
         list_graphs = []
@@ -232,6 +238,8 @@ def save_image():
             m = n + 400
             radarogramma.setXRange(n, m, padding=0)
             ui.graph.setXRange(n, m, padding=0)
+            align_graph_to_radarogram()
+            QApplication.processEvents()
             exporter.export(f'{i}_part.png')
             graph_exporter.export(f'{i}_graph.png')
             list_paths.append(f'{i}_part.png')

--- a/func.py
+++ b/func.py
@@ -254,7 +254,10 @@ def draw_image(radar):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -271,6 +274,7 @@ def draw_image(radar):
         radarogramma.getAxis('left').setScale(8)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
 
 def draw_image_deep_prof(radar, scale):
@@ -342,7 +346,10 @@ def draw_image_deep_prof(radar, scale):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -351,6 +358,7 @@ def draw_image_deep_prof(radar, scale):
     radarogramma.getAxis('left').setScale(scale)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
     # radarogramma.removeItem(roi)
 

--- a/object.py
+++ b/object.py
@@ -14,7 +14,7 @@ from models_db.model_cluster import *
 
 import tqdm as tqdm
 from PIL import Image, ImageDraw, ImageFont
-from PyQt5.QtCore import QRect, Qt
+from PyQt5.QtCore import QRect, Qt, QTimer
 from PyQt5.QtWidgets import QFileDialog, QCheckBox, QListWidgetItem, QApplication, QMessageBox, QColorDialog, QTableWidget, QTableWidgetItem
 from PyQt5.QtGui import QBrush, QColor, QCursor
 from pyqtgraph.Qt import QtWidgets
@@ -196,7 +196,97 @@ radarogramma.addItem(img)
 
 hist = pg.HistogramLUTItem(gradientPosition='left')
 
+# The radarogram and the profile graph are stacked vertically, but their
+# plotting areas can be narrowed by different decorations and by small
+# GraphicsView/Layout margins.  Keep the large side areas predictable, then
+# measure the real on-screen ViewBox positions after Qt has laid out the
+# widgets and compensate the graph axes so both plotting rectangles start and
+# end at the same pixels.
+RADAROGRAM_COLOR_SCALE_WIDTH = 80
+RADAROGRAM_LEFT_AXIS_WIDTH = 75
+hist.setMaximumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+hist.setMinimumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
 ui.radarogram.addItem(hist)
+
+for graphics_view in (ui.radarogram, ui.graph):
+    graphics_view.setContentsMargins(0, 0, 0, 0)
+    graphics_view.setFrameStyle(QtWidgets.QFrame.NoFrame)
+
+for plot_item in (radarogramma, ui.graph.plotItem):
+    plot_item.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setHorizontalSpacing(0)
+    plot_item.vb.setDefaultPadding(0)
+
+for axis in (radarogramma.getAxis('left'), ui.graph.getAxis('left')):
+    axis.setWidth(RADAROGRAM_LEFT_AXIS_WIDTH)
+    axis.setStyle(tickTextOffset=5, tickLength=5)
+
+graph_right_axis = ui.graph.getAxis('right')
+graph_right_axis.setWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+graph_right_axis.setStyle(showValues=False)
+graph_right_axis.setPen(pg.mkPen(None))
+ui.graph.showAxis('right', True)
+
+
+def align_graph_to_radarogram():
+    """Align profile graph ViewBox to the radarogram ViewBox in widget pixels.
+
+    Fixed axis widths remove most of the offset, but PyQtGraph's
+    GraphicsLayoutWidget and PlotWidget can still keep slightly different
+    scene/layout margins.  Measuring the actual ViewBox rectangles after Qt
+    layout gives the exact remaining offset and lets us compensate it through
+    the graph's left/right reserved axis space.
+    """
+    try:
+        radar_rect = radarogramma.vb.sceneBoundingRect()
+        graph_rect = ui.graph.plotItem.vb.sceneBoundingRect()
+        if not radar_rect.isValid() or not graph_rect.isValid():
+            return
+
+        radar_left = ui.radarogram.mapFromScene(radar_rect.topLeft()).x()
+        graph_left = ui.graph.mapFromScene(graph_rect.topLeft()).x()
+        radar_right = ui.radarogram.mapFromScene(radar_rect.topRight()).x()
+        graph_right = ui.graph.mapFromScene(graph_rect.topRight()).x()
+
+        graph_left_axis = ui.graph.getAxis('left')
+        graph_right_axis = ui.graph.getAxis('right')
+        left_width = graph_left_axis.width() + radar_left - graph_left
+        right_width = graph_right_axis.width() + graph_right - radar_right
+
+        graph_left_axis.setWidth(max(0, int(round(left_width))))
+        graph_right_axis.setWidth(max(0, int(round(right_width))))
+    except Exception:
+        # Alignment is a visual convenience; never block the application if a
+        # widget is not ready during startup or teardown.
+        pass
+
+def schedule_graph_alignment():
+    QTimer.singleShot(0, align_graph_to_radarogram)
+
+
+# Backward-compatible aliases: func.py imports object.py with `from object
+# import *`, so leading-underscore helpers are not exported.  Keep the old
+# spelling and the misspelled variant safe for any existing callbacks.
+_schedule_graph_alignment = schedule_graph_alignment
+_schedule_graph_aligment = schedule_graph_alignment
+schedule_graph_aligment = schedule_graph_alignment
+
+
+def _wrap_resize_alignment(widget):
+    original_resize_event = widget.resizeEvent
+
+    def resize_event(event):
+        original_resize_event(event)
+        schedule_graph_alignment()
+
+    widget.resizeEvent = resize_event
+
+
+_wrap_resize_alignment(ui.radarogram)
+_wrap_resize_alignment(ui.graph)
+schedule_graph_alignment()
+QTimer.singleShot(100, align_graph_to_radarogram)
 
 
 roi = pg.ROI(pos=[0, 0], size=[ui.spinBox_roi.value(), 512], maxBounds=QRect(0, 0, 100000000, 512))


### PR DESCRIPTION
### Motivation
- Prevent visual misalignment between the main radarogram and the profile graph so plotted ranges start and end at the same on-screen pixels and exported images keep consistent left/right offsets.
- Make exported images use the same internal width/offsets as the visible widgets to avoid stitching artifacts when saving long profiles.
- Ensure range setting and image sizing use the actual radar array dimensions and avoid automatic padding that creates gaps.

### Description
- Added layout and alignment utilities in `object.py`, including constants for scale/axis widths, `align_graph_to_radarogram()`, `schedule_graph_alignment()` (QTimer-backed), resize-event wrapping, and compatibility aliases to keep existing callbacks working.
- Forced consistent widget margins and axis widths and measured the actual `ViewBox` rectangles to compute and set graph left/right axis widths so the graph plotting area matches the radarogram plotting area in pixels.
- In `func.py` converted the radar to a `numpy` array before calling `img.setImage(...)` and set `radarogramma` ranges to the array shapes with `padding=0`, and call `schedule_graph_alignment()` after redraws.
- In `draw.py` enforced `padding=0` in `on_range_changed()`, introduced a shared `export_width` for exporters, switched graph export to `ImageExporter(ui.graph.plotItem)` to capture the same plot-item margins, and call `align_graph_to_radarogram()` plus `QApplication.processEvents()` while exporting parts to ensure exported tiles align for stitching.
- Added import of `QTimer` and a small resize wrapper to trigger alignment after widget resizes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d124a3120832f884a19ff78d75668)