### PR TITLE
Add MapInfo MIF/MID export for profiles with validation and tests

### DIFF
--- a/func.py
+++ b/func.py
@@ -4,6 +4,12 @@ import numpy as np
 import re
 import types
 from object import *
+from mapinfo_export import (
+    ProfileExportError,
+    determine_export_zone,
+    prepare_export_profile,
+    write_mif_mid,
+)
 
 
 list_param_geovel = [
@@ -149,6 +155,71 @@ def get_research_name():
 # Функция получения имени выбранного объекта
 def get_object_name():
     return ui.comboBox_object.currentText().split(' id')[0]
+
+
+def export_current_object_profiles_to_mapinfo():
+    """Export every profile of the selected object to MapInfo MIF/MID files."""
+    object_id = get_object_id()
+    if object_id is None:
+        QMessageBox.warning(MainWindow, "Экспорт MapInfo", "Сначала выберите объект.")
+        return
+
+    profiles = (
+        session.query(Profile)
+        .join(Research, Profile.research_id == Research.id)
+        .filter(Research.object_id == object_id)
+        .order_by(Profile.research_id, Profile.id)
+        .all()
+    )
+    try:
+        export_profiles = [prepare_export_profile(profile) for profile in profiles]
+        zone = determine_export_zone(export_profiles)
+    except ProfileExportError as exc:
+        QMessageBox.critical(MainWindow, "Экспорт MapInfo", str(exc))
+        return
+
+    object_name = re.sub(r"[^\w.-]+", "_", get_object_name(), flags=re.UNICODE).strip("._")
+    default_name = f"{object_name or 'profiles'}_profiles.mif"
+    output_path, _ = QFileDialog.getSaveFileName(
+        MainWindow,
+        "Экспорт профилей объекта в MapInfo MIF/MID",
+        default_name,
+        "MapInfo Interchange Format (*.mif)",
+    )
+    if not output_path:
+        return
+    if not output_path.lower().endswith(".mif"):
+        output_path += ".mif"
+
+    confirmation = QMessageBox.question(
+        MainWindow,
+        "Экспорт MapInfo",
+        f"Будет экспортировано профилей: {len(export_profiles)}\n"
+        f"Система координат: Pulkovo 1942 / Gauss-Kruger zone {zone}\n"
+        f"EPSG:{28400 + zone}\n\n"
+        "Зона определена по WGS 84 и сверена с зональным префиксом СК-42. Продолжить?",
+        QMessageBox.Yes | QMessageBox.No,
+        QMessageBox.Yes,
+    )
+    if confirmation != QMessageBox.Yes:
+        return
+
+    try:
+        saved_mif, saved_mid = write_mif_mid(output_path, export_profiles, zone)
+    except (ProfileExportError, OSError, RuntimeError) as exc:
+        QMessageBox.critical(MainWindow, "Экспорт MapInfo", f"Не удалось создать MIF/MID:\n{exc}")
+        return
+    set_info(
+        f'Профили текущего объекта экспортированы в MapInfo MIF/MID: "{saved_mif}"',
+        "green",
+    )
+    QMessageBox.information(
+        MainWindow,
+        "Экспорт MapInfo",
+        f"Экспортировано профилей: {len(export_profiles)}\n"
+        f"MIF: {saved_mif}\nMID: {saved_mid}\n\n"
+        "Открывайте в MapInfo файл MIF.",
+    )
 
 
 # Функция получения имени выбранного объекта мониторинга

--- a/geovel.py
+++ b/geovel.py
@@ -460,6 +460,7 @@ ui.pushButton_import_model_f_ai.clicked.connect(import_model_formation_ai)
 
 ui.pushButton_map.clicked.connect(show_map)
 ui.pushButton_profiles.clicked.connect(show_profiles)
+ui.pushButton_profiles_to_mapinfo.clicked.connect(export_current_object_profiles_to_mapinfo)
 
 
 def set_exclusive_profile_mode(checked_checkbox, unchecked_checkbox):

--- a/mapinfo_export.py
+++ b/mapinfo_export.py
@@ -1,0 +1,213 @@
+"""Export georadar profile polylines to native MapInfo TAB datasets."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+class ProfileExportError(ValueError):
+    """Raised when profile coordinates cannot be exported safely."""
+
+
+@dataclass(frozen=True)
+class ExportProfile:
+    profile_id: int
+    research_id: int
+    title: str
+    projected_points: tuple[tuple[float, float], ...]
+    wgs_points: tuple[tuple[float, float], ...]
+
+
+def gauss_kruger_zone_from_longitude(longitude: float) -> int:
+    """Return the six-degree Gauss-Kruger zone for a WGS longitude."""
+    if not math.isfinite(longitude) or not -180.0 <= longitude <= 180.0:
+        raise ProfileExportError(f"Некорректная долгота WGS 84: {longitude!r}")
+    # Longitudes on a zone boundary belong to the zone immediately east of it.
+    return max(1, min(60, math.floor(longitude / 6.0) + 1))
+
+
+def gauss_kruger_zone_from_easting(easting: float) -> int | None:
+    """Read a zone prefix from a full Soviet Gauss-Kruger easting."""
+    if not math.isfinite(easting):
+        return None
+    zone = int(abs(easting) // 1_000_000)
+    return zone if 1 <= zone <= 60 else None
+
+
+def _numeric_array(raw_value: str | None, label: str, profile_title: str) -> list[float]:
+    if not raw_value:
+        raise ProfileExportError(f'У профиля "{profile_title}" отсутствуют координаты {label}.')
+    try:
+        values = json.loads(raw_value)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ProfileExportError(
+            f'У профиля "{profile_title}" повреждены координаты {label}.'
+        ) from exc
+    if not isinstance(values, list):
+        raise ProfileExportError(f'Координаты {label} профиля "{profile_title}" не являются массивом.')
+    try:
+        result = [float(value) for value in values]
+    except (TypeError, ValueError) as exc:
+        raise ProfileExportError(
+            f'У профиля "{profile_title}" есть нечисловые координаты {label}.'
+        ) from exc
+    if not all(math.isfinite(value) for value in result):
+        raise ProfileExportError(f'У профиля "{profile_title}" есть пустые координаты {label}.')
+    return result
+
+
+def prepare_export_profile(profile) -> ExportProfile:
+    """Parse and validate all projected and WGS coordinate arrays of a profile."""
+    title = profile.title or f"id {profile.id}"
+    x_pulc = _numeric_array(profile.x_pulc, "x_pulc", title)
+    y_pulc = _numeric_array(profile.y_pulc, "y_pulc", title)
+    longitudes = _numeric_array(profile.x_wgs, "x_wgs", title)
+    latitudes = _numeric_array(profile.y_wgs, "y_wgs", title)
+    sizes = {len(x_pulc), len(y_pulc), len(longitudes), len(latitudes)}
+    if len(sizes) != 1:
+        raise ProfileExportError(
+            f'У профиля "{title}" не совпадает количество координат СК-42 и WGS 84.'
+        )
+    if len(x_pulc) < 2:
+        raise ProfileExportError(f'Для профиля "{title}" требуется минимум две точки.')
+    if not all(-180.0 <= lon <= 180.0 for lon in longitudes):
+        raise ProfileExportError(f'У профиля "{title}" некорректная долгота WGS 84.')
+    if not all(-90.0 <= lat <= 90.0 for lat in latitudes):
+        raise ProfileExportError(f'У профиля "{title}" некорректная широта WGS 84.')
+    return ExportProfile(
+        profile_id=profile.id,
+        research_id=profile.research_id,
+        title=title,
+        projected_points=tuple(zip(x_pulc, y_pulc)),
+        wgs_points=tuple(zip(longitudes, latitudes)),
+    )
+
+
+def determine_export_zone(profiles: Sequence[ExportProfile]) -> int:
+    """Determine one zone and require projected prefixes to agree with WGS."""
+    if not profiles:
+        raise ProfileExportError("В текущем объекте нет профилей для экспорта.")
+    wgs_zones = {
+        gauss_kruger_zone_from_longitude(longitude)
+        for profile in profiles
+        for longitude, _latitude in profile.wgs_points
+    }
+    if len(wgs_zones) != 1:
+        raise ProfileExportError(
+            "Профили объекта находятся в разных зонах Гаусса–Крюгера по координатам WGS 84. "
+            "Их необходимо экспортировать в отдельные TAB-файлы."
+        )
+    zone = wgs_zones.pop()
+    prefixed_zones = {
+        detected
+        for profile in profiles
+        for easting, _northing in profile.projected_points
+        if (detected := gauss_kruger_zone_from_easting(easting)) is not None
+    }
+    if prefixed_zones and prefixed_zones != {zone}:
+        raise ProfileExportError(
+            f"Зона по WGS 84 ({zone}) не совпадает с префиксом координат СК-42 "
+            f"({', '.join(map(str, sorted(prefixed_zones)))})."
+        )
+    return zone
+
+
+def profile_length(points: Iterable[tuple[float, float]]) -> float:
+    point_list = list(points)
+    return sum(math.dist(first, second) for first, second in zip(point_list, point_list[1:]))
+
+
+def _mif_number(value: float) -> str:
+    return format(value, ".15g")
+
+
+def _mif_points(profile: ExportProfile, zone: int) -> tuple[tuple[float, float], ...]:
+    """Return EPSG-style points, adding the zone prefix when it is absent."""
+    result = []
+    for easting, northing in profile.projected_points:
+        if gauss_kruger_zone_from_easting(easting) is None:
+            easting += math.copysign(zone * 1_000_000, easting)
+        result.append((easting, northing))
+    return tuple(result)
+
+
+def _mid_text(value: object) -> str:
+    text = str(value).replace('"', '""').replace("\r", " ").replace("\n", " ")
+    return f'"{text}"'
+
+
+def _mif_header(zone: int) -> str:
+    central_meridian = zone * 6 - 3
+    false_easting = zone * 1_000_000 + 500_000
+    # MapInfo projection 8 is Transverse Mercator; datum 1001 is Pulkovo 1942.
+    return (
+        'Version 300\n'
+        'Charset "UTF-8"\n'
+        'Delimiter ";"\n'
+        f'CoordSys Earth Projection 8, 1001, "m", {central_meridian}, 0, 1, '
+        f'{false_easting}, 0\n'
+        'Columns 7\n'
+        '  PROFILE_ID Integer\n'
+        '  RESEARCH_ID Integer\n'
+        '  TITLE Char(254)\n'
+        '  POINTS Integer\n'
+        '  LENGTH_M Float\n'
+        '  ZONE Integer\n'
+        '  EPSG Integer\n'
+        'Data\n'
+    )
+
+
+def write_mif_mid(
+    mif_path: str | Path,
+    profiles: Sequence[ExportProfile],
+    zone: int,
+) -> tuple[Path, Path]:
+    """Write MapInfo Interchange geometry and attributes without GIS dependencies."""
+    output_mif = Path(mif_path).with_suffix(".mif")
+    output_mid = output_mif.with_suffix(".mid")
+    output_mif.parent.mkdir(parents=True, exist_ok=True)
+    temp_paths: list[Path] = []
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", newline="\n", dir=output_mif.parent, delete=False
+        ) as mif_file, tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", newline="\n", dir=output_mid.parent, delete=False
+        ) as mid_file:
+            temp_mif = Path(mif_file.name)
+            temp_mid = Path(mid_file.name)
+            temp_paths.extend((temp_mif, temp_mid))
+            mif_file.write(_mif_header(zone))
+            for profile in profiles:
+                points = _mif_points(profile, zone)
+                mif_file.write(f"Pline {len(points)}\n")
+                for easting, northing in points:
+                    mif_file.write(f"{_mif_number(easting)} {_mif_number(northing)}\n")
+                mid_file.write(
+                    ";".join(
+                        (
+                            str(profile.profile_id),
+                            str(profile.research_id),
+                            _mid_text(profile.title),
+                            str(len(points)),
+                            _mif_number(profile_length(points)),
+                            str(zone),
+                            str(28400 + zone),
+                        )
+                    )
+                    + "\n"
+                )
+        os.replace(temp_mif, output_mif)
+        temp_paths.remove(temp_mif)
+        os.replace(temp_mid, output_mid)
+        temp_paths.remove(temp_mid)
+    finally:
+        for temp_path in temp_paths:
+            temp_path.unlink(missing_ok=True)
+    return output_mif, output_mid

--- a/tests/test_mapinfo_export.py
+++ b/tests/test_mapinfo_export.py
@@ -1,0 +1,84 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from mapinfo_export import (
+    ProfileExportError,
+    determine_export_zone,
+    gauss_kruger_zone_from_easting,
+    gauss_kruger_zone_from_longitude,
+    prepare_export_profile,
+    profile_length,
+    write_mif_mid,
+)
+
+
+def make_profile(**overrides):
+    values = dict(
+        id=7,
+        research_id=3,
+        title="P-7",
+        x_pulc=json.dumps([9_500_000.0, 9_500_003.0]),
+        y_pulc=json.dumps([6_100_000.0, 6_100_004.0]),
+        x_wgs=json.dumps([51.1, 51.1001]),
+        y_wgs=json.dumps([55.0, 55.0001]),
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_zone_is_derived_from_wgs_and_checked_against_projected_prefix():
+    profile = prepare_export_profile(make_profile())
+    assert determine_export_zone([profile]) == 9
+    assert gauss_kruger_zone_from_longitude(51.1) == 9
+    assert gauss_kruger_zone_from_easting(9_500_000) == 9
+
+
+def test_zone_mismatch_is_rejected():
+    profile = prepare_export_profile(
+        make_profile(x_pulc=json.dumps([8_500_000.0, 8_500_003.0]))
+    )
+    with pytest.raises(ProfileExportError, match="не совпадает"):
+        determine_export_zone([profile])
+
+
+def test_profiles_crossing_a_zone_boundary_are_rejected():
+    profile = prepare_export_profile(
+        make_profile(x_wgs=json.dumps([51.1, 54.1]))
+    )
+    with pytest.raises(ProfileExportError, match="разных зонах"):
+        determine_export_zone([profile])
+
+
+def test_all_four_coordinate_arrays_must_have_equal_lengths():
+    with pytest.raises(ProfileExportError, match="не совпадает количество"):
+        prepare_export_profile(make_profile(y_wgs=json.dumps([55.0])))
+
+
+def test_profile_length_uses_all_polyline_segments():
+    assert profile_length([(0, 0), (3, 4), (6, 8)]) == 10
+
+
+def test_write_mif_mid_creates_zone_9_polylines_and_attributes(tmp_path):
+    profile = prepare_export_profile(make_profile(title='P-7 "main"'))
+
+    mif_path, mid_path = write_mif_mid(tmp_path / "profiles.mif", [profile], 9)
+
+    mif = mif_path.read_text(encoding="utf-8")
+    mid = mid_path.read_text(encoding="utf-8")
+    assert 'CoordSys Earth Projection 8, 1001, "m", 51, 0, 1, 9500000, 0' in mif
+    assert "Pline 2\n9500000 6100000\n9500003 6100004\n" in mif
+    assert '7;3;"P-7 ""main""";2;5;9;28409\n' == mid
+
+
+def test_write_mif_mid_adds_missing_zone_prefix(tmp_path):
+    profile = prepare_export_profile(
+        make_profile(x_pulc=json.dumps([500_000.0, 500_003.0]))
+    )
+
+    mif_path, _ = write_mif_mid(tmp_path / "profiles.mif", [profile], 9)
+
+    assert "Pline 2\n9500000 6100000\n9500003 6100004\n" in mif_path.read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
### Motivation
- Provide a reliable way to export georadar profiles to native MapInfo MIF/MID files with coordinate validation and consistent zone handling.
- Integrate the export feature into the UI so users can export all profiles of the selected object from the application.

### Description
- Add a new `mapinfo_export.py` module implementing `ProfileExportError`, `ExportProfile` dataclass, validators and helpers including `prepare_export_profile`, `determine_export_zone`, `gauss_kruger_zone_from_longitude`, `gauss_kruger_zone_from_easting`, `profile_length`, and `write_mif_mid` to write MIF/MID files robustly and atomically.
- Add UI glue in `func.py` with `export_current_object_profiles_to_mapinfo()` which queries profiles, prepares export data, determines zone, prompts the user and calls `write_mif_mid`, and import the new functions at the top of the file.
- Wire the UI button in `geovel.py` by connecting `ui.pushButton_profiles_to_mapinfo` to `export_current_object_profiles_to_mapinfo`.
- Add comprehensive unit tests in `tests/test_mapinfo_export.py` covering coordinate parsing, zone detection and validation, profile length calculation, and MIF/MID output formatting (including zone prefix injection and quoting).

### Testing
- Ran the new unit tests in `tests/test_mapinfo_export.py` with `pytest` and all tests passed. 
- Verified `write_mif_mid` creates expected MIF header, polyline geometry and MID attribute rows and that missing zone prefixes are corrected by the writer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a670a1d9734832f9de064ebda6c3d53)