### PR TITLE
Add well_import helpers and refactor spreadsheet importer

### DIFF
--- a/tests/test_well_import.py
+++ b/tests/test_well_import.py
@@ -1,0 +1,69 @@
+import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from well_import import (
+    WellLookupIndex,
+    is_confident_match,
+    parse_number,
+    rank_well_candidates,
+    requires_confirmation,
+    text_similarity,
+)
+
+
+class Well:
+    def __init__(self, ident, name, x, y):
+        self.id, self.name, self.x_coord, self.y_coord = ident, name, x, y
+
+
+def test_parse_number_rejects_excel_dates_with_clear_error():
+    with pytest.raises(ValueError, match="вместо числа указана дата"):
+        parse_number(datetime.datetime(2025, 1, 2), field="Альтитуда")
+
+
+def test_parse_number_accepts_decimal_comma_and_rejects_non_finite():
+    assert parse_number(" 1 234,50 ") == 1234.5
+    with pytest.raises(ValueError, match="конечное"):
+        parse_number(float("nan"))
+
+
+def test_candidate_ranking_combines_name_area_and_coordinate_tolerance():
+    wells = [Well(1, "Скв. 124", 1000, 2000), Well(2, "Другая 9", 5000, 6000)]
+    ranked = rank_well_candidates(
+        wells, "скв 124", 1003, 2004, "Северная площадь", {1: ["пл. Северная"]}
+    )
+    assert [item.well.id for item in ranked] == [1]
+    assert ranked[0].distance == 5
+    assert ranked[0].area_similarity > 0.7
+    assert is_confident_match(ranked[0], "Северная площадь")
+
+
+def test_exact_nearby_well_is_confident_and_text_is_normalized():
+    candidate = rank_well_candidates([Well(1, "Ёлка-12", 10, 20)], "елка 12", 10.2, 20.2)[0]
+    assert text_similarity("Ёлка-12", "елка 12") == 1
+    assert is_confident_match(candidate)
+
+
+def test_confirmation_is_requested_only_beyond_50_metres_when_other_fields_match():
+    near = rank_well_candidates([Well(1, "124", 0, 0)], "124", 30, 0)[0]
+    far = rank_well_candidates([Well(1, "124", 0, 0)], "124", 70, 0)[0]
+    wrong_area = rank_well_candidates(
+        [Well(1, "124", 0, 0)], "124", 70, 0, "Южная", {1: ["Северная"]}
+    )[0]
+    assert is_confident_match(near)
+    assert not requires_confirmation(near)
+    assert requires_confirmation(far)
+    assert not requires_confirmation(wrong_area, "Южная")
+
+
+def test_lookup_index_limits_search_and_keeps_far_exact_number():
+    nearby = Well(1, "Соседняя", 10, 10)
+    far_same_number = Well(2, "124", 5000, 5000)
+    unrelated = Well(3, "Другая", 5000, 5000)
+    index = WellLookupIndex([nearby, far_same_number, unrelated])
+    assert {well.id for well in index.candidates("124", 0, 0)} == {1, 2}

--- a/well.py
+++ b/well.py
@@ -7,6 +7,13 @@ from qt.add_well_dialog import *
 from qt.add_boundary_dialog import *
 from qt.well_loader import *
 from velocity_model import update_list_binding
+from well_import import (
+    WellLookupIndex,
+    is_confident_match,
+    parse_number,
+    rank_well_candidates,
+    requires_confirmation,
+)
 
 
 def add_well():
@@ -163,127 +170,157 @@ def add_wells():
             ui_wl.lineEdit_opt.setText('/'.join(list_opt))
 
     def load_wells():
-        ui.progressBar.setMaximum(len(pd_wells.index))
+        row_count = len(pd_wells.index)
+        ui.progressBar.setMaximum(row_count)
         name_cell = ui_wl.comboBox_name.currentText()
         x_cell = ui_wl.comboBox_x.currentText()
         y_cell = ui_wl.comboBox_y.currentText()
         alt_cell = ui_wl.comboBox_alt.currentText()
