### PR TITLE
Handle duplicate coordinates in kriging maps

### DIFF
--- a/krige.py
+++ b/krige.py
@@ -9,6 +9,7 @@ from scipy import ndimage
 from scipy.spatial import ConvexHull, Delaunay, cKDTree
 
 from func import *
+from kriging_utils import prepare_variogram_data
 from qt.choose_formation_map import *
 from qt.draw_map_form import *
 
@@ -624,14 +625,37 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
         # z_interp = z_interp.reshape(gridx.shape)
         # ok.display_variogram_model()
 
-        # Интерполяция значений на сетке scikit-gstat
+        # Интерполяция значений на сетке scikit-gstat.  A Variogram rejects
+        # coincident points (zero-distance pairs); model output can contain
+        # several values for the same coordinate, therefore merge them first.
         try:
-            variogram = Variogram(coordinates=coord, values=z, estimator=estimator, dist_func=dist_func, bin_func=bin_func, fit_sigma='exp')
+            coord, z, merged_points = prepare_variogram_data(coord, z)
+            x, y = coord[:, 0], coord[:, 1]
+            if merged_points:
+                set_info(
+                    f'Для вариограммы усреднены значения в {merged_points} совпадающих точках.',
+                    'brown'
+                )
+            variogram = Variogram(
+                coordinates=coord,
+                values=z,
+                model=var_model,
+                n_lags=nlags,
+                estimator=estimator,
+                dist_func=dist_func,
+                bin_func=bin_func,
+                fit_sigma='exp'
+            )
         except MemoryError:
             set_info('MemoryError', 'red')
             return
-        except ValueError:
-            set_info('ValueError: variogram', 'red')
+        except ValueError as exc:
+            set_info(
+                f'Ошибка вариограммы ({dist_func}, {bin_func}): {exc}. '
+                'Проверьте, что есть минимум две точки с разными координатами '
+                'и выбрана поддерживаемая функция расстояния.',
+                'red'
+            )
             return
         except AttributeError:
             set_info('AttributeError', 'red')

--- a/kriging_utils.py
+++ b/kriging_utils.py
@@ -1,0 +1,38 @@
+"""Input preparation shared by the continuous-map kriging workflow."""
+
+import numpy as np
+
+
+def prepare_variogram_data(coordinates, values, min_unique_points=2):
+    """Validate variogram data and average values at coincident coordinates.
+
+    A variogram cannot be fitted to NaN/inf data or to zero-distance pairs.
+    Coincident samples are common for model results (several records can belong
+    to one map point), so their values are averaged instead of failing the map.
+    """
+    coords = np.asarray(coordinates, dtype=float)
+    data = np.asarray(values, dtype=float).reshape(-1)
+
+    if coords.ndim != 2 or coords.shape[1] != 2:
+        raise ValueError("coordinates must be an array with shape (n, 2)")
+    if len(coords) != len(data):
+        raise ValueError("coordinates and values must contain the same number of samples")
+
+    finite_mask = np.isfinite(coords).all(axis=1) & np.isfinite(data)
+    coords = coords[finite_mask]
+    data = data[finite_mask]
+    if len(coords) == 0:
+        raise ValueError("no finite coordinate/value pairs are available")
+
+    unique_coords, inverse = np.unique(coords, axis=0, return_inverse=True)
+    value_sums = np.bincount(inverse, weights=data)
+    sample_counts = np.bincount(inverse)
+    unique_values = value_sums / sample_counts
+
+    if len(unique_coords) < min_unique_points:
+        raise ValueError(
+            f"at least {min_unique_points} distinct coordinates are required; "
+            f"got {len(unique_coords)}"
+        )
+
+    return unique_coords, unique_values, int(len(data) - len(unique_coords))

--- a/tests/test_kriging_utils.py
+++ b/tests/test_kriging_utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from kriging_utils import prepare_variogram_data
+
+
+def test_prepare_variogram_data_averages_coincident_coordinates():
+    coordinates, values, merged_count = prepare_variogram_data(
+        [[0, 0], [1, 1], [0, 0], [2, 2]], [2, 4, 6, 8]
+    )
+
+    np.testing.assert_array_equal(coordinates, [[0, 0], [1, 1], [2, 2]])
+    np.testing.assert_allclose(values, [4, 4, 8])
+    assert merged_count == 1
+
+
+def test_prepare_variogram_data_discards_non_finite_samples():
+    coordinates, values, merged_count = prepare_variogram_data(
+        [[0, 0], [np.nan, 1], [2, 2]], [1, 2, np.inf], min_unique_points=1
+    )
+
+    np.testing.assert_array_equal(coordinates, [[0, 0]])
+    np.testing.assert_allclose(values, [1])
+    assert merged_count == 0
+
+
+def test_prepare_variogram_data_requires_distinct_coordinates():
+    with pytest.raises(ValueError, match="distinct coordinates"):
+        prepare_variogram_data([[0, 0], [0, 0]], [1, 2])


### PR DESCRIPTION
### Motivation
- Users may get `ValueError: variogram` when building maps because the variogram fitter rejects zero-distance pairs or non-finite samples, which can happen when multiple model outputs share the same map coordinate or when NaN/Inf values are present. 
- The map UI previously collected `var_model` and `nlags` but did not reliably pass them to the `Variogram` constructor, reducing configurability and making debugging harder.

### Description
- Add `kriging_utils.py` with `prepare_variogram_data(coordinates, values, min_unique_points=2)` that validates finite inputs, removes non-finite samples, and averages values at coincident coordinates. 
- Update `krige.py` to call `prepare_variogram_data` before creating the variogram and to extract `x, y` from prepared coordinates for downstream use. 
- Pass selected variogram options to `Variogram` (`model=var_model`, `n_lags=nlags`, `estimator`, `dist_func`, `bin_func`) and replace the generic error handling with a message that includes the original exception and actionable guidance. 
- Add unit tests in `tests/test_kriging_utils.py` covering averaging of coincident coordinates, filtering of non-finite samples, and insufficient distinct points.

### Testing
- `python -m py_compile krige.py kriging_utils.py` succeeded (no syntax errors). 
- `pytest -q tests/test_kriging_utils.py` could not be collected in this environment due to missing runtime dependency (`ModuleNotFoundError: No module named 'numpy'`).
- Repository checks `git diff --check`/staged-diff were run locally during development and showed no whitespace/check warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e53e265a0832f8475b45c1a354214)