### PR TITLE
Make profile-mode checkboxes exclusive and refactor profile display/drawing logic

### DIFF
--- a/geovel.py
+++ b/geovel.py
@@ -436,6 +436,21 @@ ui.pushButton_import_model_f_ai.clicked.connect(import_model_formation_ai)
 
 ui.pushButton_map.clicked.connect(show_map)
 ui.pushButton_profiles.clicked.connect(show_profiles)
+
+
+def set_exclusive_profile_mode(checked_checkbox, unchecked_checkbox):
+    if checked_checkbox.isChecked() and unchecked_checkbox.isChecked():
+        unchecked_checkbox.blockSignals(True)
+        unchecked_checkbox.setChecked(False)
+        unchecked_checkbox.blockSignals(False)
+
+
+ui.checkBox_prof_all.stateChanged.connect(
+    lambda _: set_exclusive_profile_mode(ui.checkBox_prof_all, ui.checkBox_profile_year)
+)
+ui.checkBox_profile_year.stateChanged.connect(
+    lambda _: set_exclusive_profile_mode(ui.checkBox_profile_year, ui.checkBox_prof_all)
+)
 ui.pushButton_get_attributes.clicked.connect(get_attributes)
 
 roi.sigRegionChanged.connect(updatePlot)

--- a/krige.py
+++ b/krige.py
@@ -730,28 +730,78 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
     Draw_Map.exec_()
 
 
-def show_profiles():
+def _get_profiles_for_display():
+    """Return profiles according to all/year/current profile drawing mode."""
     r_id = get_research_id()
-    list_x, list_y = [], []
-    if ui.checkBox_prof_all.isChecked():
-       for r in session.query(Research).all():
-           for profile in r.profiles:
-               try:
-                   list_x += (json.loads(profile.x_pulc))
-                   list_y += (json.loads(profile.y_pulc))
-               except TypeError:
-                   set_info(f'Не загружены координаты {profile.title}', 'red')
-                   pass
-    else:
 
-        r = session.query(Research).filter_by(id=r_id).first()
-        for profile in r.profiles:
-            try:
-                list_x += (json.loads(profile.x_pulc))
-                list_y += (json.loads(profile.y_pulc))
-            except TypeError:
-                set_info(f'Не загружены координаты {profile.title}', 'red')
-                pass
+    if ui.checkBox_prof_all.isChecked():
+        researches = session.query(Research).all()
+    elif ui.checkBox_profile_year.isChecked():
+        year = get_year_research()
+        researches = (session.query(Research)
+                      .filter(func.strftime('%Y', Research.date_research) == year)
+                      .all())
+    else:
+        research = session.query(Research).filter_by(id=r_id).first()
+        researches = [research] if research else []
+
+    profiles = []
+    for research in researches:
+        profiles.extend(research.profiles)
+    return profiles
+
+
+def _draw_profile_label(profile):
+    try:
+        profile_x = json.loads(profile.x_pulc)
+        profile_y = json.loads(profile.y_pulc)
+
+        plt.text(profile_x[0] + 20, profile_y[0] + 20, profile.title, fontsize=10, color='green')
+        plt.scatter(profile_x[0], profile_y[0], marker='o', color='green', s=25)
+        plt.text(profile_x[-10] + 20, profile_y[-10] + 20, profile.title, fontsize=10, color='orange')
+        plt.scatter(profile_x[-1], profile_y[-1], marker='o', color='orange', s=25)
+    except (TypeError, IndexError):
+        pass
+
+
+def _draw_object_labels(profiles):
+    object_points = {}
+
+    for profile in profiles:
+        if not profile.research or not profile.research.object:
+            continue
+
+        try:
+            profile_x = json.loads(profile.x_pulc)
+            profile_y = json.loads(profile.y_pulc)
+        except TypeError:
+            continue
+
+        object_title = profile.research.object.title
+        object_points.setdefault(object_title, {'x': [], 'y': []})
+        object_points[object_title]['x'].extend(profile_x)
+        object_points[object_title]['y'].extend(profile_y)
+
+    for object_title, points in object_points.items():
+        if not points['x'] or not points['y']:
+            continue
+
+        label_x = max(points['x']) + 100
+        label_y = (min(points['y']) + max(points['y'])) / 2
+        plt.text(label_x, label_y, object_title, fontsize=12, color='black', fontweight='bold')
+
+
+def show_profiles():
+    profiles = _get_profiles_for_display()
+    list_x, list_y = [], []
+
+    for profile in profiles:
+        try:
+            list_x += json.loads(profile.x_pulc)
+            list_y += json.loads(profile.y_pulc)
+        except TypeError:
+            set_info(f'Не загружены координаты {profile.title}', 'red')
+            pass
 
     x = np.array(list_x)
     y = np.array(list_y)
@@ -799,18 +849,14 @@ def show_profiles():
 
     plt.scatter(x, y, marker='.', edgecolors='k', s=0.1)
     if ui.checkBox_profile_title.isChecked():
-        r = session.query(Research).filter_by(id=r_id).first()
-        for profile in r.profiles:
-            try:
-                plt.text(json.loads(profile.x_pulc)[0] + 20, json.loads(profile.y_pulc)[0] + 20, profile.title, fontsize=10, color='green')
-                plt.scatter(json.loads(profile.x_pulc)[0], json.loads(profile.y_pulc)[0], marker='o', color='green', s=25)
-                plt.text(json.loads(profile.x_pulc)[-10] + 20, json.loads(profile.y_pulc)[-10] + 20, profile.title, fontsize=10, color='orange')
-                plt.scatter(json.loads(profile.x_pulc)[-1], json.loads(profile.y_pulc)[-1], marker='o', color='orange', s=25)
-            except TypeError:
-                pass
+        for profile in profiles:
+            _draw_profile_label(profile)
+
+    if ui.checkBox_prof_all.isChecked() or ui.checkBox_profile_year.isChecked():
+        _draw_object_labels(profiles)
 
     if ui.checkBox_profile_well.isChecked():
-        for profile in r.profiles:
+        for profile in profiles:
             wells = get_list_nearest_well(profile.id)
             if not wells:
                 continue


### PR DESCRIPTION
### Motivation

- Ensure the profile drawing mode UI is mutually exclusive and make profile rendering more robust and informative across modes.

### Description

- Add `set_exclusive_profile_mode` in `geovel.py` and connect `stateChanged` signals so `checkBox_prof_all` and `checkBox_profile_year` cannot be checked simultaneously.
- Refactor profile display in `krige.py` by extracting `_get_profiles_for_display`, `_draw_profile_label`, and `_draw_object_labels` and update `show_profiles` to use these helpers for clearer logic and reuse.
- Implement year-based filtering using `func.strftime('%Y', Research.date_research)` and aggregate profiles across selected researches while handling missing coordinate data gracefully via `set_info` and exception handling.
- Improve labeling by drawing profile start/end markers and aggregated object labels positioned to the right of object points, and keep existing grid/map/well plotting behavior.

### Testing

- Ran the project's automated test suite against the modified code and all tests passed.
- No new automated tests were added for the new UI-exclusive behavior or drawing helpers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8e4aa8b0832fb33410aa167250a1)