### PR TITLE
Persist window settings and file dialog paths

### DIFF
--- a/app_settings.py
+++ b/app_settings.py
@@ -1,0 +1,153 @@
+"""Persistent UI preferences shared by GeoVel windows.
+
+The module deliberately works with widget object names, so adding a new input to
+one of the supported forms does not require maintaining another settings list.
+"""
+
+import os
+
+from PyQt5 import QtCore, QtWidgets
+
+
+ORGANIZATION = "GeoVel"
+APPLICATION = "GeoVel"
+_DIALOG_KEY = "files/last_directory"
+
+
+def settings():
+    return QtCore.QSettings(ORGANIZATION, APPLICATION)
+
+
+def _editable_widgets(root):
+    types = (
+        QtWidgets.QAbstractButton,
+        QtWidgets.QComboBox,
+        QtWidgets.QSpinBox,
+        QtWidgets.QDoubleSpinBox,
+        QtWidgets.QLineEdit,
+        QtWidgets.QTabWidget,
+    )
+    widgets = []
+    for widget_type in types:
+        widgets.extend(root.findChildren(widget_type))
+    # A subclass can be returned for more than one requested base class.
+    return (widget for widget in dict.fromkeys(widgets) if widget.objectName())
+
+
+def _widget_value(widget):
+    if isinstance(widget, QtWidgets.QAbstractButton) and widget.isCheckable():
+        return widget.isChecked()
+    if isinstance(widget, (QtWidgets.QSpinBox, QtWidgets.QDoubleSpinBox)):
+        return widget.value()
+    if isinstance(widget, QtWidgets.QComboBox):
+        return widget.currentText()
+    if isinstance(widget, QtWidgets.QLineEdit):
+        return widget.text()
+    if isinstance(widget, QtWidgets.QTabWidget):
+        return widget.currentIndex()
+    return None
+
+
+def _restore_widget(widget, value):
+    if isinstance(widget, QtWidgets.QAbstractButton) and widget.isCheckable():
+        widget.setChecked(str(value).lower() in ("1", "true", "yes"))
+    elif isinstance(widget, QtWidgets.QSpinBox):
+        widget.setValue(int(value))
+    elif isinstance(widget, QtWidgets.QDoubleSpinBox):
+        widget.setValue(float(value))
+    elif isinstance(widget, QtWidgets.QComboBox):
+        index = widget.findText(str(value))
+        if index >= 0:
+            widget.setCurrentIndex(index)
+    elif isinstance(widget, QtWidgets.QLineEdit):
+        widget.setText(str(value))
+    elif isinstance(widget, QtWidgets.QTabWidget):
+        widget.setCurrentIndex(int(value))
+
+
+def save_form(root, group, name_filter=None):
+    """Save editable child widgets of *root* under a stable settings group."""
+    store = settings()
+    store.beginGroup(f"forms/{group}")
+    for widget in _editable_widgets(root):
+        if name_filter is not None and not name_filter(widget.objectName()):
+            continue
+        value = _widget_value(widget)
+        if value is not None:
+            store.setValue(widget.objectName(), value)
+    store.endGroup()
+    store.sync()
+
+
+def restore_form(root, group, name_filter=None):
+    """Restore values which are still valid for the current version of a form."""
+    store = settings()
+    store.beginGroup(f"forms/{group}")
+    for widget in _editable_widgets(root):
+        if name_filter is not None and not name_filter(widget.objectName()):
+            continue
+        name = widget.objectName()
+        if not store.contains(name):
+            continue
+        blocker = QtCore.QSignalBlocker(widget)
+        try:
+            _restore_widget(widget, store.value(name))
+        except (TypeError, ValueError):
+            # Obsolete/corrupt values must not prevent a window from opening.
+            pass
+        finally:
+            del blocker
+    store.endGroup()
+
+
+def bind_form(root, group, name_filter=None):
+    """Restore a form now and save it whenever the window is closed."""
+    restore_form(root, group, name_filter)
+    root.finished.connect(lambda _result: save_form(root, group, name_filter))
+
+
+def _dialog_directory(suggested, save=False):
+    remembered = str(settings().value(_DIALOG_KEY, "") or "")
+    if not remembered or not os.path.isdir(remembered):
+        return suggested
+    if save and suggested:
+        basename = os.path.basename(os.path.normpath(str(suggested)))
+        return os.path.join(remembered, basename)
+    return remembered
+
+
+def _remember_selection(selection):
+    path = selection[0] if isinstance(selection, tuple) else selection
+    if not path:
+        return selection
+    directory = path if os.path.isdir(path) else os.path.dirname(path)
+    if directory:
+        settings().setValue(_DIALOG_KEY, directory)
+    return selection
+
+
+def install_file_dialog_history():
+    """Make all static open/save/directory dialogs reuse their last directory."""
+    if getattr(QtWidgets.QFileDialog, "_geovel_history_installed", False):
+        return
+
+    def wrap(method_name, save=False):
+        original = getattr(QtWidgets.QFileDialog, method_name)
+
+        def remembered_dialog(*args, **kwargs):
+            args = list(args)
+            if "directory" in kwargs:
+                kwargs["directory"] = _dialog_directory(kwargs["directory"], save)
+            elif len(args) >= 3:
+                args[2] = _dialog_directory(args[2], save)
+            else:
+                kwargs["directory"] = _dialog_directory("", save)
+            return _remember_selection(original(*args, **kwargs))
+
+        setattr(QtWidgets.QFileDialog, method_name, staticmethod(remembered_dialog))
+
+    wrap("getOpenFileName")
+    wrap("getOpenFileNames")
+    wrap("getSaveFileName", save=True)
+    wrap("getExistingDirectory")
+    QtWidgets.QFileDialog._geovel_history_installed = True

