### PR TITLE
Fix incomplete queued object model calculations

### DIFF
--- a/calc_object_models.py
+++ b/calc_object_models.py
@@ -221,11 +221,8 @@ def calc_object():
                 update_co_models_list()
 
 
-    def start_co_class():
+    def start_co_class(co_cls):
         """ Расчет объекта по модели """
-
-        co_cls = session.query(CalcObject).filter_by(
-            id=ui_co.listWidget_objects.currentItem().data(Qt.UserRole)).first()
 
         model = session.query(TrainedModelClass).filter_by(
             id=co_cls.model_id).first()
@@ -276,15 +273,12 @@ def calc_object():
                 research = session.query(Research).filter(Research.id == prof.research_id).first()
                 object = session.query(GeoradarObject).filter(GeoradarObject.id == research.object_id).first()
                 set_info(f'Прогноз для исследования от {research.date_research} объекта {object.title} уже есть в БД', 'red')
-                break
+                continue
 
         update_list_model_prediction()
 
-    def start_co_reg():
+    def start_co_reg(co_reg):
         """ Расчет объекта обученной моделью """
-
-        co_reg = session.query(CalcObject).filter_by(
-            id=ui_co.listWidget_objects.currentItem().data(Qt.UserRole)).first()
 
         model = session.query(TrainedModelReg).filter_by(
             id=co_reg.model_id).first()
@@ -331,7 +325,7 @@ def calc_object():
                 research = session.query(Research).filter(Research.id == prof.research_id).first()
                 object = session.query(GeoradarObject).filter(GeoradarObject.id == research.object_id).first()
                 set_info(f'Прогноз для исследования от {research.date_research} объекта {object.title} уже есть в БД', 'red')
-                break
+                continue
 
         update_list_model_prediction()
 
@@ -349,9 +343,9 @@ def calc_object():
                 continue
 
             if co.type_ml == 'cls':
-                start_co_class()
+                start_co_class(co)
             if co.type_ml == 'reg':
-                start_co_reg()
+                start_co_reg(co)
 
             session.delete(co)
             session.commit()


### PR DESCRIPTION
### Motivation
- Calculations stopped prematurely when a profile already had an existing prediction because the loop used `break`, leaving remaining profiles unprocessed. 
- The code re-read the `CalcObject` from the UI selection inside per-object handlers which could process the wrong queued record if the widget selection changed during processing.

### Description
- Changed `start_co_class` and `start_co_reg` to accept the `CalcObject` instance (`co_cls` / `co_reg`) passed from the queue instead of re-querying the current UI selection. 
- Replaced `break` with `continue` when a profile already has a prediction so the code skips that profile but continues processing remaining profiles. 
- Updated the queue processor to call `start_co_class(co)` and `start_co_reg(co)` for the dequeued `CalcObject` so each queued record is processed deterministically.

### Testing
- Ran `python -m py_compile calc_object_models.py` to ensure the module compiles successfully. 
- Ran `git diff --check` to validate patch formatting. 
- Attempted `pytest -q`, but test collection failed due to missing environment dependencies (`numpy` and `sqlalchemy`), which are unrelated to the changes and prevented running the full test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6761c41cf4832f86cb3eef32ae66b7)