### PR TITLE
Show profile and well names in skipped measurement warning

### DIFF
--- a/build_table.py
+++ b/build_table.py
@@ -484,8 +484,10 @@ def build_table_train_no_db(analisis: str, analisis_id: int, list_param: list) -
     if skipped_measurements:
         examples = []
         for markup, measure, param in skipped_measurements[:10]:
+            profile_title = getattr(getattr(markup, 'profile', None), 'title', None) or f'id {markup.profile_id}'
+            well_name = getattr(getattr(markup, 'well', None), 'name', None) or f'id {markup.well_id}'
             examples.append(
-                f'профиль {markup.profile_id}, скважина {markup.well_id}, '
+                f'профиль {profile_title}, скважина {well_name}, '
                 f'измерение {measure}, параметр {param}'
             )
         extra = len(skipped_measurements) - len(examples)


### PR DESCRIPTION
### Motivation
- Улучшить диагностическое сообщение при пропущенных измерениях, выводя читаемые `profile.title` и `well.name` вместо сырых идентификаторов, сохраняя fallback на `id` если имя недоступно.

### Description
- В `build_table.py` при формировании первых десяти примеров пропущенных измерений заменён вывод `profile_id`/`well_id` на получение `profile.title` и `well.name` через `getattr(... )` с fallback-строкой `id {markup.profile_id}` / `id {markup.well_id}`.

### Testing
- Скомпилирован файл проверкой `python -m py_compile build_table.py`, проверка прошла успешно.
- Выполнена проверка изменений командой `git diff --check`, конфликтов не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73030c21cc832fbb12d293cec7987a)