### PR TITLE
Fix NumPy compatibility for trapezoidal integrations

### DIFF
--- a/calc_additional_features.py
+++ b/calc_additional_features.py
@@ -670,7 +670,7 @@ def calculate_envelope(signal):
 
 
 def area_under_envelope(envelope):
-    return np.trapezoid(envelope)
+    return np.trapz(envelope)
 
 
 def envelope_max(envelope):
@@ -778,7 +778,7 @@ def autocorrelation_decay(acf, num_points=10):
 
 
 def acf_integral(acf):
-    return np.trapezoid(acf)
+    return np.trapz(acf)
 
 
 def acf_main_peak_width(acf, height_ratio=0.5):


### PR DESCRIPTION
### Motivation
- Avoid an `AttributeError` on environments with older NumPy versions by using the long-established integration API instead of the newer `numpy.trapezoid` symbol.

### Description
- Replace `np.trapezoid` with `np.trapz` in `area_under_envelope` and `acf_integral` inside `calc_additional_features.py` to restore compatibility.

### Testing
- Verified syntax with `python -m py_compile calc_additional_features.py` and confirmed the occurrence/replacement check with `rg -n "np\.trapezoid|np\.trapz" calc_additional_features.py`, both indicating the change is correctly applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6749dc449c832faf75e0c35a3ac4f0)