### PR TITLE
Fix geochem model calculation for incomplete data

### DIFF
--- a/geochem.py
+++ b/geochem.py
@@ -1514,7 +1514,12 @@ def calc_geochem_classification():
         with open(model.path_model, 'rb') as f:
             class_model = pickle.load(f)
 
-        working_sample = data_test[list_param_model].values.tolist()
+        working_sample = data_test.reindex(columns=list_param_model)
+        working_sample = working_sample.replace([np.inf, -np.inf], np.nan)
+
+        if working_sample.empty:
+            set_info('Нет геохимических данных для расчёта по выбранной модели', 'red')
+            return
 
         list_cat = list(class_model.classes_)
 
@@ -1522,15 +1527,12 @@ def calc_geochem_classification():
             mark = class_model.predict(working_sample)
             probability = class_model.predict_proba(working_sample)
         except ValueError:
-            working_sample = [[np.nan if np.isinf(x) else x for x in y] for y in working_sample]
             data = imputer.fit_transform(working_sample)
             mark = class_model.predict(data)
             probability = class_model.predict_proba(data)
 
             for i in working_sample.index:
-                p_nan = [working_sample.columns[ic + 3] for ic, v in
-                         enumerate(working_sample.iloc[i, 3:].tolist()) if
-                         np.isnan(v)]
+                p_nan = [col for col, v in working_sample.loc[i].items() if pd.isna(v)]
                 if len(p_nan) > 0:
                     set_info(
                         f'Внимание для измерения "{i}" отсутствуют параметры "{", ".join(p_nan)}", поэтому расчёт для'


### PR DESCRIPTION
### Motivation
- The prediction path converted input to a list which led to `ValueError: Expected 2D array` for sparse/incomplete geochemical data.
- Infinite values and missing columns caused the imputer and classifier to receive an invalid shape or invalid values.
- The UI flow should fail gracefully when there is no data to process instead of raising an exception.

### Description
- Keep the prediction input as a 2D `DataFrame` aligned to the trained model parameters by using `data_test.reindex(columns=list_param_model)` instead of converting to a list.
- Replace `np.inf`/`-np.inf` with `NaN` via `.replace([np.inf, -np.inf], np.nan)` before prediction or imputation.
- Abort early with a user-facing message using `set_info(...)` when `working_sample.empty` to avoid further errors.
- Use `imputer.fit_transform(working_sample)` on the `DataFrame` as the fallback and report missing parameter names by inspecting each row with `working_sample.loc[i]` and `pd.isna()`.

### Testing
- `python -m py_compile geochem.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50c60e2b7c832f92990dfd13d50de8)