### PR TITLE
Introduce kriging_utils helpers, robust variogram handling, and tests

### DIFF
--- a/krige.py
+++ b/krige.py
@@ -9,6 +9,11 @@ from scipy import ndimage
 from scipy.spatial import ConvexHull, Delaunay, cKDTree
 
 from func import *
+from kriging_utils import (
+    inverse_distance_interpolation,
+    prepare_variogram_data,
+    savgol_parameters,
+)
 from qt.choose_formation_map import *
 from qt.draw_map_form import *
 
@@ -624,38 +629,72 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
         # z_interp = z_interp.reshape(gridx.shape)
         # ok.display_variogram_model()
 
-        # Интерполяция значений на сетке scikit-gstat
+        # Интерполяция значений на сетке scikit-gstat.  A Variogram rejects
+        # coincident points (zero-distance pairs); model output can contain
+        # several values for the same coordinate, therefore merge them first.
         try:
-            variogram = Variogram(coordinates=coord, values=z, estimator=estimator, dist_func=dist_func, bin_func=bin_func, fit_sigma='exp')
+            coord, z, merged_points = prepare_variogram_data(coord, z, min_unique_points=1)
+            x, y = coord[:, 0], coord[:, 1]
+            if merged_points:
+                set_info(
+                    f'Для вариограммы усреднены значения в {merged_points} совпадающих точках.',
+                    'brown'
+                )
         except MemoryError:
             set_info('MemoryError', 'red')
             return
-        except ValueError:
-            set_info('ValueError: variogram', 'red')
-            return
-        except AttributeError:
-            set_info('AttributeError', 'red')
-            return
-        except:
-            set_info('Variogram error', 'red')
+        except ValueError as exc:
+            set_info(
+                f'Невозможно подготовить данные карты: {exc}.',
+                'red'
+            )
             return
 
-        # variogram.fit()
-        kriging = OrdinaryKriging(variogram=variogram, min_points=5, max_points=20, mode='exact')
-        try:
-            z_interp = kriging.transform(xx.flatten(), yy.flatten()).reshape(xx.shape)
-        except LinAlgError:
-            set_info('LinAlgError: Singular matrix', 'red')
-            return
+        if len(coord) == 1 or np.allclose(z, z[0]):
+            z_interp = np.full(xx.shape, z[0], dtype=float)
+            set_info('Все значения карты одинаковы: построена постоянная поверхность.', 'brown')
+        else:
+            try:
+                variogram = Variogram(
+                    coordinates=coord,
+                    values=z,
+                    model=var_model,
+                    n_lags=min(nlags, len(coord) - 1),
+                    estimator=estimator,
+                    dist_func=dist_func,
+                    bin_func=bin_func,
+                    fit_sigma='exp'
+                )
+                kriging = OrdinaryKriging(
+                    variogram=variogram,
+                    min_points=min(5, len(coord)),
+                    max_points=min(20, len(coord)),
+                    mode='exact'
+                )
+                z_interp = kriging.transform(xx.flatten(), yy.flatten()).reshape(xx.shape)
+            except Exception as exc:
+                set_info(
+                    f'Вариограмма не построена ({dist_func}, {bin_func}; '
+                    f'{type(exc).__name__}: {exc}). '
+                    'Карта построена резервным методом IDW.',
+                    'brown'
+                )
+                z_interp = inverse_distance_interpolation(coord, z, xx, yy)
         # print(len(z_interp))
         # print(z_interp)
         filt_checkbox = _get_control("checkBox_filt")
         if filt_checkbox is not None and filt_checkbox.isChecked():
-            try:
-                z_interp = savgol_filter(z_interp, filt_power, 3)
-            except ValueError:
-                set_info('ValueError in savgol filter', 'red')
-                return
+            parameters = savgol_parameters(filt_power, z_interp.shape[-1])
+            if parameters is None:
+                set_info('Сглаживание пропущено: размер сетки меньше 3 точек.', 'brown')
+            else:
+                window_length, polyorder = parameters
+                if window_length != filt_power:
+                    set_info(
+                        f'Окно сглаживания уменьшено с {filt_power} до {window_length} под размер сетки.',
+                        'brown'
+                    )
+                z_interp = savgol_filter(z_interp, window_length, polyorder)
 
         # интерполяция значений на сетке gstools
         #

