### PR TITLE
Add object-wide nearby wells filter

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -643,7 +643,7 @@ _BATCH_EXPORT_CHECKBOXES = (
     'checkBox_minmax', 'checkBox_draw_layer', 'checkBox_relief',
     'checkBox_vel', 'checkBox_velmod', 'checkBox_model_nn',
     'checkBox_corr_pred', 'checkBox_filter_cls', 'checkBox_use_land',
-    'checkBox_vel_color', 'checkBox_profile_well', 'checkBox_prof_intersect',
+    'checkBox_vel_color', 'checkBox_profile_well', 'checkBox_object_well', 'checkBox_prof_intersect',
 )
 
 _BATCH_REQUIRED_CHECKBOXES = (
@@ -773,7 +773,7 @@ def _restore_batch_export_settings(settings, render=False, force_required=False)
                 draw_profile_model_prediction()
             else:
                 warnings.append('результаты выбранной модели отсутствуют')
-        if ui.checkBox_profile_well.isChecked():
+        if ui.checkBox_profile_well.isChecked() or ui.checkBox_object_well.isChecked():
             update_list_well()
         if ui.checkBox_prof_intersect.isChecked():
             draw_profile_intersection()

--- a/func.py
+++ b/func.py
@@ -5,6 +5,7 @@ import importlib.util
 import numpy as np
 import re
 import types
+from PyQt5.QtCore import QSignalBlocker
 from object import *
 from mapinfo_export import (
     ProfileExportError,
@@ -1460,7 +1461,7 @@ def update_formation_combobox():
         ui.comboBox_plast.addItem(f'{form.title} id{form.id}')
     # Обновляем список выбора параметров для выбранного пласта
     update_param_combobox()
-    if ui.checkBox_profile_well.isChecked():
+    if ui.checkBox_profile_well.isChecked() or ui.checkBox_object_well.isChecked():
         update_list_well()
 
 
@@ -1660,9 +1661,18 @@ def update_list_well(select_well=False, selected_well_id=None):
     else:
         if ui.checkBox_profile_well.isChecked():
             wells = get_list_nearest_well(get_profile_id())
+            wells = [(well, index, distance, None) for well, index, distance in (wells or [])]
+        elif ui.checkBox_object_well.isChecked():
+            wells = get_list_nearest_well_for_object(get_object_id())
+        else:
+            wells = None
+
+        if wells is not None:
             if wells:
                 for w in wells:
-                    item_text = f'скв.№ {w[0].name} - ({w[1]}) {round(w[2], 2)} м. id{w[0].id}'
+                    profile_text = f' [{w[3].title}]' if w[3] is not None else ''
+                    item_text = (f'скв.№ {w[0].name}{profile_text} - ({w[1]}) '
+                                 f'{round(w[2], 2)} м. id{w[0].id}')
                     item = QListWidgetItem(item_text)
 
                     # Обновляем максимальный ID скважины (если нужно выбрать новую)
@@ -1734,6 +1744,41 @@ def get_list_nearest_well(profile_id):
             ui.listWidget_well.addItem(f'Координаты профиля {profile.title} не загружены')
     except TypeError:
         pass
+
+
+def get_list_nearest_well_for_object(object_id):
+    """Return unique wells near any profile of the selected object.
+
+    If a well is near several profiles, the closest profile is retained so that
+    the list and map contain the well only once.
+    """
+    if object_id is None:
+        return []
+
+    profiles = (session.query(Profile)
+                .join(Research)
+                .filter(Research.object_id == object_id)
+                .order_by(Profile.title)
+                .all())
+    nearest_by_well = {}
+    for profile in profiles:
+        for well, index, distance in get_list_nearest_well(profile.id) or []:
+            current = nearest_by_well.get(well.id)
+            if current is None or distance < current[2]:
+                nearest_by_well[well.id] = (well, index, distance, profile)
+
+    return sorted(nearest_by_well.values(), key=lambda item: (item[0].name, item[0].id))
+
+
+def update_well_filter_mode(checked, source):
+    """Keep the profile/object well filters mutually exclusive and refresh."""
+    if checked:
+        other = (ui.checkBox_object_well
+                 if source == 'profile' else ui.checkBox_profile_well)
+        blocker = QSignalBlocker(other)
+        other.setChecked(False)
+        del blocker
+    update_list_well()
 
 
 def set_title_list_widget_wells():

--- a/geovel.py
+++ b/geovel.py
@@ -385,7 +385,10 @@ ui.comboBox_param_plast.activated.connect(draw_param)
 ui.checkBox_minmax.stateChanged.connect(choose_minmax)
 ui.checkBox_draw_layer.stateChanged.connect(draw_layers)
 ui.checkBox_all_formation.stateChanged.connect(draw_param)
-ui.checkBox_profile_well.stateChanged.connect(update_list_well)
+ui.checkBox_profile_well.stateChanged.connect(
+    lambda state: update_well_filter_mode(state, 'profile'))
+ui.checkBox_object_well.stateChanged.connect(
+    lambda state: update_well_filter_mode(state, 'object'))
 ui.checkBox_prof_intersect.stateChanged.connect(draw_profile_intersection)
 ui.checkBox_show_bound.stateChanged.connect(update_list_well)
 ui.checkBox_profile_intersec.stateChanged.connect(update_list_well)

--- a/krige.py
+++ b/krige.py
@@ -734,15 +734,15 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
             for n_ix in range(len(list_name)):
                 plt.text(list_x[n_ix] + 20, list_y[n_ix] + 20, list_name[n_ix], fontsize=5)
 
-        if ui.checkBox_profile_well.isChecked():
-            r = session.query(Research).filter_by(id=get_research_id()).first()
-            for profile in r.profiles:
-                wells = get_list_nearest_well(profile.id)
-                if not wells:
-                    continue
-                for well in wells:
-                    plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
-                    plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
+        if ui.checkBox_profile_well.isChecked() or ui.checkBox_object_well.isChecked():
+            if ui.checkBox_object_well.isChecked():
+                wells = get_list_nearest_well_for_object(get_object_id())
+            else:
+                r = session.query(Research).filter_by(id=get_research_id()).first()
+                wells = [well for profile in r.profiles for well in (get_list_nearest_well(profile.id) or [])]
+            for well in wells:
+                plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
+                plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
 
         plt.xlabel('X')
         plt.ylabel('Y')
@@ -912,14 +912,14 @@ def show_profiles():
     if ui.checkBox_prof_all.isChecked() or ui.checkBox_profile_year.isChecked():
         _draw_object_labels(profiles)
 
-    if ui.checkBox_profile_well.isChecked():
-        for profile in profiles:
-            wells = get_list_nearest_well(profile.id)
-            if not wells:
-                continue
-            for well in wells:
-                plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
-                plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
+    if ui.checkBox_profile_well.isChecked() or ui.checkBox_object_well.isChecked():
+        if ui.checkBox_object_well.isChecked():
+            wells = get_list_nearest_well_for_object(get_object_id())
+        else:
+            wells = [well for profile in profiles for well in (get_list_nearest_well(profile.id) or [])]
+        for well in wells:
+            plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
+            plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
 
     plt.xlabel('X')
     plt.ylabel('Y')


### PR DESCRIPTION
### Motivation
- Provide an "object wells" mode that shows wells near any profile of the selected object using the same `max distance, m` control as `profile wells`.
- Ensure `object wells` and `profile wells` behave as mutually exclusive UI modes and that the chosen mode is applied for map/profile rendering and batch export.

### Description
- Added `get_list_nearest_well_for_object(object_id)` to collect and deduplicate wells near all profiles of the chosen object, keeping the closest profile per well, and return `(well, index, distance, profile)` tuples; implemented in `func.py`.
- Made `checkBox_object_well` and `checkBox_profile_well` mutually exclusive via `update_well_filter_mode` and connected both checkboxes to this handler in `geovel.py`.
- Updated `update_list_well` to support both modes and show the source profile (when present) in the list item text; preserved the existing highlighting/tooltips for wells with logs (changes in `func.py`).
- Enabled rendering of object-mode wells on maps and profile views by extending `krige.py` and `draw.py` logic to consider `checkBox_object_well` alongside `checkBox_profile_well`.
- Included `checkBox_object_well` in batch-export snapshot/restore logic so the new mode is preserved during batch map exports (changes in `draw.py`).
- Added `QSignalBlocker` import to `func.py` to safely toggle the complementary checkbox without triggering recursion.

### Testing
- Ran static compile check with `python -m py_compile func.py geovel.py draw.py krige.py` which succeeded.
- Ran `git diff --check` which reported no whitespace issues.
- Ran `PYTHONPATH=. pytest -q tests/test_mapinfo_export.py` and all tests passed (`7 passed`).
- Noted an initial `pytest` collection error when `PYTHONPATH` was not set for local imports, which was resolved by running tests with `PYTHONPATH=.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69ee84fdd8832f9fe24245b9c67336)