--- a/classification_func.py
+++ b/classification_func.py
@@ -1930,6 +1930,8 @@ def train_classifier(data_train: pd.DataFrame, list_param: list, list_param_save
     ui_cls.pushButton_feature_selection.clicked.connect(call_feature_selection)
     ui_cls.pushButton_cov.clicked.connect(calc_cov)
     ui_cls.pushButton_gen.clicked.connect(genetic_algorithm)
+    from app_settings import bind_form
+    bind_form(Classifier, "classifier_form")
     Classifier.exec_()
 
 

--- a/geovel.py
+++ b/geovel.py
@@ -711,6 +711,13 @@ update_list_clust_analys()
 update_list_clust_object()
 update_cluster_well_dataset_combobox()
 
+# The cluster controls live on the main window rather than in a separate form.
+# Persist only that section and save it during normal application shutdown.
+from app_settings import restore_form, save_form
+_cluster_setting = lambda name: "clust" in name.lower()
+restore_form(MainWindow, "cluster", _cluster_setting)
+app.aboutToQuit.connect(lambda: save_form(MainWindow, "cluster", _cluster_setting))
+
 
 time2 = datetime.datetime.now() - time
 print(time2)

--- a/krige.py
+++ b/krige.py
@@ -791,6 +791,8 @@ def draw_map(list_x, list_y, list_z, param, color_marker=True, profiles=False, l
         draw_button.clicked.connect(form_lda_ok)
     else:
         set_info("В форме карты не найдена кнопка DRAW (pushButton_map).", "brown")
+    from app_settings import bind_form
+    bind_form(Draw_Map, "draw_map_form")
     Draw_Map.exec_()
 
 

--- a/object.py
+++ b/object.py
@@ -215,6 +215,9 @@ from functools import lru_cache
 
 
 app = QtWidgets.QApplication(sys.argv)
+from app_settings import install_file_dialog_history
+
+install_file_dialog_history()
 MainWindow = QtWidgets.QMainWindow()
 ui = Ui_MainWindow()
 ui.setupUi(MainWindow)

--- a/regression.py
+++ b/regression.py
@@ -3365,6 +3365,8 @@ def train_regression_model():
     ui_r.pushButton_cov.clicked.connect(calc_cov)
     ui_r.pushButton_gen_alg.clicked.connect(genetic_algorithm)
     ui_r.pushButton_cvw.clicked.connect(calc_model_regression_by_cvw)
+    from app_settings import bind_form
+    bind_form(Regressor, "regressor_form")
     Regressor.exec_()
 
 

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -1,0 +1,70 @@
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+from PyQt5 import QtCore, QtWidgets
+
+import app_settings
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    return QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(tmp_path):
+    QtCore.QSettings.setDefaultFormat(QtCore.QSettings.IniFormat)
+    QtCore.QSettings.setPath(QtCore.QSettings.IniFormat, QtCore.QSettings.UserScope, str(tmp_path))
+    app_settings.settings().clear()
+
+
+def test_form_values_round_trip(app):
+    dialog = QtWidgets.QDialog()
+    layout = QtWidgets.QVBoxLayout(dialog)
+    spin = QtWidgets.QSpinBox(objectName="spinBox_count")
+    check = QtWidgets.QCheckBox(objectName="checkBox_enabled")
+    combo = QtWidgets.QComboBox(objectName="comboBox_method")
+    combo.addItems(["first", "second"])
+    line = QtWidgets.QLineEdit(objectName="lineEdit_value")
+    for widget in (spin, check, combo, line):
+        layout.addWidget(widget)
+
+    spin.setValue(7)
+    check.setChecked(True)
+    combo.setCurrentText("second")
+    line.setText("saved")
+    app_settings.save_form(dialog, "test")
+
+    spin.setValue(1)
+    check.setChecked(False)
+    combo.setCurrentText("first")
+    line.clear()
+    app_settings.restore_form(dialog, "test")
+
+    assert (spin.value(), check.isChecked()) == (7, True)
+    assert combo.currentText() == "second"
+    assert line.text() == "saved"
+
+
+def test_dialog_directory_preserves_save_filename(app, tmp_path):
+    app_settings.settings().setValue(app_settings._DIALOG_KEY, str(tmp_path))
+
+    assert app_settings._dialog_directory("result.xlsx", save=True) == str(tmp_path / "result.xlsx")
+    assert app_settings._dialog_directory("ignored", save=False) == str(tmp_path)
+
+
+def test_name_filter_limits_persisted_widgets(app):
+    root = QtWidgets.QWidget()
+    kept = QtWidgets.QSpinBox(root, objectName="spinBox_cluster_count")
+    skipped = QtWidgets.QSpinBox(root, objectName="spinBox_other")
+    kept.setValue(4)
+    skipped.setValue(9)
+
+    app_settings.save_form(root, "filtered", lambda name: "cluster" in name)
+
+    store = app_settings.settings()
+    assert store.contains("forms/filtered/spinBox_cluster_count")
+    assert not store.contains("forms/filtered/spinBox_other")


### PR DESCRIPTION
### Motivation

- Remember the last UI state for map, classifier, regressor and cluster controls so users do not need to reconfigure common options each run.
- Make file open/save dialogs reuse the last directory so file operations start from the previously used location.

### Description

- Add `app_settings.py` which provides `QSettings` based helpers `save_form`, `restore_form`, `bind_form`, and `install_file_dialog_history` to persist editable widgets and remember dialog directories.
- Wire form persistence for the map, classifier and regressor dialogs by calling `bind_form` from `krige.py`, `classification_func.py`, and `regression.py` respectively and persist the cluster section of the main window via `restore_form`/`save_form` in `geovel.py`.
- Install global file-dialog history at application startup by calling `install_file_dialog_history()` from `object.py`, so `QFileDialog.getOpenFileName`, `getOpenFileNames`, `getSaveFileName` and `getExistingDirectory` reuse the last directory.
- Add focused tests in `tests/test_app_settings.py` covering round-trip persistence, name filtering for saved widgets, and save-file-name handling, and improve `_editable_widgets` to avoid duplicate widget entries.

### Testing

- Ran the small test module with `QT_QPA_PLATFORM=offscreen pytest -q tests/test_app_settings.py`, which was skipped in this environment because `PyQt5` is not available.
- Verified syntax by compiling modified modules with `python -m py_compile app_settings.py object.py krige.py classification_func.py regression.py geovel.py`, which completed without errors.
- Performed repository checks and local validations for whitespace/syntax issues with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c4527cdac832f90cc07a4aaa7cbb3)