### PR TITLE
Use NumPy 2-compatible `np.trapezoid` for integrations

### DIFF
--- a/calc_additional_features.py
+++ b/calc_additional_features.py
@@ -670,7 +670,7 @@ def calculate_envelope(signal):
 
 
 def area_under_envelope(envelope):
-    return np.trapz(envelope)
+    return np.trapezoid(envelope)
 
 
 def envelope_max(envelope):
@@ -778,7 +778,7 @@ def autocorrelation_decay(acf, num_points=10):
 
 
 def acf_integral(acf):
-    return np.trapz(acf)
+    return np.trapezoid(acf)
 
 
 def acf_main_peak_width(acf, height_ratio=0.5):


### PR DESCRIPTION
### Motivation
- Runtime errors occurred when code called the removed `np.trapz` API causing `AttributeError` during envelope and autocorrelation feature calculation.
- The intent is to restore integration behavior using a NumPy API that is present in NumPy 2.x to avoid crashes in those feature paths.

### Description
- Replaced `np.trapz(envelope)` with `np.trapezoid(envelope)` in `area_under_envelope` inside `calc_additional_features.py`.
- Replaced `np.trapz(acf)` with `np.trapezoid(acf)` in `acf_integral` inside `calc_additional_features.py`.
- Fixed file newline at EOF formatting in `calc_additional_features.py`.

### Testing
- Ran `python -m py_compile calc_additional_features.py` which succeeded without syntax errors. 
- Ran `git diff --check` which reported no whitespace or diff problems. 
- Searched the file for remaining `np.trapz`/`np.trapezoid` usages to confirm replacements, which showed only the new `np.trapezoid` calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e25ae83dc832fbb6739626b988a0e)