### PR TITLE
Добавить десятичное логарифмирование в предобработку

### DIFF
--- a/classification_func.py
+++ b/classification_func.py
@@ -5,6 +5,7 @@ import numpy as np
 import pickle
 import matplotlib.pyplot as plt
 from sklearn.model_selection import cross_validate
+from sklearn.preprocessing import FunctionTransformer
 
 from draw import plot_groups_with_smoothed_hull
 from func import *
@@ -895,6 +896,10 @@ def train_classifier(data_train: pd.DataFrame, list_param: list, list_param_save
 
         # Нормализация данных
 
+        if ui_cls.checkBox_log.isChecked():
+            log_transformer = FunctionTransformer(np.log10, validate=True)
+            pipe_steps.append(('log10', log_transformer))
+            text_scaler += '\nLog10'
         if ui_cls.checkBox_power_trans.isChecked():
             power_t = PowerTransformer(method='yeo-johnson')
             pipe_steps.append(('power_t', power_t))
@@ -2020,7 +2025,6 @@ def get_text_train_param_geochem(list_param):
     text = '\nПараметры модели:\n'
     text += ", ".join(list_param)
     return text
-
 
 
 

--- a/geochem.py
+++ b/geochem.py
@@ -491,6 +491,8 @@ def tsne_geochem():
 
         try:
             data_tsne = data_plot_new.drop(['well', 'point', 'color'], axis=1)
+            if ui_tsne.checkBox_log.isChecked():
+                data_tsne = np.log10(data_tsne)
             if ui_tsne.checkBox_power_trans.isChecked():
                 power_t = PowerTransformer(method='yeo-johnson', standardize=False)
                 data_tsne = power_t.fit_transform(data_tsne)
@@ -593,6 +595,9 @@ def tsne_geochem():
             data_meta = data_plot_new[exclude_cols].copy()
 
             # Применяем преобразования только к числовым столбцам
+            if ui_tsne.checkBox_log.isChecked():
+                data_numeric = np.log10(data_numeric)
+
             if ui_tsne.checkBox_power_trans.isChecked():
                 power_t = PowerTransformer(method='yeo-johnson', standardize=False)
                 data_numeric = power_t.fit_transform(data_numeric)
@@ -947,6 +952,8 @@ def tsne_geochem():
 
     def distance_between_centers(data, well1, well2, params):
         data_param = data[params]
+        if ui_tsne.checkBox_log.isChecked():
+            data_param = np.log10(data_param)
         if ui_tsne.checkBox_standart.isChecked():
             scaler = StandardScaler()
             data_param = scaler.fit_transform(data_param)
@@ -1019,6 +1026,8 @@ def tsne_geochem():
         data_param.reset_index(inplace=True, drop=True)
         data_point = data_plot.loc[data_plot['point'].isin(list_point)]
         data_point.reset_index(inplace=True, drop=True)
+        if ui_tsne.checkBox_log.isChecked():
+            data_param = np.log10(data_param)
         scaler = StandardScaler()
         data_param = scaler.fit_transform(data_param)
         if ui_tsne.radioButton_tsne.isChecked():
@@ -2516,7 +2525,6 @@ def clear_fake_point():
     session.query(GeochemPoint).filter_by(geochem_id=get_geochem_id()).update({'fake': False}, synchronize_session='fetch')
     session.commit()
     update_listwidget_geochem_point()
-
 
 
 


### PR DESCRIPTION
### Motivation
- Добавить поведение чекбокса `log` в формах t-SNE/PCA и классификатора, чтобы при включении выполнялся десятичный логарифм набора данных перед остальными шагами предобработки.

### Description
- В `classification_func.py` добавлен импорт `FunctionTransformer` и при включённом `ui_cls.checkBox_log` в `build_pipeline` добавляется шаг `('log10', FunctionTransformer(np.log10, validate=True))` как первый элемент пайплайна, и `text_scaler` дополнен `Log10`.
- В `geochem.py` добавлено применение `np.log10` в `draw_graph_tsne` к данным перед `PowerTransformer/Normalizer/StandardScaler` для визуализации t-SNE/PCA.
- В `geochem.py` логарифмирование также применяется в `draw_graph_anova` (к `data_numeric`), в `distance_between_centers` (к `data_param`) и в `calc_lof` (к `data_param`) чтобы обеспечить единообразную предобработку во всех связанных расчётах.
- Изменения затрагивают порядок преобразований: логарифмирование выполняется перед `PowerTransformer`, нормализацией и стандартизацией.

### Testing
- Успешно выполнена статическая проверка компиляции с помощью `python -m py_compile classification_func.py geochem.py qt/tsne_form.py qt/classifier_form.py`.
- Выполнены проверочные команды `git diff --check` и `git status --short`, проблем не выявлено.
- Изменения были зафиксированы коммитом в репозитории (`Add log10 preprocessing to analysis forms`).
- Попытка runtime-проверки `FunctionTransformer(np.log10)` не была выполнена из-за отсутствия пакета `numpy` в текущем окружении.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b328298b4832fbaf57b0f6a17f042)