### PR TITLE
Add model-points table builder and robust validation/handling to geochem classification

### DIFF
--- a/geochem.py
+++ b/geochem.py
@@ -1486,6 +1486,82 @@ def build_geochem_table_field():
 
 
 
+
+def build_geochem_table_model_points():
+    geochem_id = get_geochem_id()
+
+    params = (
+        session.query(GeochemParameter.id, GeochemParameter.title)
+        .filter_by(geochem_id=geochem_id)
+        .all()
+    )
+    param_map = dict(params)
+    param_titles = [title for _, title in params]
+
+    default_params = {title: None for title in param_titles}
+    data_rows = []
+    field_point_id_to_index = {}
+    well_point_id_to_index = {}
+
+    field_points = (
+        session.query(GeochemPoint)
+        .filter_by(geochem_id=geochem_id, fake=False)
+        .all()
+    )
+    for point in field_points:
+        field_point_id_to_index[point.id] = len(data_rows)
+        data_rows.append({
+            'title': point.title,
+            'X': point.x_coord,
+            'Y': point.y_coord,
+            'well': 'field',
+            **default_params
+        })
+
+    well_points = (
+        session.query(GeochemWellPoint)
+        .join(GeochemWell)
+        .filter(GeochemWell.geochem_id == geochem_id)
+        .all()
+    )
+    for point in well_points:
+        well_point_id_to_index[point.id] = len(data_rows)
+        data_rows.append({
+            'title': point.title,
+            'X': point.x_coord,
+            'Y': point.y_coord,
+            'well': point.g_well.title,
+            **default_params
+        })
+
+    if field_point_id_to_index:
+        point_values = (
+            session.query(GeochemPointValue)
+            .filter(GeochemPointValue.g_point_id.in_(list(field_point_id_to_index.keys())))
+            .all()
+        )
+        for pv in point_values:
+            param_title = param_map.get(pv.g_param_id)
+            row_idx = field_point_id_to_index.get(pv.g_point_id)
+            if param_title is not None and row_idx is not None:
+                data_rows[row_idx][param_title] = pv.value
+
+    if well_point_id_to_index:
+        well_point_values = (
+            session.query(GeochemWellPointValue)
+            .filter(GeochemWellPointValue.g_well_point_id.in_(list(well_point_id_to_index.keys())))
+            .all()
+        )
+        for pv in well_point_values:
+            param_title = param_map.get(pv.g_param_id)
+            row_idx = well_point_id_to_index.get(pv.g_well_point_id)
+            if param_title is not None and row_idx is not None:
+                data_rows[row_idx][param_title] = pv.value
+
+    data = pd.DataFrame(data_rows, columns=['title', 'X', 'Y', 'well'] + param_titles)
+    return data, param_titles
+
+
 def train_model_geochem():
     data_train, list_param = build_geochem_table()
     colors = {}
@@ -1496,7 +1572,7 @@ def train_model_geochem():
 
 
 def calc_geochem_classification():
-    data_test, list_param = build_geochem_table_field()
+    data_test, list_param = build_geochem_table_model_points()
 
     Choose_RegModel = QtWidgets.QDialog()
     ui_rm = Ui_FormRegMod()
@@ -1514,26 +1590,64 @@ def calc_geochem_classification():
         with open(model.path_model, 'rb') as f:
             class_model = pickle.load(f)
 
-        working_sample = data_test[list_param_model].values.tolist()
+        if data_test.empty:
+            set_info('Нет геохимических точек для расчёта по выбранной модели', 'red')
+            return
+
+        if not list_param_model:
+            set_info('В выбранной модели не сохранён список параметров для расчёта', 'red')
+            return
+
+        missing_model_params = [param for param in list_param_model if param not in data_test.columns]
+        if missing_model_params:
+            set_info(
+                f'В текущем геохимическом объекте отсутствуют параметры, необходимые выбранной модели: '
+                f'{", ".join(missing_model_params)}',
+                'red'
+            )
+            return
+
+        n_features_model = getattr(class_model, 'n_features_in_', None)
+        if n_features_model is not None and n_features_model != len(list_param_model):
+            set_info(
+                f'Количество параметров выбранной модели ({n_features_model}) не совпадает с сохранённым списком '
+                f'параметров ({len(list_param_model)}). Возможно, запись модели повреждена или создана в старой версии.',
+                'red'
+            )
+            return
+
+        working_sample = data_test[list_param_model].copy()
+        working_sample = working_sample.replace([np.inf, -np.inf], np.nan)
+
+        empty_value_params = [param for param in list_param_model if working_sample[param].isna().all()]
+        if empty_value_params:
+            set_info(
+                f'Для параметров выбранной модели нет ни одного значения в геохимических точках: '
+                f'{", ".join(empty_value_params)}',
+                'red'
+            )
 
         list_cat = list(class_model.classes_)
 
         try:
             mark = class_model.predict(working_sample)
             probability = class_model.predict_proba(working_sample)
-        except ValueError:
-            working_sample = [[np.nan if np.isinf(x) else x for x in y] for y in working_sample]
-            data = imputer.fit_transform(working_sample)
-            mark = class_model.predict(data)
-            probability = class_model.predict_proba(data)
+        except ValueError as err:
+            try:
+                data = imputer.fit_transform(working_sample)
+                mark = class_model.predict(data)
+                probability = class_model.predict_proba(data)
+            except ValueError as impute_err:
+                set_info(f'Не удалось рассчитать модель: {impute_err}', 'red')
+                return
 
+            set_info(f'Расчёт выполнен после заполнения пропусков. Исходная ошибка модели: {err}', 'red')
             for i in working_sample.index:
-                p_nan = [working_sample.columns[ic + 3] for ic, v in
-                         enumerate(working_sample.iloc[i, 3:].tolist()) if
-                         np.isnan(v)]
+                p_nan = [col for col, v in working_sample.loc[i].items() if pd.isna(v)]
                 if len(p_nan) > 0:
+                    point_title = data_test.loc[i, 'title'] if 'title' in data_test.columns else i
                     set_info(
-                        f'Внимание для измерения "{i}" отсутствуют параметры "{", ".join(p_nan)}", поэтому расчёт для'
+                        f'Внимание для измерения "{point_title}" отсутствуют параметры "{", ".join(p_nan)}", поэтому расчёт для'
                         f' этого измерения может быть не корректен', 'red')
 
         # Добавление предсказанных меток и вероятностей в рабочие данные


### PR DESCRIPTION
### Motivation

- Separate handling of field points and well points was needed to build a unified dataset for model-based geochemical classification.  
- The classification routine required more robust validation and NaN/inf handling to avoid silent failures when models or data are incompatible.

### Description

- Add `build_geochem_table_model_points()` which builds a DataFrame containing both field `GeochemPoint` and well `GeochemWellPoint` rows and their parameter values, returning `(data, param_titles)`.  
- Update `calc_geochem_classification()` to use `build_geochem_table_model_points()` and to early-return with user-visible messages when the test set is empty or the model has no saved parameter list.  
- Add checks for missing model parameters in the current object and for mismatches between model `n_features_in_` and the saved parameter list, with clear error messages.  
- Sanitize `working_sample` by replacing `inf`/`-inf` with `NaN`, detect parameters that are all-missing, and attempt imputation on `ValueError` during prediction; if imputation fails an error is shown; when imputation succeeds a notice is shown.  
- Improve per-row NaN reporting to use the row `title` when available and avoid fragile column-index logic.  

### Testing

- Ran the project automated test suite with `pytest`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50c60e2b7c832f92990dfd13d50de8)