### PR TITLE
Add MapInfo TAB export for object profiles with validation and GDAL writer

### DIFF
--- a/func.py
+++ b/func.py
@@ -1,9 +1,12 @@
 # from torch.cuda import graph
 import os.path
+import importlib
+import importlib.util
 import numpy as np
 import re
 import types
 from object import *
+from mapinfo_export import ProfileExportError, determine_export_zone, prepare_export_profile
 
 
 list_param_geovel = [
@@ -149,6 +152,79 @@ def get_research_name():
 # Функция получения имени выбранного объекта
 def get_object_name():
     return ui.comboBox_object.currentText().split(' id')[0]
+
+
+def export_current_object_profiles_to_mapinfo():
+    """Export every profile of the selected object to a native MapInfo TAB layer."""
+    object_id = get_object_id()
+    if object_id is None:
+        QMessageBox.warning(MainWindow, "Экспорт MapInfo", "Сначала выберите объект.")
+        return
+
+    profiles = (
+        session.query(Profile)
+        .join(Research, Profile.research_id == Research.id)
+        .filter(Research.object_id == object_id)
+        .order_by(Profile.research_id, Profile.id)
+        .all()
+    )
+    try:
+        export_profiles = [prepare_export_profile(profile) for profile in profiles]
+        zone = determine_export_zone(export_profiles)
+    except ProfileExportError as exc:
+        QMessageBox.critical(MainWindow, "Экспорт MapInfo", str(exc))
+        return
+
+    if importlib.util.find_spec("osgeo") is None:
+        QMessageBox.critical(
+            MainWindow,
+            "Экспорт MapInfo",
+            "Для создания нативного TAB требуется GDAL/OGR с драйвером MapInfo File. "
+            "Установите пакет GDAL в окружение приложения.",
+        )
+        return
+
+    object_name = re.sub(r"[^\w.-]+", "_", get_object_name(), flags=re.UNICODE).strip("._")
+    default_name = f"{object_name or 'profiles'}_profiles.tab"
+    output_path, _ = QFileDialog.getSaveFileName(
+        MainWindow,
+        "Экспорт профилей объекта в MapInfo TAB",
+        default_name,
+        "MapInfo TAB (*.tab)",
+    )
+    if not output_path:
+        return
+    if not output_path.lower().endswith(".tab"):
+        output_path += ".tab"
+
+    confirmation = QMessageBox.question(
+        MainWindow,
+        "Экспорт MapInfo",
+        f"Будет экспортировано профилей: {len(export_profiles)}\n"
+        f"Система координат: Pulkovo 1942 / Gauss-Kruger zone {zone}\n"
+        f"EPSG:{28400 + zone}\n\n"
+        "Зона определена по WGS 84 и сверена с координатами СК-42. Продолжить?",
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.Yes,
+    )
+    if confirmation != QMessageBox.Yes:
+        return
+
+    try:
+        writer = importlib.import_module("mapinfo_gdal")
+        saved_path = writer.write_native_tab(output_path, export_profiles, zone)
+    except (ProfileExportError, OSError, RuntimeError) as exc:
+        QMessageBox.critical(MainWindow, "Экспорт MapInfo", f"Не удалось создать TAB:\n{exc}")
+        return
+    set_info(
+        f'Профили текущего объекта экспортированы в MapInfo TAB: "{saved_path}"',
+        "green",
+    )
+    QMessageBox.information(
+        MainWindow,
+        "Экспорт MapInfo",
+        f"Экспортировано профилей: {len(export_profiles)}\nФайл: {saved_path}",
+    )
 
 
 # Функция получения имени выбранного объекта мониторинга

--- a/geovel.py
+++ b/geovel.py
@@ -460,6 +460,7 @@ ui.pushButton_import_model_f_ai.clicked.connect(import_model_formation_ai)
 
 ui.pushButton_map.clicked.connect(show_map)
 ui.pushButton_profiles.clicked.connect(show_profiles)
+ui.pushButton_profiles_to_mapinfo.clicked.connect(export_current_object_profiles_to_mapinfo)
 
 
 def set_exclusive_profile_mode(checked_checkbox, unchecked_checkbox):

--- a/mapinfo_export.py
+++ b/mapinfo_export.py
@@ -1,0 +1,130 @@
+"""Export georadar profile polylines to native MapInfo TAB datasets."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+DEFAULT_ZONE = 9
+WGS_MATCH_TOLERANCE_METERS = 100.0
+
+
+class ProfileExportError(ValueError):
+    """Raised when profile coordinates cannot be exported safely."""
+
+
+@dataclass(frozen=True)
+class ExportProfile:
+    profile_id: int
+    research_id: int
+    title: str
+    projected_points: tuple[tuple[float, float], ...]
+    wgs_points: tuple[tuple[float, float], ...]
+
+
+def gauss_kruger_zone_from_longitude(longitude: float) -> int:
+    """Return the six-degree Gauss-Kruger zone for a WGS longitude."""
+    if not math.isfinite(longitude) or not -180.0 <= longitude <= 180.0:
+        raise ProfileExportError(f"Некорректная долгота WGS 84: {longitude!r}")
+    # Longitudes on a zone boundary belong to the zone immediately east of it.
+    return max(1, min(60, math.floor(longitude / 6.0) + 1))
+
+
+def gauss_kruger_zone_from_easting(easting: float) -> int | None:
+    """Read a zone prefix from a full Soviet Gauss-Kruger easting."""
+    if not math.isfinite(easting):
+        return None
+    zone = int(abs(easting) // 1_000_000)
+    return zone if 1 <= zone <= 60 else None
+
+
+def _numeric_array(raw_value: str | None, label: str, profile_title: str) -> list[float]:
+    if not raw_value:
+        raise ProfileExportError(f'У профиля "{profile_title}" отсутствуют координаты {label}.')
+    try:
+        values = json.loads(raw_value)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ProfileExportError(
+            f'У профиля "{profile_title}" повреждены координаты {label}.'
+        ) from exc
+    if not isinstance(values, list):
+        raise ProfileExportError(f'Координаты {label} профиля "{profile_title}" не являются массивом.')
+    try:
+        result = [float(value) for value in values]
+    except (TypeError, ValueError) as exc:
+        raise ProfileExportError(
+            f'У профиля "{profile_title}" есть нечисловые координаты {label}.'
+        ) from exc
+    if not all(math.isfinite(value) for value in result):
+        raise ProfileExportError(f'У профиля "{profile_title}" есть пустые координаты {label}.')
+    return result
+
+
+def prepare_export_profile(profile) -> ExportProfile:
+    """Parse and validate all projected and WGS coordinate arrays of a profile."""
+    title = profile.title or f"id {profile.id}"
+    x_pulc = _numeric_array(profile.x_pulc, "x_pulc", title)
+    y_pulc = _numeric_array(profile.y_pulc, "y_pulc", title)
+    longitudes = _numeric_array(profile.x_wgs, "x_wgs", title)
+    latitudes = _numeric_array(profile.y_wgs, "y_wgs", title)
+    sizes = {len(x_pulc), len(y_pulc), len(longitudes), len(latitudes)}
+    if len(sizes) != 1:
+        raise ProfileExportError(
+            f'У профиля "{title}" не совпадает количество координат СК-42 и WGS 84.'
+        )
+    if len(x_pulc) < 2:
+        raise ProfileExportError(f'Для профиля "{title}" требуется минимум две точки.')
+    if not all(-180.0 <= lon <= 180.0 for lon in longitudes):
+        raise ProfileExportError(f'У профиля "{title}" некорректная долгота WGS 84.')
+    if not all(-90.0 <= lat <= 90.0 for lat in latitudes):
+        raise ProfileExportError(f'У профиля "{title}" некорректная широта WGS 84.')
+    return ExportProfile(
+        profile_id=profile.id,
+        research_id=profile.research_id,
+        title=title,
+        projected_points=tuple(zip(x_pulc, y_pulc)),
+        wgs_points=tuple(zip(longitudes, latitudes)),
+    )
+
+
+def determine_export_zone(profiles: Sequence[ExportProfile]) -> int:
+    """Determine one zone and require projected prefixes to agree with WGS."""
+    if not profiles:
+        raise ProfileExportError("В текущем объекте нет профилей для экспорта.")
+    wgs_zones = {
+        gauss_kruger_zone_from_longitude(longitude)
+        for profile in profiles
+        for longitude, _latitude in profile.wgs_points
+    }
+    if len(wgs_zones) != 1:
+        raise ProfileExportError(
+            "Профили объекта находятся в разных зонах Гаусса–Крюгера по координатам WGS 84. "
+            "Их необходимо экспортировать в отдельные TAB-файлы."
+        )
+    zone = wgs_zones.pop()
+    prefixed_zones = {
+        detected
+        for profile in profiles
+        for easting, _northing in profile.projected_points
+        if (detected := gauss_kruger_zone_from_easting(easting)) is not None
+    }
+    if prefixed_zones and prefixed_zones != {zone}:
+        raise ProfileExportError(
+            f"Зона по WGS 84 ({zone}) не совпадает с префиксом координат СК-42 "
+            f"({', '.join(map(str, sorted(prefixed_zones)))})."
+        )
+    return zone
+
+
+def profile_length(points: Iterable[tuple[float, float]]) -> float:
+    point_list = list(points)
+    return sum(math.dist(first, second) for first, second in zip(point_list, point_list[1:]))
+
+
+def tab_sidecar_paths(tab_path: str | Path) -> tuple[Path, ...]:
+    path = Path(tab_path).with_suffix(".tab")
+    return tuple(path.with_suffix(suffix) for suffix in (".tab", ".dat", ".map", ".id", ".ind"))

--- a/mapinfo_gdal.py
+++ b/mapinfo_gdal.py
@@ -1,0 +1,108 @@
+"""GDAL-backed native MapInfo writer, isolated from the dependency-free validation code."""
+
+import math
+from pathlib import Path
+from typing import Sequence
+
+from osgeo import ogr, osr
+
+from mapinfo_export import (
+    ExportProfile,
+    ProfileExportError,
+    WGS_MATCH_TOLERANCE_METERS,
+    profile_length,
+    tab_sidecar_paths,
+)
+
+
+def _spatial_reference(epsg: int):
+    reference = osr.SpatialReference()
+    if reference.ImportFromEPSG(epsg) != 0:
+        raise ProfileExportError(f"GDAL не удалось загрузить EPSG:{epsg}.")
+    if hasattr(reference, "SetAxisMappingStrategy"):
+        reference.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    return reference
+
+
+def _validate_against_wgs(profiles: Sequence[ExportProfile], projected_srs) -> None:
+    wgs_srs = _spatial_reference(4326)
+    transformation = osr.CoordinateTransformation(projected_srs, wgs_srs)
+    for profile in profiles:
+        # Checking every point is deliberate: the WGS arrays are our safety net
+        # against a wrong zone, swapped axes, or an incorrectly labelled dataset.
+        for index, ((easting, northing), (expected_lon, expected_lat)) in enumerate(
+            zip(profile.projected_points, profile.wgs_points), start=1
+        ):
+            actual_lon, actual_lat, *_ = transformation.TransformPoint(easting, northing)
+            mean_latitude = math.radians((expected_lat + actual_lat) / 2.0)
+            latitude_delta = math.radians(actual_lat - expected_lat)
+            longitude_delta = math.radians(actual_lon - expected_lon)
+            distance = 6_371_008.8 * math.hypot(
+                latitude_delta,
+                longitude_delta * math.cos(mean_latitude),
+            )
+            if not distance <= WGS_MATCH_TOLERANCE_METERS:
+                raise ProfileExportError(
+                    f'Профиль "{profile.title}", точка {index}: координаты СК-42 расходятся '
+                    f"с WGS 84 на {distance:.1f} м (допуск {WGS_MATCH_TOLERANCE_METERS:.0f} м)."
+                )
+
+
+def write_native_tab(tab_path: str | Path, profiles: Sequence[ExportProfile], zone: int) -> Path:
+    """Write profiles to a MapInfo Native TAB dataset using GDAL/OGR."""
+    output_path = Path(tab_path).with_suffix(".tab")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    projected_srs = _spatial_reference(28400 + zone)
+    _validate_against_wgs(profiles, projected_srs)
+
+    driver = ogr.GetDriverByName("MapInfo File")
+    if driver is None:
+        raise ProfileExportError("Установленный GDAL не содержит драйвер MapInfo File.")
+    for sidecar in tab_sidecar_paths(output_path):
+        if sidecar.exists():
+            sidecar.unlink()
+    data_source = driver.CreateDataSource(str(output_path))
+    if data_source is None:
+        raise ProfileExportError(f"Не удалось создать MapInfo TAB: {output_path}")
+    layer = data_source.CreateLayer(
+        output_path.stem,
+        srs=projected_srs,
+        geom_type=ogr.wkbLineString,
+        options=["FORMAT=NATIVE", "ENCODING=UTF-8"],
+    )
+    if layer is None:
+        raise ProfileExportError("GDAL не удалось создать линейный слой MapInfo.")
+    for name, field_type, width in (
+        ("PROFILE_ID", ogr.OFTInteger, 0),
+        ("RESEARCH_ID", ogr.OFTInteger, 0),
+        ("TITLE", ogr.OFTString, 254),
+        ("POINTS", ogr.OFTInteger, 0),
+        ("LENGTH_M", ogr.OFTReal, 0),
+        ("ZONE", ogr.OFTInteger, 0),
+        ("EPSG", ogr.OFTInteger, 0),
+    ):
+        field = ogr.FieldDefn(name, field_type)
+        if width:
+            field.SetWidth(width)
+        if layer.CreateField(field) != 0:
+            raise ProfileExportError(f"Не удалось создать поле {name} в MapInfo TAB.")
+
+    for profile in profiles:
+        feature = ogr.Feature(layer.GetLayerDefn())
+        feature.SetField("PROFILE_ID", profile.profile_id)
+        feature.SetField("RESEARCH_ID", profile.research_id)
+        feature.SetField("TITLE", profile.title)
+        feature.SetField("POINTS", len(profile.projected_points))
+        feature.SetField("LENGTH_M", profile_length(profile.projected_points))
+        feature.SetField("ZONE", zone)
+        feature.SetField("EPSG", 28400 + zone)
+        line = ogr.Geometry(ogr.wkbLineString)
+        for easting, northing in profile.projected_points:
+            line.AddPoint_2D(easting, northing)
+        feature.SetGeometry(line)
+        if layer.CreateFeature(feature) != 0:
+            raise ProfileExportError(f'Не удалось записать профиль "{profile.title}".')
+        feature = None
+    layer.SyncToDisk()
+    data_source = None
+    return output_path

--- a/tests/test_mapinfo_export.py
+++ b/tests/test_mapinfo_export.py
@@ -1,0 +1,59 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mapinfo_export import (
+    ProfileExportError,
+    determine_export_zone,
+    gauss_kruger_zone_from_easting,
+    gauss_kruger_zone_from_longitude,
+    prepare_export_profile,
+    profile_length,
+)
+
+
+def make_profile(**overrides):
+    values = dict(
+        id=7,
+        research_id=3,
+        title="P-7",
+        x_pulc=json.dumps([9_500_000.0, 9_500_003.0]),
+        y_pulc=json.dumps([6_100_000.0, 6_100_004.0]),
+        x_wgs=json.dumps([51.1, 51.1001]),
+        y_wgs=json.dumps([55.0, 55.0001]),
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_zone_is_derived_from_wgs_and_checked_against_projected_prefix():
+    profile = prepare_export_profile(make_profile())
+    assert determine_export_zone([profile]) == 9
+    assert gauss_kruger_zone_from_longitude(51.1) == 9
+    assert gauss_kruger_zone_from_easting(9_500_000) == 9
+
+
+def test_zone_mismatch_is_rejected():
+    profile = prepare_export_profile(
+        make_profile(x_pulc=json.dumps([8_500_000.0, 8_500_003.0]))
+    )
+    with pytest.raises(ProfileExportError, match="не совпадает"):
+        determine_export_zone([profile])
+
+
+def test_profiles_crossing_a_zone_boundary_are_rejected():
+    profile = prepare_export_profile(
+        make_profile(x_wgs=json.dumps([51.1, 54.1]))
+    )
+    with pytest.raises(ProfileExportError, match="разных зонах"):
+        determine_export_zone([profile])
+
+
+def test_all_four_coordinate_arrays_must_have_equal_lengths():
+    with pytest.raises(ProfileExportError, match="не совпадает количество"):
+        prepare_export_profile(make_profile(y_wgs=json.dumps([55.0])))
+
+
+def test_profile_length_uses_all_polyline_segments():
+    assert profile_length([(0, 0), (3, 4), (6, 8)]) == 10


### PR DESCRIPTION
### Motivation
- Provide an integrated, safe way to export georadar profile polylines for the selected object into native MapInfo TAB datasets.
- Avoid creating invalid TAB files by validating projected SK-42 coordinates against WGS 84 and ensuring all profiles belong to the same Gauss–Kruger zone.

### Description
- Add `mapinfo_export.py` which implements validation, parsing and zone-determination logic and defines `ExportProfile` and `ProfileExportError` used to prepare exportable profile data and enforce consistency checks.
- Add `mapinfo_gdal.py` which implements the GDAL/OGR-backed writer `write_native_tab` that creates a MapInfo native TAB with attributes and geometry and validates projected coordinates against the provided WGS points using an EPSG transformation.
- Add UI integration in `func.py` and `geovel.py`: implement `export_current_object_profiles_to_mapinfo()` that collects profiles from the DB, validates them via `prepare_export_profile`/`determine_export_zone`, prompts the user, checks for GDAL availability, and delegates writing to the `mapinfo_gdal` module; connect the new export function to `ui.pushButton_profiles_to_mapinfo`.
- Add unit tests in `tests/test_mapinfo_export.py` covering coordinate parsing, zone derivation, mismatch rejection, boundary crossing rejection, and `profile_length` calculation.

### Testing
- Ran `pytest tests/test_mapinfo_export.py` and the new unit tests passed successfully.
- The GDAL-backed writer was not exercised by unit tests because it requires GDAL/OGR and system drivers; runtime code checks for GDAL availability and reports a clear error message when absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a670a1d9734832f9de064ebda6c3d53)