-        empty_value = '' if ui_wl.lineEdit_empty.text() == '' else int(ui_wl.lineEdit_empty.text())
-        list_layers = [] if ui_wl.lineEdit_layers.text() == '' else ui_wl.lineEdit_layers.text().split('/')
-        list_opt = [] if ui_wl.lineEdit_opt.text() == '' else ui_wl.lineEdit_opt.text().split('/')
+        empty_text = ui_wl.lineEdit_empty.text().strip()
+        empty_value = None if not empty_text else empty_text
+        list_layers = [] if not ui_wl.lineEdit_layers.text() else ui_wl.lineEdit_layers.text().split('/')
+        list_opt = [] if not ui_wl.lineEdit_opt.text() else ui_wl.lineEdit_opt.text().split('/')
+        area_column = next((column for column in list_opt if 'площад' in column.casefold() or 'area' in column.casefold()), None)
 
-        distance_threshold = 5.0   # метры
-        name_ratio = 0.5           # доля совпадения названий
-        n_new, n_update = 0, 0
+        # One initial read replaces database queries for every spreadsheet row.
+        all_wells = session.query(Well).all()
+        well_index = WellLookupIndex(all_wells)
+        all_options = session.query(WellOptionally).all()
+        areas_by_well = {}
+        option_keys = set()
+        for option in all_options:
+            option_keys.add((option.well_id, option.option, option.value))
+            if 'площад' in option.option.casefold() or 'area' in option.option.casefold():
+                areas_by_well.setdefault(option.well_id, []).append(option.value)
+        boundary_keys = {
+            (boundary.well_id, boundary.title)
+            for boundary in session.query(Boundary).filter(Boundary.title.in_(list_layers)).all()
+        } if list_layers else set()
 
-        for i in pd_wells.index:
-            try:
-                name = str(pd_wells[name_cell][i])
-                x = float(process_string(pd_wells[x_cell][i]))
-                y = float(process_string(pd_wells[y_cell][i]))
-            except ValueError:
-                continue
+        def has_value(value):
+            if pd.isna(value):
+                return False
+            return empty_value is None or str(value).strip() != empty_value
 
-            # поиск кандидатов поблизости
-            candidates = session.query(Well).filter(
-                Well.x_coord.between(x - distance_threshold, x + distance_threshold),
-                Well.y_coord.between(y - distance_threshold, y + distance_threshold)
-            ).all()
+        def ask_about_candidate(imported_name, x, y, area, candidate):
+            well = candidate.well
+            area_line = f'\nПлощадь из файла: {area}' if area else ''
+            message = (
+                f'Возможный дубль скважины «{imported_name}» ({x:.2f}; {y:.2f}).{area_line}\n\n'
+                f'В базе: «{well.name}» ({well.x_coord:.2f}; {well.y_coord:.2f})\n'
+                f'Расстояние: {candidate.distance:.1f} м; сходство номера/названия: '
+                f'{candidate.name_similarity:.0%}; площади: {candidate.area_similarity:.0%}.\n\n'
+                'Обновить найденную скважину?\n'
+                '«Нет» — создать новую, «Отмена» — пропустить строку.'
+            )
+            return QMessageBox.question(
+                WellLoader, 'Проверка возможного дубля', message,
+                QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Yes
+            )
 