--- a/kriging_utils.py
+++ b/kriging_utils.py
@@ -1,0 +1,82 @@
+"""Input preparation shared by the continuous-map kriging workflow."""
+
+import numpy as np
+
+
+def prepare_variogram_data(coordinates, values, min_unique_points=2):
+    """Validate variogram data and average values at coincident coordinates.
+
+    A variogram cannot be fitted to NaN/inf data or to zero-distance pairs.
+    Coincident samples are common for model results (several records can belong
+    to one map point), so their values are averaged instead of failing the map.
+    """
+    coords = np.asarray(coordinates, dtype=float)
+    data = np.asarray(values, dtype=float).reshape(-1)
+
+    if coords.ndim != 2 or coords.shape[1] != 2:
+        raise ValueError("coordinates must be an array with shape (n, 2)")
+    if len(coords) != len(data):
+        raise ValueError("coordinates and values must contain the same number of samples")
+
+    finite_mask = np.isfinite(coords).all(axis=1) & np.isfinite(data)
+    coords = coords[finite_mask]
+    data = data[finite_mask]
+    if len(coords) == 0:
+        raise ValueError("no finite coordinate/value pairs are available")
+
+    unique_coords, inverse = np.unique(coords, axis=0, return_inverse=True)
+    value_sums = np.bincount(inverse, weights=data)
+    sample_counts = np.bincount(inverse)
+    unique_values = value_sums / sample_counts
+
+    if len(unique_coords) < min_unique_points:
+        raise ValueError(
+            f"at least {min_unique_points} distinct coordinates are required; "
+            f"got {len(unique_coords)}"
+        )
+
+    return unique_coords, unique_values, int(len(data) - len(unique_coords))
+
+
+def inverse_distance_interpolation(coordinates, values, grid_x, grid_y, power=2.0):
+    """Interpolate a grid with inverse-distance weighting.
+
+    This is a deterministic fallback when a variogram cannot be fitted.  It
+    also handles a grid cell that exactly matches a source coordinate without
+    a division by zero.
+    """
+    coords = np.asarray(coordinates, dtype=float)
+    data = np.asarray(values, dtype=float).reshape(-1)
+    flat_grid = np.column_stack([np.ravel(grid_x), np.ravel(grid_y)])
+    result = np.empty(len(flat_grid), dtype=float)
+    exponent = max(float(power), np.finfo(float).eps)
+
+    # Process chunks so a large map does not allocate a full grid-by-points
+    # distance matrix at once.
+    chunk_size = 10_000
+    for start in range(0, len(flat_grid), chunk_size):
+        stop = min(start + chunk_size, len(flat_grid))
+        delta = flat_grid[start:stop, np.newaxis, :] - coords[np.newaxis, :, :]
+        squared_distance = np.einsum("ijk,ijk->ij", delta, delta)
+        exact_match = squared_distance == 0.0
+        weights = 1.0 / np.maximum(squared_distance, np.finfo(float).eps) ** (exponent / 2.0)
+        weighted_values = weights @ data
+        interpolated = weighted_values / weights.sum(axis=1)
+        if np.any(exact_match):
+            exact_rows = np.any(exact_match, axis=1)
+            interpolated[exact_rows] = (
+                exact_match[exact_rows] @ data / exact_match[exact_rows].sum(axis=1)
+            )
+        result[start:stop] = interpolated
+
+    return result.reshape(np.shape(grid_x))
+
+
+def savgol_parameters(requested_window, data_length, polyorder=3):
+    """Return valid Savitzky-Golay parameters or ``None`` when smoothing is impossible."""
+    window = min(int(requested_window), int(data_length))
+    if window % 2 == 0:
+        window -= 1
+    if window < 3:
+        return None
+    return window, min(int(polyorder), window - 1)

--- a/tests/test_kriging_utils.py
+++ b/tests/test_kriging_utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from kriging_utils import (
+    inverse_distance_interpolation,
+    prepare_variogram_data,
+    savgol_parameters,
+)
+
+
+def test_prepare_variogram_data_averages_coincident_coordinates():
+    coordinates, values, merged_count = prepare_variogram_data(
+        [[0, 0], [1, 1], [0, 0], [2, 2]], [2, 4, 6, 8]
+    )
+
+    np.testing.assert_array_equal(coordinates, [[0, 0], [1, 1], [2, 2]])
+    np.testing.assert_allclose(values, [4, 4, 8])
+    assert merged_count == 1
+
+
+def test_prepare_variogram_data_discards_non_finite_samples():
+    coordinates, values, merged_count = prepare_variogram_data(
+        [[0, 0], [np.nan, 1], [2, 2]], [1, 2, np.inf], min_unique_points=1
+    )
+
+    np.testing.assert_array_equal(coordinates, [[0, 0]])
+    np.testing.assert_allclose(values, [1])
+    assert merged_count == 0
+
+
+def test_prepare_variogram_data_requires_distinct_coordinates():
+    with pytest.raises(ValueError, match="distinct coordinates"):
+        prepare_variogram_data([[0, 0], [0, 0]], [1, 2])
+
+
+def test_inverse_distance_interpolation_preserves_source_values():
+    grid_x = np.array([[0.0, 1.0]])
+    grid_y = np.array([[0.0, 0.0]])
+
+    result = inverse_distance_interpolation([[0, 0], [1, 0]], [2, 6], grid_x, grid_y)
+
+    np.testing.assert_allclose(result, [[2, 6]])
+
+
+def test_savgol_parameters_clamps_window_to_odd_data_length():
+    assert savgol_parameters(13, 8) == (7, 3)
+
+
+def test_savgol_parameters_skips_too_short_data():
+    assert savgol_parameters(13, 2) is None


### PR DESCRIPTION
### Motivation
- Prevent variogram fitting from failing on coincident or non-finite samples and provide a deterministic fallback when kriging cannot be built.
- Avoid crashes or poor behavior when all input values are identical or when Savitzky–Golay smoothing parameters are invalid for the grid size.

### Description
- Add `kriging_utils.py` with `prepare_variogram_data`, `inverse_distance_interpolation`, and `savgol_parameters` to centralize input validation, IDW fallback, and Savitzky–Golay parameter computation.
- Update `krige.py` to import and use `prepare_variogram_data`, averaging coincident coordinates before building a `Variogram`, and to notify the user via `set_info` when merges occur.
- Implement robust variogram workflow: short-circuit to a constant surface when inputs are constant, attempt to build a `Variogram` with safe `n_lags`/point limits, and fall back to `inverse_distance_interpolation` on any variogram error with an explanatory `set_info` message.
- Replace previous ad-hoc Savitzky–Golay calls with `savgol_parameters` to compute a valid `(window_length, polyorder)` or skip smoothing with an informative message.
- IDW implementation in `kriging_utils` processes the grid in chunks and handles exact coordinate matches to avoid division-by-zero.
- Add unit tests in `tests/test_kriging_utils.py` covering coordinate merging, non-finite sample handling, error conditions, IDW exact-match preservation, and Savitzky–Golay parameter behavior.

### Testing
- Ran `pytest tests/test_kriging_utils.py` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e53e265a0832f8475b45c1a354214)