### PR TITLE
Align profile graph to radarogram and improve export/image stitching

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -99,7 +99,8 @@ def change_background():
 
 def on_range_changed():
     X, Y = radarogramma.viewRange()
-    ui.graph.setXRange(X[0], X[1])
+    ui.graph.setXRange(X[0], X[1], padding=0)
+    schedule_graph_alignment()
 
 
 def crop_from_right(image):
@@ -131,7 +132,58 @@ def concatenate_images_vertically(image1, image2):
     return new_image
 
 
-def process_images(images, graphs):
+
+def _pixel_differs(pixel, color, tolerance=10):
+    return any(abs(int(pixel[i]) - int(color[i])) > tolerance for i in range(3))
+
+
+def _find_plot_left_border(image, color):
+    """Find the first long vertical plot-border line in an exported image."""
+    rgb_image = image.convert('RGB')
+    width, height = rgb_image.size
+    y_start = max(0, int(height * 0.12))
+    y_end = min(height, int(height * 0.88))
+    min_hits = max(10, int((y_end - y_start) * 0.35))
+    max_x = max(1, int(width * 0.65))
+
+    for x in range(max_x):
+        hits = 0
+        for y in range(y_start, y_end):
+            if _pixel_differs(rgb_image.getpixel((x, y)), color):
+                hits += 1
+        if hits >= min_hits:
+            return x
+    return 0
+
+
+def _shift_image_horizontally(image, delta, color):
+    """Move image content right/left by delta pixels while preserving image width."""
+    if delta == 0:
+        return image
+
+    width, height = image.size
+    result = Image.new('RGB', (width, height), color)
+    rgb_image = image.convert('RGB')
+    delta = max(-width + 1, min(width - 1, delta))
+
+    if delta > 0:
+        crop = rgb_image.crop((0, 0, width - delta, height))
+        result.paste(crop, (delta, 0))
+    else:
+        shift = abs(delta)
+        crop = rgb_image.crop((shift, 0, width, height))
+        result.paste(crop, (0, 0))
+    return result
+
+
+def align_graph_export_to_radar(image, graph, color):
+    """Align the saved graph's left plot border with the radarogram border."""
+    radar_left = _find_plot_left_border(image, color)
+    graph_left = _find_plot_left_border(graph, color)
+    return _shift_image_horizontally(graph, radar_left - graph_left, color)
+
+
+def process_images(images, graphs, color_short):
     """
         Изменить размеры изображений в graphs и объединить каждую пару с изображениями из images.
         images - список с основными изображениями
@@ -151,6 +203,7 @@ def process_images(images, graphs):
         aspect_ratio = crop_from_right(graphs[inx]).height / crop_from_right(graphs[inx]).width
         new_height = int(aspect_ratio * images[inx].width)
         graph_resized = resize_image(graph_cropped, img.width, new_height)
+        graph_resized = align_graph_export_to_radar(img, graph_resized, color_short)
         # Склейка изображение вертикально
         combined_image = concatenate_images_vertically(img, graph_resized)
 
@@ -208,6 +261,8 @@ def save_image():
 
     # Создаем объект экспортера PyQtGraph для основного изображения и настраиваем фиксированный размер изображения
     exporter = ImageExporter(radarogramma)
+    export_width = 868
+    exporter.parameters()['width'] = export_width
     exporter.parameters()['height'] = 610
     count_measure = len(
         json.loads(session.query(Profile.signal).filter(Profile.id == get_profile_id()).first()[0]))
@@ -217,9 +272,12 @@ def save_image():
 
     # Сохранение изображения с графиком
     if ui.checkBox_save_graph.isChecked():
-        # Создаем объект экспортера для графика
-        graph_exporter = ImageExporter(ui.graph.scene())
-        graph_exporter.parameters()['width'] = 868
+        # Создаем объект экспортера для графика. Экспортируем именно PlotItem,
+        # а не всю scene(), и используем ту же ширину, что у радарограммы.
+        # Так сохраненное изображение получает те же служебные отступы слева/справа,
+        # что и видимое окно после align_graph_to_radarogram().
+        graph_exporter = ImageExporter(ui.graph.plotItem)
+        graph_exporter.parameters()['width'] = export_width
 
         list_paths = []
         list_graphs = []
@@ -227,15 +285,24 @@ def save_image():
         # В цикле сдвигаем шкалу для смены части изображения, затем
         # сохраняем части основных изображений и графиков в соответствующие списки
         N = (count_measure + 399) // 400
+        original_x_range, original_y_range = radarogramma.viewRange()
+        radarogram_top_label_margin = 45
         for i in range(N):
             n = i * 400
             m = n + 400
             radarogramma.setXRange(n, m, padding=0)
+            radarogramma.setYRange(original_y_range[0] - radarogram_top_label_margin, original_y_range[1], padding=0)
             ui.graph.setXRange(n, m, padding=0)
+            align_graph_to_radarogram()
+            QApplication.processEvents()
             exporter.export(f'{i}_part.png')
             graph_exporter.export(f'{i}_graph.png')
             list_paths.append(f'{i}_part.png')
             list_graphs.append(f'{i}_graph.png')
+
+        radarogramma.setXRange(original_x_range[0], original_x_range[1], padding=0)
+        radarogramma.setYRange(original_y_range[0], original_y_range[1], padding=0)
+        ui.graph.setXRange(original_x_range[0], original_x_range[1], padding=0)
 
         # Открываем изображения с помощью библиотеки PIL для дальнейшей работы
         images = [Image.open(path) for path in list_paths]
@@ -291,7 +358,7 @@ def save_image():
             graphs[i] = graphs[i].crop((left, 0, width, height))
 
         # Объединяем изображения
-        combined_images = process_images(images, graphs)
+        combined_images = process_images(images, graphs, color_short)
 
         # Находим суммарные для всех изображений длину и ширину и создаем объект Image
         total_width = sum(img.width for img in combined_images)
@@ -371,12 +438,19 @@ def save_image():
         # В цикле сохраняем основные изображения в список list_paths
         list_paths = []
         N = (count_measure + 399) // 400
+        original_x_range, original_y_range = radarogramma.viewRange()
+        radarogram_top_label_margin = 45
         for i in range(N):
             n = i * 400
             m = n + 400
             radarogramma.setXRange(n, m, padding=0)
+            radarogramma.setYRange(original_y_range[0] - radarogram_top_label_margin, original_y_range[1], padding=0)
             exporter.export(f'{i}_part.png')
             list_paths.append(f'{i}_part.png')
+
+        radarogramma.setXRange(original_x_range[0], original_x_range[1], padding=0)
+        radarogramma.setYRange(original_y_range[0], original_y_range[1], padding=0)
+
         # Открываем изображения с помощью библиотеки PIL для дальнейшей работы
         images = [Image.open(path) for path in list_paths]
 

--- a/func.py
+++ b/func.py
@@ -254,7 +254,10 @@ def draw_image(radar):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -271,6 +274,7 @@ def draw_image(radar):
         radarogramma.getAxis('left').setScale(8)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
 
 def draw_image_deep_prof(radar, scale):
@@ -342,7 +346,10 @@ def draw_image_deep_prof(radar, scale):
     cmap = pg.ColorMap(pos=np.linspace(0.0, 1.0, len(colors)), color=colors)
     img.setColorMap(cmap)
     hist.gradient.setColorMap(cmap)
-    img.setImage(np.array(radar))
+    radar_array = np.array(radar)
+    img.setImage(radar_array)
+    radarogramma.setXRange(0, radar_array.shape[0], padding=0)
+    radarogramma.setYRange(0, radar_array.shape[1], padding=0)
 
     radarogramma.getAxis('bottom').setLabel('Профиль, м')
     radarogramma.getAxis('bottom').setScale(2.5)
@@ -351,6 +358,7 @@ def draw_image_deep_prof(radar, scale):
     radarogramma.getAxis('left').setScale(scale)
     if ui.checkBox_grid.isChecked():
         radarogramma.showGrid(x=True, y=True)
+    schedule_graph_alignment()
 
     # radarogramma.removeItem(roi)
 

--- a/object.py
+++ b/object.py
@@ -14,7 +14,7 @@ from models_db.model_cluster import *
 
 import tqdm as tqdm
 from PIL import Image, ImageDraw, ImageFont
-from PyQt5.QtCore import QRect, Qt
+from PyQt5.QtCore import QRect, Qt, QTimer
 from PyQt5.QtWidgets import QFileDialog, QCheckBox, QListWidgetItem, QApplication, QMessageBox, QColorDialog, QTableWidget, QTableWidgetItem
 from PyQt5.QtGui import QBrush, QColor, QCursor
 from pyqtgraph.Qt import QtWidgets
@@ -196,7 +196,97 @@ radarogramma.addItem(img)
 
 hist = pg.HistogramLUTItem(gradientPosition='left')
 
+# The radarogram and the profile graph are stacked vertically, but their
+# plotting areas can be narrowed by different decorations and by small
+# GraphicsView/Layout margins.  Keep the large side areas predictable, then
+# measure the real on-screen ViewBox positions after Qt has laid out the
+# widgets and compensate the graph axes so both plotting rectangles start and
+# end at the same pixels.
+RADAROGRAM_COLOR_SCALE_WIDTH = 80
+RADAROGRAM_LEFT_AXIS_WIDTH = 75
+hist.setMaximumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+hist.setMinimumWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
 ui.radarogram.addItem(hist)
+
+for graphics_view in (ui.radarogram, ui.graph):
+    graphics_view.setContentsMargins(0, 0, 0, 0)
+    graphics_view.setFrameStyle(QtWidgets.QFrame.NoFrame)
+
+for plot_item in (radarogramma, ui.graph.plotItem):
+    plot_item.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setContentsMargins(0, 0, 0, 0)
+    plot_item.layout.setHorizontalSpacing(0)
+    plot_item.vb.setDefaultPadding(0)
+
+for axis in (radarogramma.getAxis('left'), ui.graph.getAxis('left')):
+    axis.setWidth(RADAROGRAM_LEFT_AXIS_WIDTH)
+    axis.setStyle(tickTextOffset=5, tickLength=5)
+
+graph_right_axis = ui.graph.getAxis('right')
+graph_right_axis.setWidth(RADAROGRAM_COLOR_SCALE_WIDTH)
+graph_right_axis.setStyle(showValues=False)
+graph_right_axis.setPen(pg.mkPen(None))
+ui.graph.showAxis('right', True)
+
+
+def align_graph_to_radarogram():
+    """Align profile graph ViewBox to the radarogram ViewBox in widget pixels.
+
+    Fixed axis widths remove most of the offset, but PyQtGraph's
+    GraphicsLayoutWidget and PlotWidget can still keep slightly different
+    scene/layout margins.  Measuring the actual ViewBox rectangles after Qt
+    layout gives the exact remaining offset and lets us compensate it through
+    the graph's left/right reserved axis space.
+    """
+    try:
+        radar_rect = radarogramma.vb.sceneBoundingRect()
+        graph_rect = ui.graph.plotItem.vb.sceneBoundingRect()
+        if not radar_rect.isValid() or not graph_rect.isValid():
+            return
+
+        radar_left = ui.radarogram.mapFromScene(radar_rect.topLeft()).x()
+        graph_left = ui.graph.mapFromScene(graph_rect.topLeft()).x()
+        radar_right = ui.radarogram.mapFromScene(radar_rect.topRight()).x()
+        graph_right = ui.graph.mapFromScene(graph_rect.topRight()).x()
+
+        graph_left_axis = ui.graph.getAxis('left')
+        graph_right_axis = ui.graph.getAxis('right')
+        left_width = graph_left_axis.width() + radar_left - graph_left
+        right_width = graph_right_axis.width() + graph_right - radar_right
+
+        graph_left_axis.setWidth(max(0, int(round(left_width))))
+        graph_right_axis.setWidth(max(0, int(round(right_width))))
+    except Exception:
+        # Alignment is a visual convenience; never block the application if a
+        # widget is not ready during startup or teardown.
+        pass
+
+def schedule_graph_alignment():
+    QTimer.singleShot(0, align_graph_to_radarogram)
+
+
+# Backward-compatible aliases: func.py imports object.py with `from object
+# import *`, so leading-underscore helpers are not exported.  Keep the old
+# spelling and the misspelled variant safe for any existing callbacks.
+_schedule_graph_alignment = schedule_graph_alignment
+_schedule_graph_aligment = schedule_graph_alignment
+schedule_graph_aligment = schedule_graph_alignment
+
+
+def _wrap_resize_alignment(widget):
+    original_resize_event = widget.resizeEvent
+
+    def resize_event(event):
+        original_resize_event(event)
+        schedule_graph_alignment()
+
+    widget.resizeEvent = resize_event
+
+
+_wrap_resize_alignment(ui.radarogram)
+_wrap_resize_alignment(ui.graph)
+schedule_graph_alignment()
+QTimer.singleShot(100, align_graph_to_radarogram)
 
 
 roi = pg.ROI(pos=[0, 0], size=[ui.spinBox_roi.value(), 512], maxBounds=QRect(0, 0, 100000000, 512))


### PR DESCRIPTION
### Motivation

- Ensure the profile `ui.graph` plotting area is pixel-aligned with the radarogram `radarogramma` so saved/exported graph images line up exactly with the radar image.
- Remove visual/export inconsistencies caused by differing widget/layout margins, axis widths and padding when exporting stitched images.
- Improve robustness of image stitching by detecting plot borders and shifting exported graph images before concatenation.

### Description

- Added layout/axis width constants and fixed histogram width, removed extra margins, and set axis styles in `object.py`, plus added `align_graph_to_radarogram` and `schedule_graph_alignment` helpers to measure and align ViewBox rectangles in widget pixels and a small `QTimer` scheduling shim to run alignment after layout.
- Wrapped `resizeEvent` for the radar and graph widgets to re-schedule alignment on resize and exposed backward-compatible aliases for the new scheduler functions in `object.py`.
- In `func.py` replaced direct `img.setImage(np.array(radar))` calls with a `radar_array` and set `radarogramma` ranges via `radarogramma.setXRange` and `radarogramma.setYRange`, and call `schedule_graph_alignment()` after drawing to keep views synced.
- In `draw.py` added precise export handling: unified export width (`export_width`), export of `ui.graph.plotItem` (instead of entire scene) to match radar margins, saving/restoring original ranges, calling `align_graph_to_radarogram()` and `QApplication.processEvents()` while creating parts, and replaced loose padding with explicit `padding=0` calls where appropriate.
- Implemented image helpers `_pixel_differs`, `_find_plot_left_border`, `_shift_image_horizontally`, and `align_graph_export_to_radar` and integrated them into `process_images` so exported graph images are horizontally shifted to match the radarogram plot border before vertical concatenation.

### Testing

- No automated tests were executed for these UI and image-export related changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d124a3120832f884a19ff78d75668)