-            curr_well = None
-            for cand in candidates:
-                dist = math.hypot((cand.x_coord or 0) - x, (cand.y_coord or 0) - y)
-                name_sim = SequenceMatcher(None, cand.name or "", name).ratio()
-                if dist <= distance_threshold and name_sim >= name_ratio:
-                    curr_well = cand
-                    break
-
-            if curr_well:
-                n_update += 1
-                set_info(f'Скважина {curr_well.name} уже есть в БД', 'red')
-                alt = 0 if pd_wells[alt_cell][i] == '' else float(process_string(pd_wells[alt_cell][i]))
-                session.query(Well).filter_by(id=curr_well.id).update(
-                    {'alt': alt},
-                    synchronize_session="fetch"
-                )
-                for lr in list_layers:
-                    try:
-                        if pd_wells[lr][i] != empty_value:
-                            bound = session.query(Boundary).filter(
-                                Boundary.well_id == curr_well.id,
-                                Boundary.title == str(lr)
-                            ).first()
-                            if not bound:
-                                if ui_wl.checkBox_deep.isChecked():
-                                    depth = round(float(process_string(pd_wells[lr][i])), 2)
-                                else:
-                                    depth = round(curr_well.alt - float(process_string(pd_wells[lr][i])), 2)
-                                session.add(Boundary(
-                                    well_id=curr_well.id,
-                                    depth=depth,
-                                    title=str(lr)
-                                ))
-                                session.commit()
-                    except ValueError:
-                        continue
-                for opt in list_opt:
-                    try:
-                        if pd_wells[opt][i] != empty_value:
-                            well_opt = session.query(WellOptionally).filter(
-                                WellOptionally.well_id == curr_well.id,
-                                WellOptionally.option == opt,
-                                WellOptionally.value == str(pd_wells[opt][i])
-                            ).first()
-                            if not well_opt:
-                                session.add(WellOptionally(
-                                    well_id=curr_well.id,
-                                    option=opt,
-                                    value=str(pd_wells[opt][i])
-                                ))
-                                session.commit()
-                    except ValueError:
-                        continue
-            else:
-                try:
-                    n_new += 1
-                    new_well = Well(
-                        name=name,
-                        x_coord=x,
-                        y_coord=y,
-                        alt=round(float(process_string(pd_wells[alt_cell][i])), 2),
+        n_new = n_update = n_skipped = 0
+        errors = []
+        progress_step = max(1, row_count // 100)
+        ui.progressBar.setRange(0, row_count)
+        ui.progressBar.setValue(0)
+        ui.progressBar.setFormat('Загрузка скважин: %v из %m (%p%)')
+        print(f'[Импорт скважин] Начало: строк={row_count}, скважин в БД={len(all_wells)}', flush=True)
+        try:
+            for position, (_, row) in enumerate(pd_wells.iterrows(), start=1):
+                ui.progressBar.setValue(position)
+                if position == 1 or position == row_count or position % progress_step == 0:
+                    ui.progressBar.repaint()
+                    QApplication.processEvents()
+                    percent = position * 100 / row_count if row_count else 100
+                    print(
+                        f'[Импорт скважин] {position}/{row_count} ({percent:5.1f}%): '
+                        f'добавлено={n_new}, обновлено={n_update}, пропущено={n_skipped}',
+                        flush=True,
                     )
-                    session.add(new_well)
-                    session.commit()
-                    for lr in list_layers:
-                        if pd_wells[lr][i] != empty_value:
-                            if ui_wl.checkBox_deep.isChecked():
-                                depth = round(float(process_string(pd_wells[lr][i])), 2)
-                            else:
-                                depth = round(new_well.alt - float(process_string(pd_wells[lr][i])), 2)
-                            session.add(Boundary(
-                                well_id=new_well.id,
-                                depth=depth,
-                                title=str(lr)
-                            ))
-                except ValueError:
-                    continue
-                for opt in list_opt:
-                    try:
-                        if pd_wells[opt][i] != empty_value:
-                            session.add(WellOptionally(
-                                well_id=new_well.id,
-                                option=opt,
-                                value=str(pd_wells[opt][i])
-                            ))
-                    except ValueError:
-                        continue
+                try:
+                    name = str(row[name_cell]).strip()
+                    if not name or name.casefold() == 'nan':
+                        raise ValueError('номер скважины: пустое значение')
+                    x = parse_number(row[x_cell], field='координата X')
+                    y = parse_number(row[y_cell], field='координата Y')
+                    alt = 0.0 if not has_value(row[alt_cell]) else round(parse_number(row[alt_cell], field='альтитуда'), 2)
+                    area = str(row[area_column]).strip() if area_column and has_value(row[area_column]) else ''
+                    parsed_layers = {}
+                    for layer in list_layers:
+                        if has_value(row[layer]):
+                            parsed_layers[layer] = parse_number(row[layer], field=f'граница «{layer}»')
 
+                    possible_wells = well_index.candidates(name, x, y)
+                    candidates = rank_well_candidates(possible_wells, name, x, y, area, areas_by_well)
+                    curr_well = (
+                        candidates[0].well
+                        if candidates and is_confident_match(candidates[0], area)
+                        else None
+                    )
+                    if candidates and curr_well is None and requires_confirmation(candidates[0], area):
+                        print(
+                            f'[Импорт скважин] Строка {position + 1}: требуется решение пользователя; '
+                            f'«{name}» ↔ «{candidates[0].well.name}», расстояние '
+                            f'{candidates[0].distance:.1f} м',
+                            flush=True,
+                        )
+                        decision = ask_about_candidate(name, x, y, area, candidates[0])
+                        if decision == QMessageBox.Cancel:
+                            n_skipped += 1
+                            continue
+                        if decision == QMessageBox.Yes:
+                            curr_well = candidates[0].well
+
+                    if curr_well is None:
+                        curr_well = Well(name=name, x_coord=x, y_coord=y, alt=alt)
+                        session.add(curr_well)
+                        session.flush()
+                        all_wells.append(curr_well)
+                        well_index.add(curr_well)
+                        n_new += 1
+                    else:
+                        curr_well.alt = alt
+                        n_update += 1
+
+                    for layer in list_layers:
+                        if layer not in parsed_layers or (curr_well.id, str(layer)) in boundary_keys:
+                            continue
+                        value = parsed_layers[layer]
+                        depth = round(value if ui_wl.checkBox_deep.isChecked() else curr_well.alt - value, 2)
+                        session.add(Boundary(well_id=curr_well.id, depth=depth, title=str(layer)))
+                        boundary_keys.add((curr_well.id, str(layer)))
+
+                    for option in list_opt:
+                        if not has_value(row[option]):
+                            continue
+                        value = str(row[option])
+                        key = (curr_well.id, option, value)
+                        if key not in option_keys:
+                            session.add(WellOptionally(well_id=curr_well.id, option=option, value=value))
+                            option_keys.add(key)
+                            if 'площад' in option.casefold() or 'area' in option.casefold():
+                                areas_by_well.setdefault(curr_well.id, []).append(value)
+                except (TypeError, ValueError, OverflowError) as error:
+                    n_skipped += 1
+                    errors.append(f'строка {position + 1}: {error}')
+                    print(f'[Импорт скважин] Ошибка в строке {position + 1}: {error}', flush=True)
+
+            print('[Импорт скважин] Сохранение изменений в БД…', flush=True)
             session.commit()
-            ui.progressBar.setValue(i + 1)
+        except Exception:
+            session.rollback()
+            raise
 
-        session.commit()
         update_list_well(select_well=True)
-        set_info(f'Добавлено {n_new} скважин, обновлено {n_update} скважин', 'green')
+        summary = f'Добавлено: {n_new}; обновлено: {n_update}; пропущено: {n_skipped}'
+        ui.progressBar.setValue(row_count)
+        print(f'[Импорт скважин] Завершено. {summary}', flush=True)
+        set_info(summary, 'green' if not errors else 'rgb(188, 160, 3)')
+        if errors:
+            details = '\n'.join(errors[:20])
+            if len(errors) > 20:
+                details += f'\n… и ещё {len(errors) - 20}'
+            QMessageBox.warning(WellLoader, 'Загрузка завершена с замечаниями', f'{summary}\n\n{details}')
 
     def cancel_load():
         WellLoader.close()

--- a/well_import.py
+++ b/well_import.py
@@ -1,0 +1,129 @@
+"""Pure helpers for validating and matching wells imported from spreadsheets."""
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from difflib import SequenceMatcher
+import math
+import re
+from collections import defaultdict
+
+
+def parse_number(value, *, field="значение"):
+    """Return a finite float or raise a user-facing ValueError.
+
+    Excel dates must not silently turn into numbers: this was the source of a
+    ``round(datetime)`` crash in the old importer.
+    """
+    if isinstance(value, (date, datetime)):
+        raise ValueError(f'{field}: вместо числа указана дата «{value}»')
+    if value is None:
+        raise ValueError(f'{field}: пустое значение')
+    if isinstance(value, str):
+        value = value.strip().replace("\u00a0", "").replace(" ", "").replace(",", ".")
+        if not value:
+            raise ValueError(f'{field}: пустое значение')
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f'{field}: «{value}» не является числом') from error
+    if not math.isfinite(result):
+        raise ValueError(f'{field}: требуется конечное число')
+    return result
+
+
+def normalize_text(value):
+    text = "" if value is None else str(value).casefold().replace("ё", "е")
+    tokens = re.findall(r"[a-zа-я0-9]+", text)
+    # Common area prefixes carry no identifying information and often differ
+    # between sources ("пл. Северная" / "Северная площадь").
+    tokens = [token for token in tokens if token not in {"пл", "площадь", "area"}]
+    return " ".join(tokens)
+
+
+def text_similarity(left, right):
+    left, right = normalize_text(left), normalize_text(right)
+    if not left or not right:
+        return 0.0
+    return SequenceMatcher(None, left, right).ratio()
+
+
+@dataclass(frozen=True)
+class WellCandidate:
+    well: object
+    distance: float
+    name_similarity: float
+    area_similarity: float
+    score: float
+
+
+class WellLookupIndex:
+    """Small in-memory index that avoids comparing every imported row to every well."""
+
+    def __init__(self, wells=(), *, cell_size=100.0):
+        self.cell_size = cell_size
+        self._by_cell = defaultdict(list)
+        self._by_name = defaultdict(list)
+        for well in wells:
+            self.add(well)
+
+    def _cell(self, x, y):
+        return math.floor(x / self.cell_size), math.floor(y / self.cell_size)
+
+    def add(self, well):
+        self._by_name[normalize_text(well.name)].append(well)
+        if well.x_coord is not None and well.y_coord is not None:
+            self._by_cell[self._cell(well.x_coord, well.y_coord)].append(well)
+
+    def candidates(self, name, x, y):
+        """Return exact-name wells plus wells in neighbouring coordinate cells."""
+        result = {well.id: well for well in self._by_name.get(normalize_text(name), ())}
+        cell_x, cell_y = self._cell(x, y)
+        for offset_x in (-1, 0, 1):
+            for offset_y in (-1, 0, 1):
+                for well in self._by_cell.get((cell_x + offset_x, cell_y + offset_y), ()):
+                    result[well.id] = well
+        return result.values()
+
+
+def rank_well_candidates(wells, name, x, y, area="", areas_by_well=None, *, max_distance=100.0):
+    """Rank plausible duplicates using number/name, area and nearby coordinates."""
+    areas_by_well = areas_by_well or {}
+    ranked = []
+    for well in wells:
+        if well.x_coord is None or well.y_coord is None:
+            continue
+        distance = math.hypot(well.x_coord - x, well.y_coord - y)
+        name_similarity = text_similarity(well.name, name)
+        area_similarity = max(
+            (text_similarity(candidate_area, area) for candidate_area in areas_by_well.get(well.id, ())),
+            default=0.0,
+        )
+        # Do not show unrelated records. A number match may compensate for
+        # shifted coordinates; close coordinates may compensate for spelling.
+        if distance > max_distance and name_similarity < 0.9:
+            continue
+        coordinate_score = max(0.0, 1.0 - distance / max_distance)
+        available = [(name_similarity, 0.5), (coordinate_score, 0.35)]
+        if normalize_text(area):
+            available.append((area_similarity, 0.15))
+        score = sum(value * weight for value, weight in available) / sum(weight for _, weight in available)
+        if score >= 0.45:
+            ranked.append(WellCandidate(well, distance, name_similarity, area_similarity, score))
+    return sorted(ranked, key=lambda item: (-item.score, item.distance))
+
+
+def other_fields_match(candidate, area=""):
+    """Check the well number/name and, when supplied, the area."""
+    return candidate.name_similarity >= 0.9 and (
+        not normalize_text(area) or candidate.area_similarity >= 0.8
+    )
+
+
+def is_confident_match(candidate, area=""):
+    """Matching fields and coordinates within 50 m are safe to merge automatically."""
+    return candidate.distance <= 50.0 and other_fields_match(candidate, area)
+
+
+def requires_confirmation(candidate, area=""):
+    """Ask the user only when other fields match but coordinates differ by over 50 m."""
+    return candidate.distance > 50.0 and other_fields_match(candidate, area)


### PR DESCRIPTION
### Motivation
- Make spreadsheet import more robust against Excel dates, locale-formatted numbers and non-finite values.
- Avoid expensive per-row DB queries by indexing wells in-memory and improve duplicate detection using name/area/coordinate heuristics.
- Improve user feedback during import with progress updates, better error reporting and optional interactive confirmation for ambiguous matches.

### Description
- Add `well_import.py` providing `parse_number`, `normalize_text`, `text_similarity`, `WellLookupIndex`, `rank_well_candidates`, `is_confident_match` and `requires_confirmation` to encapsulate validation and matching logic.
- Refactor `load_wells` in `well.py` to prefetch wells and options, build an in-memory `WellLookupIndex`, use `rank_well_candidates` to find duplicates, and only prompt the user when `requires_confirmation` returns true.
- Replace fragile string-to-number parsing with `parse_number`, unify empty-value handling, collect and deduplicate `WellOptionally` and `Boundary` entries, and provide a summary with warnings for rows that failed to parse.
- Add `tests/test_well_import.py` unit tests that cover numeric parsing, text normalization/similarity, candidate ranking and the lookup index behavior.

### Testing
- Run `pytest tests/test_well_import.py` which exercises `parse_number`, `text_similarity`, `WellLookupIndex`, `rank_well_candidates`, `is_confident_match` and `requires_confirmation` and completed successfully.
- Manual invocation of the importer code paths was exercised via the updated progress and error reporting during import (no automated GUI tests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a756dbe4798832f920c1ee5604de5c4)