### PR TITLE
Make PyTorch/skorch optional with runtime checks and friendly error dialogs

### DIFF
--- a/classification_func.py
+++ b/classification_func.py
@@ -153,6 +153,7 @@ def train_classifier(data_train: pd.DataFrame, list_param: list, list_param_save
     def build_torch_model(training_sample_train):
         """ Сборка модели PyTorch"""
 
+        require_torch_stack()
         output_dim = 1
 
         epochs = ui_cls.spinBox_epochs_torch.value()

--- a/geovel.py
+++ b/geovel.py
@@ -19,8 +19,6 @@ from geochem import *
 from velocity_model import *
 from velocity_prediction import *
 from test_model import *
-from nn_torch_classifier import *
-from nn_torch_regression import *
 from feature_selection import *
 from index_productivity import *
 from pareto import *
@@ -266,9 +264,35 @@ ui.toolButton_rm_well_fake.clicked.connect(remove_fake_current_markup)
 ui.toolButton_cls_upgrade_model.clicked.connect(cls_model_prediction_upgrade)
 ui.toolButton_dist_well.clicked.connect(calc_object_training_well_distances_mlp)
 
+def _show_optional_torch_error(error):
+    QtWidgets.QMessageBox.warning(
+        MainWindow,
+        'PyTorch не установлен',
+        f'Для этой функции нужно установить PyTorch/skorch.\n\n{error}'
+    )
+
+
+def open_torch_classifier_train():
+    try:
+        from nn_torch_classifier import torch_classifier_train
+    except ImportError as exc:
+        _show_optional_torch_error(exc)
+        return
+    torch_classifier_train()
+
+
+def open_torch_regressor_train():
+    try:
+        from nn_torch_regression import torch_regressor_train
+    except ImportError as exc:
+        _show_optional_torch_error(exc)
+        return
+    torch_regressor_train()
+
+
 # torch
-ui.pushButton_add_torch.clicked.connect(torch_classifier_train)
-ui.pushButton_torch.clicked.connect(torch_regressor_train)
+ui.pushButton_add_torch.clicked.connect(open_torch_classifier_train)
+ui.pushButton_torch.clicked.connect(open_torch_regressor_train)
 
 
 #   regression

--- a/mlp.py
+++ b/mlp.py
@@ -8,7 +8,6 @@ from draw import draw_radarogram, draw_formation, draw_fill, draw_fake, draw_fil
 from formation_ai import get_model_id
 from func import *
 from build_table import *
-from nn_torch_classifier import *
 from krige import draw_map
 from qt.choose_formation_lda import *
 from random_search import push_random_search

--- a/object.py
+++ b/object.py
@@ -143,13 +143,45 @@ from collections import defaultdict
 
 from difflib import SequenceMatcher
 
-import torch
-import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader, TensorDataset, random_split, RandomSampler, SubsetRandomSampler
-from skorch import NeuralNetClassifier, NeuralNetRegressor
+try:
+    import torch
+    import torch.nn as nn
+    from torch.utils.data import Dataset, DataLoader, TensorDataset, random_split, RandomSampler, SubsetRandomSampler
+except ImportError as exc:
+    torch = None
+    _TORCH_IMPORT_ERROR = exc
 
-from skorch.dataset import ValidSplit
-from skorch.callbacks import EarlyStopping
+    class _OptionalTorchNN:
+        class Module:
+            pass
+
+        def __getattr__(self, name):
+            raise ImportError("PyTorch is required for this neural-network action.") from _TORCH_IMPORT_ERROR
+
+    nn = _OptionalTorchNN()
+    Dataset = object
+    DataLoader = TensorDataset = random_split = RandomSampler = SubsetRandomSampler = None
+else:
+    _TORCH_IMPORT_ERROR = None
+
+try:
+    from skorch import NeuralNetClassifier, NeuralNetRegressor
+    from skorch.dataset import ValidSplit
+    from skorch.callbacks import EarlyStopping
+except ImportError as exc:
+    NeuralNetClassifier = NeuralNetRegressor = ValidSplit = EarlyStopping = None
+    _SKORCH_IMPORT_ERROR = exc
+else:
+    _SKORCH_IMPORT_ERROR = None
+
+
+def require_torch_stack():
+    """Ensure optional PyTorch/skorch dependencies are available before Torch actions."""
+
+    if torch is None:
+        raise ImportError("PyTorch is required for this neural-network action.") from _TORCH_IMPORT_ERROR
+    if NeuralNetClassifier is None or NeuralNetRegressor is None or ValidSplit is None or EarlyStopping is None:
+        raise ImportError("skorch is required for this neural-network action.") from _SKORCH_IMPORT_ERROR
 
 from yellowbrick.classifier import DiscriminationThreshold
 

--- a/random_param.py
+++ b/random_param.py
@@ -212,6 +212,7 @@ def push_random_param():
         return labels
 
     def build_torch_model(pipe_steps, x_train):
+        require_torch_stack()
         labels = set_marks()
         output_dim = 1
 

--- a/random_param_reg.py
+++ b/random_param_reg.py
@@ -682,6 +682,7 @@ def push_random_param_reg():
             update_list_test_well()
 
     def build_torch_model(pipe_steps, x_train):
+        require_torch_stack()
         output_dim = 1
 
         epochs = ui_r.spinBox_epochs_torch.value()

--- a/regression.py
+++ b/regression.py
@@ -1047,6 +1047,7 @@ def train_regression_model():
     def build_torch_model(training_sample_train):
         """ Сбор модели PyTorch """
 
+        require_torch_stack()
         output_dim = 1
 
         epochs = ui_r.spinBox_epochs_torch.value()

--- a/velocity_prediction.py
+++ b/velocity_prediction.py
@@ -2,7 +2,6 @@ import json
 import random
 import statistics
 
-from torch.cuda import graph
 
 from func import *
 from velocity_model import check_intersection


### PR DESCRIPTION
### Motivation
- Allow the application to run on systems without PyTorch/skorch by avoiding hard import failures at startup.
- Surface clear, user-friendly messages when torch-based features are invoked so non-torch installs do not crash the UI.

### Description
- Add guarded imports and a `require_torch_stack()` helper in `object.py` that raises informative `ImportError`s when PyTorch or skorch are unavailable.
- Call `require_torch_stack()` at the start of torch-model builder functions in `classification_func.py`, `random_param.py`, `random_param_reg.py`, and `regression.py` to fail early with a clear message if dependencies are missing.
- Change eager imports of `nn_torch_classifier`/`nn_torch_regression` to lazy imports wrapped in try/except in `geovel.py`, and add `_show_optional_torch_error()` to display a `QMessageBox` when torch/skorch are not installed; update UI button handlers to use these wrappers.
- Remove an unused `torch.cuda.graph` import from `velocity_prediction.py` and remove direct imports of torch-based modules from `mlp.py` so those modules are only loaded when needed.

### Testing
- Ran the existing test suite with `pytest`; existing tests passed and revealed no regressions in non-torch code paths.
- Verified (locally) that the application imports and main UI load on systems without PyTorch installed, and that attempting to open torch-based dialogs shows the friendly error dialog (manual GUI smoke verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a2bd164c4832fb88992def3556829)