### PR TITLE
Выделить скважины с каротажем на картах

### DIFF
--- a/krige.py
+++ b/krige.py
@@ -17,6 +17,7 @@ from kriging_utils import (
 )
 from qt.choose_formation_map import *
 from qt.draw_map_form import *
+from well_map_style import well_marker_color
 
 cmap_list = ['viridis', 'plasma', 'inferno', 'magma', 'cividis','Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
             'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu', 'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn',
@@ -741,7 +742,13 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
                 r = session.query(Research).filter_by(id=get_research_id()).first()
                 wells = [well for profile in r.profiles for well in (get_list_nearest_well(profile.id) or [])]
             for well in wells:
-                plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
+                plt.scatter(
+                    well[0].x_coord,
+                    well[0].y_coord,
+                    marker='o',
+                    color=well_marker_color(well[0]),
+                    s=50,
+                )
                 plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
 
         plt.xlabel('X')
@@ -918,7 +925,13 @@ def show_profiles():
         else:
             wells = [well for profile in profiles for well in (get_list_nearest_well(profile.id) or [])]
         for well in wells:
-            plt.scatter(well[0].x_coord, well[0].y_coord, marker='o', color='r', s=50)
+            plt.scatter(
+                well[0].x_coord,
+                well[0].y_coord,
+                marker='o',
+                color=well_marker_color(well[0]),
+                s=50,
+            )
             plt.text(well[0].x_coord + 20, well[0].y_coord + 20, well[0].name)
 
     plt.xlabel('X')

--- a/tests/test_well_map_style.py
+++ b/tests/test_well_map_style.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+
+from well_map_style import DEFAULT_WELL_MARKER_COLOR, WELL_LOG_MARKER_COLOR, well_marker_color
+
+
+def test_well_with_logging_curves_uses_bright_purple_marker():
+    well = SimpleNamespace(well_logs=[object()])
+
+    assert well_marker_color(well) == WELL_LOG_MARKER_COLOR == "#D500F9"
+
+
+def test_well_without_logging_curves_keeps_default_marker():
+    well = SimpleNamespace(well_logs=[])
+
+    assert well_marker_color(well) == DEFAULT_WELL_MARKER_COLOR == "red"

--- a/well_map_style.py
+++ b/well_map_style.py
@@ -1,0 +1,9 @@
+"""Shared styling rules for wells displayed on maps."""
+
+DEFAULT_WELL_MARKER_COLOR = "red"
+WELL_LOG_MARKER_COLOR = "#D500F9"
+
+
+def well_marker_color(well):
+    """Return a bright accent color when a well has logging curves."""
+    return WELL_LOG_MARKER_COLOR if well.well_logs else DEFAULT_WELL_MARKER_COLOR


### PR DESCRIPTION
### Motivation
- Сделать скважины с наличием каротажных кривых более заметными на картах, чтобы визуально выделять их на интерполяционных и обзорных картах профилей.

### Description
- Добавлен модуль `well_map_style.py` с константами цвета и функцией `well_marker_color(well)`, возвращающей `#D500F9` для скважин с каротажем и `red` для остальных. 
- В `krige.py` заменён жёстко заданный красный маркер на вызов `well_marker_color(well)` при отрисовке карты интерполяции и при показе карты профилей. 
- Добавлены юнит-тесты `tests/test_well_map_style.py`, проверяющие поведение `well_marker_color` для скважин с каротажем и без него.

### Testing
- Запущено `python -m pytest tests/test_well_map_style.py`, тесты прошли: 2 passed. 
- Выполнена проверка компиляции `python -m py_compile krige.py well_map_style.py tests/test_well_map_style.py` и `git diff --check`, ошибок не выявлено. 
- Попытка запустить дополнительно `pytest` вместе с `tests/test_kriging_utils.py` прервана из-за отсутствующего в окружении пакета `numpy`, что не связано с изменениями в этом PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a33e98560832fb99c8e144d32cab3)